### PR TITLE
Keep-alive for ssh connection

### DIFF
--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/ssh/SshConnection.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/ssh/SshConnection.java
@@ -45,10 +45,10 @@ import org.slf4j.LoggerFactory;
 public class SshConnection {
 
     private static final Logger logger = LoggerFactory.getLogger(SshConnection.class);
-	/**
-	 * Keep-alive interval [msec]
-	 */
-	private static final int ALIVE_INTERVAL = 30 * 1000;
+    /**
+     * Keep-alive interval [msec]
+     */
+    private static final int ALIVE_INTERVAL = 30 * 1000;
     private final JSch client;
     private Session connectSession;
     private Channel currentSession;


### PR DESCRIPTION
I set keep-alive as 30 sec. It solves a connection dropping problem.
