### PR TITLE
Add the possibility to add reviewers to a Gerrit change from Jenkins

### DIFF
--- a/gerrithudsontrigger/pom.xml
+++ b/gerrithudsontrigger/pom.xml
@@ -136,6 +136,11 @@
             <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>10.0.1</version>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/NotificationFactory.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/NotificationFactory.java
@@ -30,6 +30,7 @@ import com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritSendCommandQueu
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.AddReviewersCommandJob;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.BuildCompletedCommandJob;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.BuildStartedCommandJob;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildMemory;
@@ -126,6 +127,21 @@ public class NotificationFactory {
                                   GerritTriggeredEvent event, BuildsStartedStats stats) {
         BuildStartedCommandJob job = new BuildStartedCommandJob(getConfig(),
                 build, listener, event, stats);
+        GerritSendCommandQueue.queue(job);
+    }
+
+    /**
+     * Queues an add reviewers command on the send-command queue.
+     *
+     * @param memoryImprint the memory of the builds
+     * @param listener a listener
+     */
+    public void queueAddReviewers(BuildMemory.MemoryImprint memoryImprint, TaskListener listener) {
+        AddReviewersCommandJob job = new AddReviewersCommandJob(
+                getConfig(),
+                memoryImprint,
+                listener
+        );
         GerritSendCommandQueue.queue(job);
     }
 }

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
@@ -121,6 +121,9 @@ public class ToGerritRunListener extends RunListener<AbstractBuild> {
                         logger.info("All Builds are completed for cause: {}", cause);
                         event.fireAllBuildsCompleted();
                         NotificationFactory.getInstance().queueBuildCompleted(memory.getMemoryImprint(event), listener);
+                        if(memory.isAllBuildsSuccessful(event)) {
+                            NotificationFactory.getInstance().queueAddReviewers(memory.getMemoryImprint(event), listener);
+                        }
                     } finally {
                         memory.forget(event);
                     }

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/AddReviewersCommandJob.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/AddReviewersCommandJob.java
@@ -1,0 +1,37 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.cmd.AbstractSendCommandJob;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.GerritNotifier;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.NotificationFactory;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildMemory;
+import hudson.model.TaskListener;
+
+import java.util.Set;
+
+/**
+ * A send-command-job that sends the add reviewers command.
+ *
+ * @author Emanuele Zattin
+ */
+public class AddReviewersCommandJob extends AbstractSendCommandJob {
+
+    private BuildMemory.MemoryImprint memoryImprint;
+    private TaskListener listener;
+
+    public AddReviewersCommandJob(IGerritHudsonTriggerConfig config,
+                                  BuildMemory.MemoryImprint memoryImprint,
+                                  TaskListener listener) {
+        super(config);
+        this.memoryImprint = memoryImprint;
+        this.listener = listener;
+    }
+
+    @Override
+    public void run() {
+        Set<String> reviewers = FindReviewersHelper.perform(memoryImprint);
+        GerritNotifier notifier = NotificationFactory.getInstance()
+                .createGerritNotifier((IGerritHudsonTriggerConfig)getConfig(), this);
+        notifier.addReviewers(memoryImprint, listener, reviewers);
+    }
+}

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/FindReviewersHelper.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/FindReviewersHelper.java
@@ -1,0 +1,90 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+import com.google.common.collect.Sets;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildMemory;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritpublisher.GerritPublisher;
+import hudson.FilePath;
+import hudson.model.Descriptor;
+import hudson.scm.ChangeLogSet;
+import hudson.tasks.Publisher;
+import hudson.util.DescribableList;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * A helper class to find the reviewers of a Gerrit change.
+ *
+ * @author Emanuele Zattin
+ */
+@SuppressWarnings("unchecked")
+public class FindReviewersHelper {
+    public static Set<String> perform(BuildMemory.MemoryImprint memoryImprint) {
+        Set<String> reviewers = Sets.newHashSet();
+        for (BuildMemory.MemoryImprint.Entry entry : memoryImprint.getEntries()) {
+            DescribableList describableList = entry.getProject().getPublishersList();
+            GerritPublisher gerritPublisher =
+                    ((DescribableList<Publisher,Descriptor<Publisher>>)describableList).get(GerritPublisher.class);
+
+            reviewers.addAll(gerritPublisher.getReviewersAsSet());
+
+            if (!gerritPublisher.getOwnersFileName().isEmpty()) {
+                // Find the files affected by the commit
+                for (Object change : entry.getBuild().getChangeSet()) {
+                    // generics gone wrong :(
+                    if (change instanceof ChangeLogSet.Entry) {
+                        ChangeLogSet.Entry changeEntry = (ChangeLogSet.Entry) change;
+                        FilePath workspace = entry.getBuild().getWorkspace();
+                        for (String path : changeEntry.getAffectedPaths()) {
+                            FilePath filePath = new FilePath(workspace, path);
+                            try {
+                                // Ok, enough nesting :)
+                                if (!filePath.exists()) {
+                                    continue;
+                                }
+                                if (!filePath.isDirectory()) {
+                                    if (filePath.sibling(gerritPublisher.getOwnersFileName()).exists()) {
+                                        String fileContents =
+                                                filePath.sibling(gerritPublisher.getOwnersFileName()).readToString();
+                                        Iterable<String> reviewersInOwnerFile = Splitter.on(CharMatcher.anyOf(",;\n"))
+                                                .omitEmptyStrings()
+                                                .trimResults()
+                                                .split(fileContents);
+                                        reviewers.addAll(Sets.newHashSet(reviewersInOwnerFile));
+                                        continue;
+                                    } else {
+                                        filePath = filePath.getParent();
+                                    }
+                                }
+                                while (!filePath.sibling(gerritPublisher.getOwnersFileName()).exists()) {
+                                    if (filePath.equals(workspace)) {
+                                        continue;
+                                    }
+                                    filePath = filePath.getParent();
+                                }
+                                String fileContents =
+                                        filePath.sibling(gerritPublisher.getOwnersFileName()).readToString();
+                                Iterable<String> reviewersInOwnerFile = Splitter.on(CharMatcher.anyOf(",;\n"))
+                                        .omitEmptyStrings()
+                                        .trimResults()
+                                        .split(fileContents);
+                                reviewers.addAll(Sets.newHashSet(reviewersInOwnerFile));
+
+                            } catch (InterruptedException e) {
+                                throw Throwables.propagate(e);
+                            } catch (IOException e) {
+                                throw Throwables.propagate(e);
+                            }
+                        }
+                    }
+
+                }
+            }
+        }
+
+        return reviewers;
+    }
+}

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
@@ -50,6 +50,16 @@ import java.util.TreeMap;
  */
 public class BuildMemory {
 
+    public boolean isAllBuildsSuccessful(GerritTriggeredEvent event) {
+        boolean result = true;
+        for (AbstractBuild build : getBuilds(event)) {
+            if (build.getResult() != Result.SUCCESS) {
+                result = false;
+            }
+        }
+        return result;
+    }
+
     /**
      * Compares GerritTriggeredEvents using the Object.hashCode() method.
      * This ensures that every event received from Gerrit is kept track of individually.

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritpublisher/GerritPublisher.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritpublisher/GerritPublisher.java
@@ -1,0 +1,102 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritpublisher;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+import hudson.Extension;
+import hudson.Launcher;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.model.BuildListener;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import net.sf.json.JSONObject;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+
+import java.io.IOException;
+import java.util.Set;
+
+/**
+ * Adds reviewers to the Gerrit change that triggered the build.
+ * It is actually only used as a container, since we want to add
+ * reviewers per Gerrit change and not per job.
+ *
+ * @author Emanuele Zattin
+ */
+public class GerritPublisher extends Notifier {
+
+    private String reviewers;
+    private String ownersFileName;
+
+    @DataBoundConstructor
+    public GerritPublisher(String reviewers, String ownersFileName) {
+        Preconditions.checkNotNull(reviewers);
+        Preconditions.checkNotNull(ownersFileName);
+        this.reviewers = reviewers;
+        this.ownersFileName = ownersFileName;
+    }
+
+    public String getReviewers() {
+        return reviewers;
+    }
+
+    public void setReviewers(String reviewers) {
+        this.reviewers = reviewers;
+    }
+
+    public String getOwnersFileName() {
+        return ownersFileName;
+    }
+
+    public void setOwnersFileName(String ownersFileName) {
+        this.ownersFileName = ownersFileName;
+    }
+
+    /**
+     * @return a Set containing the reviewers. It splits on commas and trims the results.
+     */
+    public Set<String> getReviewersAsSet() {
+        Preconditions.checkNotNull(reviewers);
+        return Sets.newHashSet(
+            Splitter.on(",")
+                    .omitEmptyStrings()
+                    .trimResults()
+                    .split(reviewers));
+    }
+
+    @Override
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    @Override
+    public boolean perform(AbstractBuild<?, ?> build, Launcher launcher, BuildListener listener) throws InterruptedException, IOException {
+        return true;
+    }
+
+    @Extension
+    public static final class Descriptor extends BuildStepDescriptor<Publisher> {
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> aClass) {
+            return true;
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Add Gerrit Reviewers";
+        }
+
+        @Override
+        public Publisher newInstance(StaplerRequest req, JSONObject formData) throws FormException {
+            return new GerritPublisher(
+                Strings.nullToEmpty(formData.getString("reviewers")),
+                Strings.nullToEmpty(formData.getString("ownersFileName"))
+            );
+        }
+    }
+}

