### PR TITLE
Fix for problem using the gerrit-trigger under Windows

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtil.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtil.java
@@ -25,6 +25,9 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.utils;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
 import java.util.regex.Pattern;
 
 /**
@@ -123,7 +126,18 @@ public final class StringUtil {
         if (value == null) {
             return null;
         } else {
-            return QUOTES_PATTERN.matcher(value).replaceAll("\\\\\"");
+            String os = AccessController
+                    .doPrivileged(new PrivilegedAction<String>() {
+                        @Override
+                        public String run() {
+                            return System.getProperty("os.name");
+                        }
+                    });
+            if (os.startsWith("Windows"))
+                return QUOTES_PATTERN.matcher(value).replaceAll("\\\"\"\"");
+            else
+                return QUOTES_PATTERN.matcher(value).replaceAll("\\\\\"");
         }
+
     }
 }


### PR DESCRIPTION
The plugin works, though i personally feel we have too many quotes. Is that a problem in Linux too?

e.g. in the build properties i see

GERRIT_CHANGE_OWNER="""Robin Rosenberg""" me@example.com

I added an echo to my ant build file like this and it says
        GERRIT_CHANGE_OWNER=${GERRIT_CHANGE_OWNER}

GERRIT_CHANGE_OWNER=""Robin Rosenberg"" me@example.com
