### PR TITLE
Fix For JENKINS-16851

### DIFF
--- a/gerrithudsontrigger/pom.xml
+++ b/gerrithudsontrigger/pom.xml
@@ -65,7 +65,7 @@
         <dependency>
             <groupId>org.jenkinsci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>1.1.10</version>
+            <version>1.1.29</version>
         </dependency>
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>


### PR DESCRIPTION
It is probably fixed in git plugin v. 1.1.29
this commit should remove any use of deprecated APIs.
But when I test this I gen something very similar to
JENKINS-16849 at the end of the build.
