### PR TITLE
Fix regexp sample

### DIFF
--- a/gerrithudsontrigger/src/main/webapp/trigger/help-DynamicTriggerConfiguration.html
+++ b/gerrithudsontrigger/src/main/webapp/trigger/help-DynamicTriggerConfiguration.html
@@ -14,7 +14,7 @@
     On a set interval, the plugin fetches and parses this file. The file contents should follow this syntax:
 <pre style="border: 1px dashed black; padding: 2px"><code>p=some/project
 b^**/master/*
-f~*.txt
+f~\.txt$
 p=some/other/project
 b^**</code></pre>
 


### PR DESCRIPTION
From Gerrit Trigger wiki, "regexp" means java.util.regexp.Pattern.
But sample "*.txt" is not regexp but glob.
