### PR TITLE
Set GERRIT_REFSPEC and GERRIT_BRANCH variables for ref-updated event

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -296,6 +296,10 @@ public enum GerritTriggerParameters {
                     parameters, getEmail(uploader), escapeQuotes);
         } else if (gerritEvent instanceof RefUpdated) {
             RefUpdated event = (RefUpdated)gerritEvent;
+            GERRIT_REFSPEC.setOrCreateStringParameterValue(
+                    parameters, event.getRefUpdate().getRefName(), escapeQuotes);
+            GERRIT_BRANCH.setOrCreateStringParameterValue(
+		    parameters, event.getRefUpdate().getRefName(), escapeQuotes);
             GERRIT_REFNAME.setOrCreateStringParameterValue(
                     parameters, event.getRefUpdate().getRefName(), escapeQuotes);
             GERRIT_PROJECT.setOrCreateStringParameterValue(


### PR DESCRIPTION
If Refstpec and 'Branches to build' parameters are set to
$GERRIT_REFSPEC and $GERRIT_BRANCH in git plugin configuration as
it's suggested on the wiki[1] git plugin catn't fetch the ref from the
repository for ref-updated events. It crashes with the following
messages:
ERROR: Problem fetching from origin / origin - could be unavailable.
Continuing anyway hudson.plugins.git.GitException:
org.eclipse.jgit.api.errors.TransportException: Remote does not have $GERRIT_REFSPEC available for fetch.

ERROR: Couldn't find any revision to build. Verify the repository and
branch configuration for this job. Finished: FAILURE

This makes it impossible to process ref-updated and any change-specific events
by the same Jenkins job.

This change fixes the issue by setting GERRIT_REFSPEC and GERRIT_BRANCH
to the same value as GERRIT_REFNAME
1. https://wiki.jenkins-ci.org/display/JENKINS/Gerrit+Trigger#GerritTrigger-UsagewiththeGitPlugin

Signed-off-by: Ed Bartosh eduard.bartosh@intel.com
