### PR TITLE
Add link to plugin page in dynamic trigger configuration's description.

### DIFF
--- a/gerrithudsontrigger/src/main/webapp/trigger/help-DynamicTriggerConfiguration.html
+++ b/gerrithudsontrigger/src/main/webapp/trigger/help-DynamicTriggerConfiguration.html
@@ -5,4 +5,6 @@ regular intervals, and the trigger configuration will be updated accordingly.<br
 The URL must be in a format that can be parsed by <b>java.net.URL</b>.<br>
 <br>
 A Dynamic Trigger Configuration can co-exist peacefully with the
-regular way of manually specifying the trigger configuration below.
+regular way of manually specifying the trigger configuration below.<br>
+<br>
+Regarding configuration file format, see "Dynamic triggering" section in <a href="https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Trigger">plugin page</a> on jenkins-ci.org.


### PR DESCRIPTION
Missing configuraton file format, so add link to plugin page.
