### PR TITLE
Add a new executeCommand variation, that returns the Channel

### DIFF
--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/ssh/SshConnection.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/ssh/SshConnection.java
@@ -23,6 +23,8 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh;
 
+import com.jcraft.jsch.ChannelExec;
+
 import java.io.IOException;
 import java.io.Reader;
 
@@ -76,6 +78,18 @@ public interface SshConnection {
      * @throws SshException if there are any ssh problems.
      */
     Reader executeCommandReader(String command) throws SshException, IOException;
+
+    /**
+     * Execute an ssh command on the server, without closing the session
+     * so that the caller can get access to all the Channel attributes from
+     * the server.
+     *
+     * @param command the command to execute.
+     * @return a Channel with access to all streams and the exit code.
+     * @throws IOException  if it is so.
+     * @throws SshException if there are any ssh problems.
+     */
+    ChannelExec executeCommandChannel(String command) throws SshException, IOException;
 
     /**
      * Disconnects the connection.

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/ssh/SshConnectionImpl.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/ssh/SshConnectionImpl.java
@@ -191,6 +191,25 @@ public class SshConnectionImpl implements SshConnection {
     }
 
     /**
+     * This version takes a command to run, and then returns a wrapper instance
+     * that exposes all the standard state of the channel (stdin, stdout,
+     * stderr, exit status, etc).
+     */
+    public synchronized ChannelExec executeCommandChannel(String command) throws SshException, IOException {
+        if (!isConnected()) {
+            throw new IllegalStateException("Not connected!");
+        }
+        try {
+            ChannelExec channel = (ChannelExec) connectSession.openChannel("exec");
+            channel.setCommand(command);
+            channel.connect();
+            return channel;
+        } catch (JSchException ex) {
+            throw new SshException(ex);
+        }
+    }
+
+    /**
         * Disconnects the connection.
         */
     @Override


### PR DESCRIPTION
This variation returns the SSH Channel, giving access to all 3 streams
and the exit status.

This is just a convenience change.  I'm making use of the `gerrit-events` module in a separate project (a JIRA plugin, not related to Jenkins), and this change allows the plugin to detect when there was an error while running a command.  Current implementation does not allow for obtaining the stderr response, and does not return the exit status code.
