### PR TITLE
Cancel old jobs when a new patch is uploaded

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -74,11 +74,13 @@ public class Config implements IGerritHudsonTriggerConfig {
      * Default verified vote to Gerrit when a build is successful.
      */
     public static final boolean DEFAULT_ENABLE_MANUAL_TRIGGER = true;
+    public static final boolean DEFAULT_BUILD_CURRENT_PATCHES_ONLY = true;
     private String gerritHostName;
     private int gerritSshPort;
     private String gerritUserName;
     private File gerritAuthKeyFile;
     private String gerritAuthKeyFilePassword;
+    private boolean gerritBuildCurrentPatchesOnly;
     private int numberOfWorkerThreads;
     private String gerritVerifiedCmdBuildSuccessful;
     private String gerritVerifiedCmdBuildUnstable;
@@ -124,6 +126,9 @@ public class Config implements IGerritHudsonTriggerConfig {
         if (gerritAuthKeyFilePassword != null && gerritAuthKeyFilePassword.length() <= 0) {
             gerritAuthKeyFilePassword = null;
         }
+        gerritBuildCurrentPatchesOnly = formData.optBoolean(
+                "gerritBuildCurrentPatchesOnly",
+                DEFAULT_BUILD_CURRENT_PATCHES_ONLY);
 
         numberOfWorkerThreads = formData.optInt(
                 "numberOfReceivingWorkerThreads",
@@ -240,6 +245,16 @@ public class Config implements IGerritHudsonTriggerConfig {
         this.gerritAuthKeyFilePassword = gerritAuthKeyFilePassword;
     }
 
+    /**
+     * GerritBuildCurrentPatchesOnly
+     *
+     * @param gerritBuildCurrentPatchesOnly whether to only build the current patch set
+     * @see #isGerritBuildCurrentPatchesOnly()
+     */
+    public void setGerritBuildCurrentPatchesOnly(boolean gerritBuildCurrentPatchesOnly) {
+        this.gerritBuildCurrentPatchesOnly = gerritBuildCurrentPatchesOnly;
+    }
+
     @Override
     public String getGerritFrontEndUrl() {
         String url = gerritFrontEndUrl;
@@ -343,6 +358,11 @@ public class Config implements IGerritHudsonTriggerConfig {
      */
     public void setNumberOfReceivingWorkerThreads(int numberOfReceivingWorkerThreads) {
         this.numberOfWorkerThreads = numberOfReceivingWorkerThreads;
+    }
+
+    @Override
+    public boolean isGerritBuildCurrentPatchesOnly() {
+        return gerritBuildCurrentPatchesOnly;
     }
 
     @Override

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
@@ -33,6 +33,12 @@ import net.sf.json.JSONObject;
 public interface IGerritHudsonTriggerConfig extends GerritConnectionConfig {
 
     /**
+     * If enabled, then old patch revision builds will be canceled
+     * @return true if so.
+     */
+    boolean isGerritBuildCurrentPatchesOnly();
+
+    /**
      * Base URL for the Gerrit UI.
      * @return the gerrit front end URL. Always ends with '/'
      */

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -89,7 +89,7 @@ public class ParameterExpander {
     public String getBuildStartedCommand(AbstractBuild r, TaskListener taskListener,
             PatchsetCreated event, BuildsStartedStats stats) {
 
-        GerritTrigger trigger = getTrigger(r.getProject());
+        GerritTrigger trigger = GerritTrigger.getTrigger(r.getProject());
         String gerritCmd = config.getGerritCmdBuildStarted();
         Map<String, String> parameters = createStandardParameters(r, event,
                 getBuildStartedCodeReviewValue(r),
@@ -115,7 +115,7 @@ public class ParameterExpander {
      * @return the value.
      */
     private int getBuildStartedVerifiedValue(AbstractBuild r) {
-        GerritTrigger trigger = getTrigger(r.getProject());
+        GerritTrigger trigger = GerritTrigger.getTrigger(r.getProject());
         if (trigger == null) {
             logger.warn("Unable to get trigger config for build {} will use global value.");
             return config.getGerritBuildStartedVerifiedValue();
@@ -139,7 +139,7 @@ public class ParameterExpander {
      * @return the value.
      */
     private int getBuildStartedCodeReviewValue(AbstractBuild r) {
-        GerritTrigger trigger = getTrigger(r.getProject());
+        GerritTrigger trigger = GerritTrigger.getTrigger(r.getProject());
         if (trigger == null) {
             logger.warn("Unable to get trigger config for build {} will use global value.");
             return config.getGerritBuildStartedCodeReviewValue();
@@ -192,15 +192,6 @@ public class ParameterExpander {
         map.put("CODE_REVIEW", String.valueOf(codeReview));
 
         return map;
-    }
-
-    /**
-     * Finds the GerritTrigger in a project.
-     * @param project the project.
-     * @return the trigger if there is one, null otherwise.
-     */
-    private GerritTrigger getTrigger(AbstractProject project) {
-        return (GerritTrigger)project.getTrigger(GerritTrigger.class);
     }
 
     /**
@@ -311,7 +302,7 @@ public class ParameterExpander {
         for (Entry entry : memoryImprint.getEntries()) {
             verified = Math.min(verified, getVerifiedValue(
                     entry.getBuild().getResult(),
-                    getTrigger(entry.getProject())));
+                    GerritTrigger.getTrigger(entry.getProject())));
         }
         return verified;
     }
@@ -326,7 +317,7 @@ public class ParameterExpander {
         for (Entry entry : memoryImprint.getEntries()) {
             codeReview = Math.min(codeReview, getCodeReviewValue(
                     entry.getBuild().getResult(),
-                    getTrigger(entry.getProject())));
+                    GerritTrigger.getTrigger(entry.getProject())));
         }
         return codeReview;
     }
@@ -386,7 +377,7 @@ public class ParameterExpander {
             for (Entry entry : entries) {
                 AbstractBuild build = entry.getBuild();
                 if (build != null) {
-                    GerritTrigger trigger = getTrigger(build.getProject());
+                    GerritTrigger trigger = GerritTrigger.getTrigger(build.getProject());
                     Result res = build.getResult();
                     String customMessage = null;
 

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
@@ -28,6 +28,7 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.Build
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildMemory.PatchSetKey;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildsStartedStats;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritCause;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger;
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -84,6 +85,10 @@ public class ToGerritRunListener extends RunListener<AbstractBuild> {
         if (cause != null) {
             cleanUpGerritCauses(cause, r);
             PatchsetCreated event = cause.getEvent();
+            if (GerritTrigger.getTrigger(r.getProject()) != null) {
+                // There won't be a trigger if this job was run through a unit test
+                GerritTrigger.getTrigger(r.getProject()).notifyBuildEnded(event);
+            }
             event.fireBuildCompleted(r);
             if (!cause.isSilentMode()) {
                 PatchSetKey key = memory.completed(event, r);

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
@@ -178,8 +178,9 @@ public class BuildMemory {
         PatchSetKey key = createKey(event);
         MemoryImprint pb = memory.get(key);
         if (pb == null) {
-            //Shoudn't happen but just in case, keep the memory.
+            //A build should not start for a job that hasn't been registered. Keep the memory anyway.
             pb = new MemoryImprint(event);
+            logger.warn("Build started without being registered first.");
             memory.put(key, pb);
         }
         pb.set(build.getProject(), build);

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -23,6 +23,8 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
 
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_BUILD_SCHEDULE_DELAY;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Change;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritEventListener;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.ChangeAbandoned;
@@ -54,6 +56,9 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
+import org.kohsuke.stapler.QueryParameter;
+import java.util.HashMap;
+import java.util.concurrent.Future;
 
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_BUILD_SCHEDULE_DELAY;
 import static com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTriggerParameters.setOrCreateParameters;
@@ -71,6 +76,8 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
     private static final int HASH_NUMBER = 53;
 
     private static final Logger logger = LoggerFactory.getLogger(GerritTrigger.class);
+    //! Association between patches and the jobs that we're running for them
+    private transient HashMap<Change, Future> runningJobs = new HashMap<Change, Future>();
     private transient AbstractProject myProject;
     private List<GerritProject> gerritProjects;
     private Integer gerritBuildStartedVerifiedValue;
@@ -157,6 +164,15 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
         this.buildFailureMessage = buildFailureMessage;
     }
 
+    /**
+     * Finds the GerritTrigger in a project.
+     * @param project the project.
+     * @return the trigger if there is one, null otherwise.
+     */
+    public static GerritTrigger getTrigger(AbstractProject project) {
+        return (GerritTrigger)project.getTrigger(GerritTrigger.class);
+    }
+
     @Override
     public void start(AbstractProject project, boolean newInstance) {
         logger.debug("Start project: {}", project);
@@ -204,6 +220,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
             logger.trace("Disabled.");
             return;
         }
+
         if (isInteresting(event)) {
             logger.trace("The event is interesting.");
             if (!silentMode) {
@@ -217,6 +234,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
             } else {
                 cause = new GerritCause(event, silentMode);
             }
+
             schedule(cause, event);
         }
     }
@@ -241,7 +259,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
      */
     protected void schedule(GerritCause cause, PatchsetCreated event, AbstractProject project) {
         //during low traffic we still don't want to spam Gerrit, 3 is a nice number, isn't it?
-        boolean ok = project.scheduleBuild(
+        Future build = project.scheduleBuild2(
                 getBuildScheduleDelay(),
                 cause,
                 new BadgeAction(event),
@@ -249,9 +267,28 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
                 new RetriggerAllAction(cause.getContext()),
                 createParameters(event, project));
 
+        // check if we're running any jobs for this event
+        if (runningJobs.containsKey(event.getChange())) {
+            // if we were, let's cancel them
+            Future oldBuild = runningJobs.remove(event.getChange());
+            if (PluginImpl.getInstance().getConfig().isGerritBuildCurrentPatchesOnly()) {
+                oldBuild.cancel(true);
+            }
+        }
+        // add our new job
+        runningJobs.put(event.getChange(), build);
+
         logger.info("Project {} Build Scheduled: {} By event: {}",
-                new Object[]{project.getName(), ok,
+                new Object[]{project.getName(), (build != null),
                         event.getChange().getNumber() + "/" + event.getPatchSet().getNumber(), });
+    }
+
+    /**
+     * Used to inform the plugin that the builds for a job have ended
+     * This allows us to clean up our list of what jobs we're running
+     */
+    public void notifyBuildEnded(PatchsetCreated patchset) {
+        runningJobs.remove(patchset.getChange());
     }
 
     /**

--- a/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/index.jelly
+++ b/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/index.jelly
@@ -50,6 +50,12 @@
                                     value="${it.config.gerritAuthKeyFilePassword}"
                                     default="${com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_AUTH_KEY_FILE_PASSWORD}"/>
                     </f:entry>
+                    <f:entry title="${%Build Current Patches Only}"
+                             help="/plugin/gerrit-trigger/help-GerritBuildCurrentPatchesOnly.html">
+                        <f:checkbox name="gerritBuildCurrentPatchesOnly"
+                                    checked="${it.config.gerritBuildCurrentPatchesOnly}"
+                                    default="true" />
+                    </f:entry>
                     <f:validateButton title="${%Test Connection}"
                                       progress="${%Testing...}"
                                       method="testConnection"

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
@@ -147,7 +147,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with an average buildScheduleDelay 20.
      */
     @Test
@@ -169,7 +169,7 @@ public class GerritTriggerTest {
         gerritCause = spy(gerritCause);
         doReturn("http://mock.url").when(gerritCause).getUrl();
         trigger.schedule(gerritCause, event);
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 eq(20),
                 same(gerritCause),
                 isA(Action.class),
@@ -180,7 +180,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with an negative buildScheduleDelay -20.
      */
     @Test
@@ -202,7 +202,7 @@ public class GerritTriggerTest {
         gerritCause = spy(gerritCause);
         doReturn("http://mock.url").when(gerritCause).getUrl();
         trigger.schedule(gerritCause, event);
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 //negative value will be reset into default value 3
                 eq(3),
                 same(gerritCause),
@@ -214,7 +214,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with an negative buildScheduleDelay 10000.
      */
     @Test
@@ -236,7 +236,7 @@ public class GerritTriggerTest {
         gerritCause = spy(gerritCause);
         doReturn("http://mock.url").when(gerritCause).getUrl();
         trigger.schedule(gerritCause, event);
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 eq(10000),
                 same(gerritCause),
                 isA(Action.class),
@@ -248,7 +248,7 @@ public class GerritTriggerTest {
     /**
      * Tests the schedule method of GerritTrigger.
      * It verifies that
-     * {@link hudson.model.AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * {@link hudson.model.AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with correct parameters when there are some default parameters present.
      */
     @Test
@@ -277,7 +277,7 @@ public class GerritTriggerTest {
         PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
         trigger.schedule(gerritCause, event);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -285,7 +285,7 @@ public class GerritTriggerTest {
                 isA(Action.class),
                 isParameterActionWithStringParameterValue("MOCK_PARAM", "mock_value"));
         //Just to make sure the normal arguments are there as well.
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -296,7 +296,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with correct parameters when there are no default parameters present.
      */
     @Test
@@ -323,7 +323,7 @@ public class GerritTriggerTest {
 
         trigger.schedule(gerritCause, event);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -331,7 +331,7 @@ public class GerritTriggerTest {
                 isA(Action.class),
                 isParameterActionWithStringParameterValue(GERRIT_CHANGE_ID.name(), event.getChange().getId()));
         //Just to make sure one more normal arguments is there as well.
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -342,7 +342,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with correct change owner and uploader parameters when there are no default parameters present.
      */
     @Test
@@ -375,7 +375,7 @@ public class GerritTriggerTest {
 
         trigger.schedule(gerritCause, event);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -392,7 +392,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with correct change owner and uploader parameters when there are no default parameters present.
      * And sets the event.uploader to null keeping event.patchSet.uploader.
      */
@@ -426,7 +426,7 @@ public class GerritTriggerTest {
 
         trigger.schedule(gerritCause, event);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -443,7 +443,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with correct change owner and uploader parameters when there are no default parameters present.
      * And sets the event.patchSet.uploader to null keeping event.uploader set.
      */
@@ -477,7 +477,7 @@ public class GerritTriggerTest {
 
         trigger.schedule(gerritCause, event);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -494,7 +494,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with correct change owner and uploader parameters when there are no default parameters present.
      * And sets the event.patchSet.uploader and event.uploader to null.
      */
@@ -527,7 +527,7 @@ public class GerritTriggerTest {
 
         trigger.schedule(gerritCause, event);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -544,7 +544,7 @@ public class GerritTriggerTest {
 
     /**
      * Tests the schedule method of GerritTrigger.
-     * It verifies that {@link AbstractProject#scheduleBuild(int, hudson.model.Cause, hudson.model.Action...)}
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with correct change owner and uploader parameters when there are no default parameters present.
      * And sets the event.patchSet.uploader and event.uploader to null.
      */
@@ -578,7 +578,7 @@ public class GerritTriggerTest {
 
         trigger.schedule(gerritCause, event);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 same(gerritCause),
                 isA(Action.class),
@@ -624,7 +624,7 @@ public class GerritTriggerTest {
 
         verify(listener).onRetriggered(same(project), same(event), anyListOf(AbstractBuild.class));
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 isA(GerritUserCause.class),
                 isA(BadgeAction.class),
@@ -666,7 +666,7 @@ public class GerritTriggerTest {
                 isA(PatchsetCreated.class),
                 anyListOf(AbstractBuild.class));
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 isA(GerritUserCause.class),
                 isA(BadgeAction.class),
@@ -721,7 +721,7 @@ public class GerritTriggerTest {
 
         verify(listener).onRetriggered(thisProject, event, null);
 
-        verify(thisProject).scheduleBuild(
+        verify(thisProject).scheduleBuild2(
                 anyInt(),
                 isA(GerritUserCause.class),
                 isA(BadgeAction.class),
@@ -731,7 +731,7 @@ public class GerritTriggerTest {
 
         verify(listener).onRetriggered(otherProject, event, null);
 
-        verify(otherProject).scheduleBuild(
+        verify(otherProject).scheduleBuild2(
                 anyInt(),
                 isA(GerritUserCause.class),
                 isA(BadgeAction.class),
@@ -766,7 +766,7 @@ public class GerritTriggerTest {
 
         verify(listener).onTriggered(same(project), same(event));
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 isA(GerritCause.class),
                 isA(BadgeAction.class),
@@ -857,7 +857,7 @@ public class GerritTriggerTest {
 
         verify(listener).onTriggered(same(project), same(event));
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 isA(GerritManualCause.class),
                 isA(BadgeAction.class),
@@ -892,7 +892,7 @@ public class GerritTriggerTest {
 
         verifyNoMoreInteractions(listener);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 isA(GerritCause.class),
                 isA(BadgeAction.class),
@@ -928,7 +928,7 @@ public class GerritTriggerTest {
 
         verifyNoMoreInteractions(listener);
 
-        verify(project).scheduleBuild(
+        verify(project).scheduleBuild2(
                 anyInt(),
                 isA(GerritManualCause.class),
                 isA(BadgeAction.class),

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -191,4 +191,8 @@ public class MockGerritHudsonTriggerConfig implements
     public boolean hasDefaultValues() {
         return false;
     }
+
+    public boolean isGerritBuildCurrentPatchesOnly() {
+        return true;
+    }
 }


### PR DESCRIPTION
When a new patch set is posted, building the previous patch set
is no longer valuable. This causes an enormous extra load on the
build servers. If someone rapidly posts several revisions of a
patch, it could cause enormous delays and wasted resources in
Jenkins.

If others feel a need to make this an option, I can, but for the
environments I have seen, this is always desired behavior.
