### PR TITLE
Triggered jobs now show up in trigger monitor panel when manually selecting silent builds

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -206,7 +206,11 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
         }
         if (isInteresting(event)) {
             logger.trace("The event is interesting.");
-            ToGerritRunListener.getInstance().onTriggered(myProject, event);
+            if (!silentMode) {
+                ToGerritRunListener.getInstance().onTriggered(myProject, event);
+            } else {
+                event.fireProjectTriggered(myProject);
+            }
             GerritCause cause;
             if (event instanceof ManualPatchsetCreated) {
                 cause = new GerritManualCause((ManualPatchsetCreated)event, silentMode);


### PR DESCRIPTION
Make sure triggered jobs show up in trigger monitor panel when manually selecting silent builds

Signed-off-by: Stephen Ware stephen.e.ware@intel.com