--- a/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritpublisher/GerritPublisher/config.jelly
+++ b/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritpublisher/GerritPublisher/config.jelly
@@ -1,0 +1,8 @@
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
+    <f:entry title="${%File Name}" field="ownersFileName" help="/plugin/gerrit-trigger/help-ownersFileName.html">
+        <f:textbox />
+    </f:entry>
+    <f:entry title="${%Reviewers}" field="reviewers" help="/plugin/gerrit-trigger/help-reviewers.html">
+        <f:textbox />
+    </f:entry>
+</j:jelly>

--- a/gerrithudsontrigger/src/main/webapp/help-ownersFileName.html
+++ b/gerrithudsontrigger/src/main/webapp/help-ownersFileName.html
@@ -1,0 +1,4 @@
+<p>The name of the files in the workspace containing a list of comma and/or newline separated list of emails of people
+    responsible for a specific area.</p>
+<p>This is helpful in big projects where, for example, a .owners file can be places in specific sub-folders according
+    to the group of people expert in that specific area.</p>

--- a/gerrithudsontrigger/src/main/webapp/help-reviewers.html
+++ b/gerrithudsontrigger/src/main/webapp/help-reviewers.html
@@ -1,0 +1,3 @@
+<p>A comma separated list of default reviewers. This list can be left empty</p>
+<p>Example:<br>
+<code>john.doe@gmail.com, anonymous.coward@hotmail.com</code></p>

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/FindReviewersHelperTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/FindReviewersHelperTest.java
@@ -1,0 +1,89 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildMemory;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritpublisher.GerritPublisher;
+import hudson.FilePath;
+import hudson.model.AbstractBuild;
+import hudson.model.AbstractProject;
+import hudson.scm.ChangeLogSet;
+import hudson.util.DescribableList;
+import junit.framework.TestCase;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Set;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(AbstractBuild.class)
+public class FindReviewersHelperTest extends TestCase {
+
+    public void testPerform() throws Exception {
+        GerritPublisher gerritPublisher = new GerritPublisher("me@me.com, you@you.com", ".owners");
+
+        DescribableList mockDescribableList = mock(DescribableList.class);
+        when(mockDescribableList.get(GerritPublisher.class)).thenReturn(gerritPublisher);
+
+        AbstractProject mockProject = mock(AbstractProject.class);
+        when(mockProject.getPublishersList()).thenReturn(mockDescribableList);
+
+        URL url = this.getClass().getResource("workspace");
+        File f;
+        try {
+            f = new File(url.toURI());
+        } catch(URISyntaxException e) {
+            f = new File(url.getPath());
+        }
+
+        FilePath workspace = new FilePath(f);
+
+        AbstractBuild mockBuild = PowerMockito.mock(AbstractBuild.class);
+
+        ChangeLogSet.Entry mockChangeEntry = mock(ChangeLogSet.Entry.class);
+        when(mockChangeEntry.getAffectedPaths()).thenReturn(Arrays.asList("somefile.c", "subfolder/subsubfolder/someotherfile.c"));
+
+        final Iterator mockIterator = mock(Iterator.class);
+        when(mockIterator.hasNext()).thenReturn(true, false);
+        when(mockIterator.next()).thenReturn(mockChangeEntry);
+
+        ChangeLogSet changeLogSet = new ChangeLogSet(mockBuild) {
+            @Override
+            public boolean isEmptySet() {
+                return false;
+            }
+
+            @Override
+            public Iterator iterator() {
+                return mockIterator;
+            }
+        };
+
+        PowerMockito.when(mockBuild.getWorkspace()).thenReturn(workspace);
+        when(mockBuild.getChangeSet()).thenReturn(changeLogSet);
+
+        BuildMemory.MemoryImprint.Entry mockEntry = mock(BuildMemory.MemoryImprint.Entry.class);
+        when(mockEntry.getProject()).thenReturn(mockProject);
+        when(mockEntry.getBuild()).thenReturn(mockBuild);
+
+        BuildMemory.MemoryImprint mockMemoryImprint = mock(BuildMemory.MemoryImprint.class);
+        when(mockMemoryImprint.getEntries()).thenReturn(new BuildMemory.MemoryImprint.Entry[] {mockEntry});
+
+        Set<String> reviewers = FindReviewersHelper.perform(mockMemoryImprint);
+        assertNotNull(reviewers);
+        assertEquals(5, reviewers.size());
+        assertTrue(reviewers.contains("me@me.com"));
+        assertTrue(reviewers.contains("you@you.com"));
+        assertTrue(reviewers.contains("him@him.com"));
+        assertTrue(reviewers.contains("she@she.com"));
+        assertTrue(reviewers.contains("they@they.com"));
+    }
+}

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritpublisher/GerritPublisherTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritpublisher/GerritPublisherTest.java
@@ -1,0 +1,45 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritpublisher;
+
+import hudson.model.FreeStyleProject;
+import org.jvnet.hudson.test.HudsonTestCase;
+
+import java.util.Set;
+
+public class GerritPublisherTest extends HudsonTestCase {
+
+    public void testRoundTrip() throws Exception {
+        FreeStyleProject project = createFreeStyleProject();
+        GerritPublisher publisher = new GerritPublisher("this", "that");
+        project.getPublishersList().add(publisher);
+        submit(createWebClient().getPage(project,"configure").getFormByName("config"));
+        GerritPublisher after = project.getPublishersList().get(GerritPublisher.class);
+        assertEqualBeans(publisher, after, "reviewers,ownersFileName");
+    }
+
+    public void testGetReviewersAsSet() throws Exception {
+        GerritPublisher publisher = new GerritPublisher("1,2,3,4,5", "anything");
+        Set<String> reviewers = publisher.getReviewersAsSet();
+        assertEquals(5, reviewers.size());
+        assertTrue(reviewers.contains("1"));
+        assertTrue(reviewers.contains("2"));
+        assertTrue(reviewers.contains("3"));
+        assertTrue(reviewers.contains("4"));
+        assertTrue(reviewers.contains("5"));
+
+        // Trimming and empty elements removal
+        publisher = new GerritPublisher("1 ,   2, 3,,  ,4,5   ", "anything");
+        reviewers = publisher.getReviewersAsSet();
+        assertEquals(5, reviewers.size());
+        assertTrue(reviewers.contains("1"));
+        assertTrue(reviewers.contains("2"));
+        assertTrue(reviewers.contains("3"));
+        assertTrue(reviewers.contains("4"));
+        assertTrue(reviewers.contains("5"));
+
+        // Avoid null as much as possible
+        publisher = new GerritPublisher("", "anything");
+        reviewers = publisher.getReviewersAsSet();
+        assertNotNull(reviewers);
+        assertTrue(reviewers.isEmpty());
+    }
+}

--- a/gerrithudsontrigger/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/workspace/.owners
+++ b/gerrithudsontrigger/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/workspace/.owners
@@ -1,0 +1,2 @@
+him@him.com
+they@they.com

--- a/gerrithudsontrigger/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/workspace/somefile.c
+++ b/gerrithudsontrigger/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/workspace/somefile.c
@@ -1,0 +1,1 @@
+some content

--- a/gerrithudsontrigger/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/workspace/subfolder/.owners
+++ b/gerrithudsontrigger/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/workspace/subfolder/.owners
@@ -1,0 +1,1 @@
+she@she.com

--- a/gerrithudsontrigger/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/workspace/subfolder/subsubfolder/someotherfile.c
+++ b/gerrithudsontrigger/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/workspace/subfolder/subsubfolder/someotherfile.c
@@ -1,0 +1,1 @@
+some content


### PR DESCRIPTION
This is implemented as a Notifier only for UX purposes.
If all the builds related to a Gerrit change succeed, then
the reviewers will be added. This avoids spamming reviewers as much as
possible.
