### PR TITLE
Update jgit references to be eclipse-based.

### DIFF
--- a/gerrithudsontrigger/pom.xml
+++ b/gerrithudsontrigger/pom.xml
@@ -61,9 +61,9 @@
             <artifactId>gerrit-events</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jvnet.hudson.plugins</groupId>
+            <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>0.9</version>
+            <version>1.1.10</version>
         </dependency>
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
@@ -14,7 +14,7 @@ import hudson.plugins.git.util.BuildData;
 import hudson.plugins.git.util.BuildChooser;
 import hudson.plugins.git.util.BuildChooserDescriptor;
 import org.kohsuke.stapler.DataBoundConstructor;
-import org.spearce.jgit.lib.ObjectId;
+import org.eclipse.jgit.lib.ObjectId;
 
 import java.io.BufferedReader;
 import java.io.StringReader;


### PR DESCRIPTION
The git-plugin no longer provides access to the spearce
jgit packages.
