### PR TITLE
Add JGit repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,12 @@
             <id>repo.jenkins-ci.org</id>
             <url>http://repo.jenkins-ci.org/public</url>
         </repository>
+
+        <repository>
+            <id>jgit-repository</id>
+            <name>Eclipse JGit Repository</name>
+            <url>http://download.eclipse.org/jgit/maven</url>
+        </repository>
     </repositories>
 
     <pluginRepositories>


### PR DESCRIPTION
Now repo.jenkins-ci.org and central do not have the past JGit packages.
git-plugin needs it.

So add JGit official repository until git-plugin supports the latest one.
