### PR TITLE
Set GERRIT_REFSPEC variable for ref-updated event

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -296,6 +296,10 @@ public enum GerritTriggerParameters {
                     parameters, getEmail(uploader), escapeQuotes);
         } else if (gerritEvent instanceof RefUpdated) {
             RefUpdated event = (RefUpdated)gerritEvent;
+            GERRIT_REFSPEC.setOrCreateStringParameterValue(
+                    parameters, event.getRefUpdate().getRefName(), escapeQuotes);
+            GERRIT_BRANCH.setOrCreateStringParameterValue(
+		    parameters, event.getRefUpdate().getRefName(), escapeQuotes);
             GERRIT_REFNAME.setOrCreateStringParameterValue(
                     parameters, event.getRefUpdate().getRefName(), escapeQuotes);
             GERRIT_PROJECT.setOrCreateStringParameterValue(


### PR DESCRIPTION
If Refstpec parameter is set to $GERRIT_REFSPEC in git plugin
configuration as suggested on the wiki[1] plugin can't fetch the ref
from the repository for ref-updated events. It crashes with the following
message:
ERROR: Problem fetching from origin / origin - could be unavailable.
Continuing anyway hudson.plugins.git.GitException:
org.eclipse.jgit.api.errors.TransportException: Remote does not have $GERRIT_REFSPEC available for fetch.

This makes impossible to use ref-updated and any change-specific events
in the same Jenkins job.

This change fixes the issue by setting GERRIT_REFSPEC to the same value
as GERRIT_REFNAME
1. https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Trigger#GerritTrigger-UsagewiththeGitPlugin

Signed-off-by: Ed Bartosh eduard.bartosh@intel.com
