### PR TITLE
Add jGit repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <id>repo.jenkins-ci.org</id>
             <url>http://repo.jenkins-ci.org/public</url>
         </repository>
+
+        <repository>
+            <id>jgit-repository</id>
+            <name>Eclipse JGit Repository</name>
+            <url>http://download.eclipse.org/jgit/maven</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
Now repo.jenkins-ci.org does not host jGit properly.
So add jGit official repository as failsafe.
