### PR TITLE
Delay connection until Jenkins completes to load all items.

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
@@ -136,10 +136,6 @@ public class PluginImpl extends Plugin {
             categories.add(new VerdictCategory("CRVW", "Code Review"));
             categories.add(new VerdictCategory("VRIF", "Verified"));
         }
-        if (!config.hasDefaultValues()) {
-            startManager();
-            logger.info("Started");
-        }
     }
 
     /**
@@ -182,15 +178,6 @@ public class PluginImpl extends Plugin {
             gerritEventManager = null;
         }
         GerritSendCommandQueue.shutdown();
-    }
-
-    /**
-     * Starts the GerritEventManager
-     */
-    private void startManager() {
-        logger.debug("starting Gerrit manager");
-        createManager();
-        gerritEventManager.start();
     }
 
     /**
@@ -265,19 +252,22 @@ public class PluginImpl extends Plugin {
      * @throws Exception if it is so unfortunate.
      */
     public synchronized void startConnection() throws Exception {
-        if (gerritEventManager == null) {
-            createManager();
-            if (savedEventListeners != null) {
-                gerritEventManager.addEventListeners(savedEventListeners);
-                savedEventListeners = null;
+        if (!config.hasDefaultValues()) {
+            if (gerritEventManager == null) {
+                createManager();
+                if (savedEventListeners != null) {
+                    gerritEventManager.addEventListeners(savedEventListeners);
+                    savedEventListeners = null;
+                }
+                if (savedConnectionListeners != null) {
+                    gerritEventManager.addConnectionListeners(savedConnectionListeners);
+                    savedConnectionListeners = null;
+                }
+                gerritEventManager.start();
+                logger.info("Started");
+            } else {
+                logger.warn("Already started!");
             }
-            if (savedConnectionListeners != null) {
-                gerritEventManager.addConnectionListeners(savedConnectionListeners);
-                savedConnectionListeners = null;
-            }
-            gerritEventManager.start();
-        } else {
-            logger.warn("Already started!");
         }
     }
 

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritItemListener.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritItemListener.java
@@ -23,6 +23,11 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+
 import hudson.Extension;
 import hudson.model.AbstractProject;
 import hudson.model.Item;
@@ -37,6 +42,7 @@ import hudson.model.listeners.ItemListener;
  */
 @Extension
 public class GerritItemListener extends ItemListener {
+    private static final Logger logger = LoggerFactory.getLogger(GerritItemListener.class);
 
     /**
      * Called by Jenkins when an item is about to be deleted. If this item is a project
@@ -59,5 +65,18 @@ public class GerritItemListener extends ItemListener {
                 gerritTrigger.cancelTimer();
             }
         }
+    }
+
+    /**
+     * Called by Jenkins when all items are loaded.
+     */
+    @Override
+    public void onLoaded() {
+        try {
+            PluginImpl.getInstance().startConnection();
+        } catch (Exception e) {
+            logger.error("Could not start connection. ", e);
+        }
+        super.onLoaded();
     }
 }


### PR DESCRIPTION
Configured gerrit triggered job cannot take any gerrit events until
it is loaded to Jenkins. So stream-events connection should be delayed
until Jenkins completes to load all items.
