### PR TITLE
Update build-config dependency versions.

### DIFF
--- a/gerrit-events/pom.xml
+++ b/gerrit-events/pom.xml
@@ -148,7 +148,7 @@
                     <dependency>
                         <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
                         <artifactId>build-config</artifactId>
-                        <version>1.2.4-SNAPSHOT</version>
+                        <version>1.2.5-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/gerrithudsontrigger/pom.xml
+++ b/gerrithudsontrigger/pom.xml
@@ -165,7 +165,7 @@
                     <dependency>
                         <groupId>com.sonyericsson.hudson.plugins.gerrit</groupId>
                         <artifactId>build-config</artifactId>
-                        <version>1.2.4-SNAPSHOT</version>
+                        <version>1.2.5-SNAPSHOT</version>
                     </dependency>
                 </dependencies>
                 <executions>


### PR DESCRIPTION
Update to 1.2.5-SNAPSHOT.

Fixes https://issues.jenkins-ci.org/browse/JENKINS-12824
