### PR TITLE
[DO NOT MERGE] Isolate connection functions from GerritHandler

### DIFF
--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/Connector.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/Connector.java
@@ -1,0 +1,35 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents;
+
+/**
+ * A interface to connect network resources.
+ * @author rinrinne &lt;rinrin.ne@gmail.om&gt;
+ */
+public interface Connector {
+    /**
+     * Shuts down the stream-events connection so that the auto reconnect goes in effect.
+     */
+    void reconnect();
+}

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritConnection.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritConnection.java
@@ -1,0 +1,567 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2010 Sony Ericsson Mobile Communications. All rights reserved.
+ *  Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.Authentication;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshAuthenticationException;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshConnectException;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshConnection;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshConnectionFactory;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.watchdog.StreamWatchdog;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.Reader;
+
+//CS IGNORE LineLength FOR NEXT 7 LINES. REASON: static import.
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_AUTH_KEY_FILE;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_AUTH_KEY_FILE_PASSWORD;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_HOSTNAME;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_SSH_PORT;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_PROXY;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_USERNAME;
+
+//CS IGNORE LineLength FOR NEXT 2 LINES. REASON: static import.
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritConnectionEvent.GERRIT_CONNECTION_ESTABLISHED;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritConnectionEvent.GERRIT_CONNECTION_DOWN;
+
+/**
+ * Main class for this module. Contains the main loop for connecting and reading streamed events from Gerrit.
+ *
+ * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
+ */
+public class GerritConnection implements Runnable, Connector {
+
+    /**
+     * Time to wait between connection attempts.
+     */
+    public static final int CONNECT_SLEEP = 2000;
+    private static final String CMD_STREAM_EVENTS = "gerrit stream-events";
+    private static final String GERRIT_VERSION_PREFIX = "gerrit version ";
+    private static final String GERRIT_NAME = "gerrit";
+    private static final String GERRIT_PROTOCOL_NAME = "ssh";
+    /**
+     * The amount of milliseconds to pause when brute forcing the shutdown flag to true.
+     */
+    protected static final int PAUSE_SECOND = 1000;
+    /**
+     * The interval of millisecond to read from gerrit stream when buffer is not ready.
+     */
+    protected static final int INTERVAL_READ = 200;
+    /**
+     * How many times to try and set the shutdown flag to true. Noticed during unit tests there seems to be a timing
+     * issue or something so sometimes the {@shutdownInProgress} flag is not set properly. Setting it a number of times
+     * with some delay helped.
+     *
+     * @see #shutdown(boolean)
+     * @see #PAUSE_SECOND
+     */
+    protected static final int BRUTE_FORCE_TRIES = 10;
+    private static final Logger logger = LoggerFactory.getLogger(GerritConnection.class);
+    private String gerritHostName;
+    private int gerritSshPort;
+    private String gerritProxy;
+    private Authentication authentication;
+    private SshConnection sshConnection;
+    private volatile boolean shutdownInProgress = false;
+    private boolean connected = false;
+    private String gerritVersion = null;
+    private int watchdogTimeoutSeconds;
+    private WatchTimeExceptionData exceptionData;
+    private StreamWatchdog watchdog;
+    private int reconnectCallCount = 0;
+    private Handler handler;
+
+
+    /**
+     * Creates a GerritHandler with all the default values set.
+     *
+     * @see GerritDefaultValues#DEFAULT_GERRIT_HOSTNAME
+     * @see GerritDefaultValues#DEFAULT_GERRIT_SSH_PORT
+     * @see GerritDefaultValues#DEFAULT_GERRIT_PROXY
+     * @see GerritDefaultValues#DEFAULT_GERRIT_USERNAME
+     * @see GerritDefaultValues#DEFAULT_GERRIT_AUTH_KEY_FILE
+     * @see GerritDefaultValues#DEFAULT_GERRIT_AUTH_KEY_FILE_PASSWORD
+     */
+    public GerritConnection() {
+        this(DEFAULT_GERRIT_HOSTNAME,
+                DEFAULT_GERRIT_SSH_PORT,
+                DEFAULT_GERRIT_PROXY,
+                new Authentication(DEFAULT_GERRIT_AUTH_KEY_FILE,
+                        DEFAULT_GERRIT_USERNAME,
+                        DEFAULT_GERRIT_AUTH_KEY_FILE_PASSWORD));
+    }
+
+    /**
+     * Creates a GerritHandler with the specified values.
+     *
+     * @param gerritHostName the hostName
+     * @param gerritSshPort  the ssh port that the gerrit server listens to.
+     * @param authentication the authentication credentials.
+     */
+    public GerritConnection(String gerritHostName,
+                         int gerritSshPort,
+                         Authentication authentication) {
+        this(gerritHostName,
+                gerritSshPort,
+                DEFAULT_GERRIT_PROXY,
+                authentication);
+    }
+
+    /**
+     * Standard Constructor.
+     *
+     * @param config the configuration containing the connection values.
+     */
+    public GerritConnection(GerritConnectionConfig config) {
+        this(config, DEFAULT_GERRIT_PROXY, 0, null);
+    }
+
+    /**
+     * Standard Constructor.
+     *
+     * @param config the configuration containing the connection values.
+     */
+    public GerritConnection(GerritConnectionConfig2 config) {
+        this(config, config.getGerritProxy(), config.getWatchdogTimeoutSeconds(), config.getExceptionData());
+    }
+
+    /**
+     * Creates a GerritHandler with the specified values.
+     *
+     * @param config                 the configuration containing the connection values.
+     * @param gerritProxy            the URL of gerrit proxy.
+     * @param watchdogTimeoutSeconds number of seconds before the connection watch dog restarts the connection set to 0
+     *                               or less to disable it.
+     * @param exceptionData          time info for when the watch dog's timeout should not be in effect. set to null to
+     *                               disable the watch dog.
+     */
+    public GerritConnection(GerritConnectionConfig config,
+                         String gerritProxy,
+                         int watchdogTimeoutSeconds,
+                         WatchTimeExceptionData exceptionData) {
+        this(config.getGerritHostName(),
+                config.getGerritSshPort(),
+                gerritProxy,
+                config.getGerritAuthentication(),
+                watchdogTimeoutSeconds, exceptionData);
+    }
+
+    /**
+     * Standard Constructor.
+     *
+     * @param gerritHostName        the hostName for gerrit.
+     * @param gerritSshPort         the ssh port that the gerrit server listens to.
+     * @param gerritProxy           the proxy url socks5|http://host:port.
+     * @param authentication        the authentication credentials.
+     */
+    public GerritConnection(String gerritHostName,
+                         int gerritSshPort,
+                         String gerritProxy,
+                         Authentication authentication) {
+        this(gerritHostName, gerritSshPort, gerritProxy, authentication, 0, null);
+    }
+
+    /**
+     * Standard Constructor.
+     *
+     * @param gerritHostName          the hostName for gerrit.
+     * @param gerritSshPort             the ssh port that the gerrit server listens to.
+     * @param gerritProxy              the proxy url socks5|http://host:port.
+     * @param authentication            the authentication credentials.
+     * @param watchdogTimeoutSeconds number of seconds before the connection watch dog restarts the connection
+     *                               set to 0 or less to disable it.
+     * @param exceptionData           time info for when the watch dog's timeout should not be in effect.
+     *                                  set to null to disable the watch dog.
+     */
+    public GerritConnection(String gerritHostName,
+                         int gerritSshPort,
+                         String gerritProxy,
+                         Authentication authentication,
+                         int watchdogTimeoutSeconds,
+                         WatchTimeExceptionData exceptionData) {
+        this.gerritHostName = gerritHostName;
+        this.gerritSshPort = gerritSshPort;
+        this.gerritProxy = gerritProxy;
+        this.authentication = authentication;
+        this.watchdogTimeoutSeconds = watchdogTimeoutSeconds;
+        this.exceptionData = exceptionData;
+    }
+
+    /**
+     * Sets gerrit handler.
+     *
+     * @param handler the handler.
+     */
+    public void setHandler(Handler handler) {
+        this.handler = handler;
+    }
+
+    /**
+     * Gets gerrit handler.
+     *
+     * @return the handler.
+     */
+    public Handler getHandler() {
+        return handler;
+    }
+
+    /**
+     * The gerrit version we are connected to.
+     *
+     * @return the gerrit version.
+     */
+    public String getGerritVersion() {
+        return gerritVersion;
+    }
+
+    /**
+     * Main loop for connecting and reading Gerrit JSON Events and dispatching them to Workers.
+     */
+    @Override
+    public void run() {
+        logger.info("Starting Up...");
+        do {
+            sshConnection = connect();
+            if (sshConnection == null) {
+                return;
+            }
+            if (watchdogTimeoutSeconds > 0 && exceptionData != null) {
+                watchdog = new StreamWatchdog(this, watchdogTimeoutSeconds, exceptionData);
+            }
+
+            BufferedReader br = null;
+            try {
+                logger.trace("Executing stream-events command.");
+                Reader reader = sshConnection.executeCommandReader(CMD_STREAM_EVENTS);
+                br = new BufferedReader(reader);
+                String line = "";
+                Provider provider = new Provider(
+                        GERRIT_NAME,
+                        gerritHostName,
+                        String.valueOf(gerritSshPort),
+                        GERRIT_PROTOCOL_NAME,
+                        DEFAULT_GERRIT_HOSTNAME,
+                        getGerritVersionString());
+                logger.info("Ready to receive data from Gerrit");
+                notifyConnectionEstablished();
+                do {
+                    logger.debug("Data-line from Gerrit: {}", line);
+                    if (line != null && line.length() > 0) {
+                        logger.trace("putting work on queue: {}", line);
+                        if (handler != null) {
+                            handler.post(line, provider);
+                        }
+                    }
+                    logger.trace("Reading next line.");
+                    line = br.readLine();
+                    if (watchdog != null) {
+                        watchdog.signal();
+                    }
+                } while (line != null);
+            } catch (IOException ex) {
+                logger.error("Stream events command error. ", ex);
+            } finally {
+                logger.trace("Connection closed, ended read loop.");
+                try {
+                    if (sshConnection.isConnected()) {
+                        sshConnection.disconnect();
+                    }
+                } catch (Exception ex) {
+                    logger.warn("Error when disconnecting sshConnection.", ex);
+                }
+                sshConnection = null;
+                if (br != null) {
+                    try {
+                        br.close();
+                    } catch (IOException ex) {
+                        logger.warn("Could not close events reader.", ex);
+                    }
+                }
+                notifyConnectionDown();
+            }
+        } while (!isShutdownInProgress());
+        handler = null;
+        logger.debug("End of GerritHandler Thread.");
+    }
+
+    /**
+     * Connects to the Gerrit server and authenticates as the specified user.
+     *
+     * @return not null if everything is well, null if connect and reconnect failed.
+     */
+    private SshConnection connect() {
+        while (!isShutdownInProgress()) {
+            SshConnection ssh = null;
+            try {
+                logger.debug("Connecting...");
+                ssh = SshConnectionFactory.getConnection(gerritHostName, gerritSshPort, gerritProxy, authentication);
+                notifyConnectionEstablished();
+                gerritVersion  = formatVersion(ssh.executeCommand("gerrit version"));
+                logger.debug("connection seems ok, returning it.");
+                return ssh;
+            } catch (SshConnectException sshConEx) {
+                logger.error("Could not connect to Gerrit server! "
+                        + "Host: {} Port: {}", gerritHostName, gerritSshPort);
+                logger.error(" Proxy: {}", gerritProxy);
+                logger.error(" User: {} KeyFile: {}", authentication.getUsername(), authentication.getPrivateKeyFile());
+                logger.error("ConnectionException: ", sshConEx);
+                notifyConnectionDown();
+            } catch (SshAuthenticationException sshAuthEx) {
+                logger.error("Could not authenticate to Gerrit server!"
+                        + "\n\tUsername: {}\n\tKeyFile: {}\n\tPassword: {}",
+                        new Object[]{authentication.getUsername(),
+                                authentication.getPrivateKeyFile(),
+                                authentication.getPrivateKeyFilePassword(), });
+                logger.error("AuthenticationException: ", sshAuthEx);
+                notifyConnectionDown();
+            } catch (IOException ex) {
+                logger.error("Could not connect to Gerrit server! "
+                        + "Host: {} Port: {}", gerritHostName, gerritSshPort);
+                logger.error(" Proxy: {}", gerritProxy);
+                logger.error(" User: {} KeyFile: {}", authentication.getUsername(), authentication.getPrivateKeyFile());
+                logger.error("IOException: ", ex);
+                notifyConnectionDown();
+            }
+
+            if (ssh != null) {
+                logger.trace("Disconnecting bad connection.");
+                try {
+                    //The ssh lib used is starting at least one thread for each connection.
+                    //The thread isn't shutdown properly when the connection goes down,
+                    //so we need to close it "manually"
+                    if (ssh.isConnected()) {
+                        ssh.disconnect();
+                    }
+                } catch (Exception ex) {
+                    logger.warn("Error when disconnecting bad connection.", ex);
+                } finally {
+                    ssh = null;
+                }
+            }
+
+            if (isShutdownInProgress()) {
+                return null;
+            }
+
+            //If we end up here, sleep for a while and then go back up in the loop.
+            logger.trace("Sleeping for a bit.");
+            try {
+                Thread.sleep(CONNECT_SLEEP);
+            } catch (InterruptedException ex) {
+                logger.warn("Got interrupted while sleeping.", ex);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Removes the "gerrit version " from the start of the response from gerrit.
+     * @param version the response from gerrit.
+     * @return the input string with "gerrit version " removed.
+     */
+    private String formatVersion(String version) {
+        if (version == null) {
+            return version;
+        }
+        String[] split = version.split(GERRIT_VERSION_PREFIX);
+        if (split.length < 2) {
+            return version.trim();
+        }
+        return split[1].trim();
+    }
+
+    /**
+     * Gets the gerrit version.
+     * @return the gerrit version as valid string.
+     */
+    private String getGerritVersionString() {
+        String version = getGerritVersion();
+        if (version == null) {
+            version = "";
+        }
+        return version;
+    }
+
+    /**
+     * The authentication credentials for ssh connection.
+     *
+     * @return the credentials.
+     */
+    public Authentication getAuthentication() {
+        return authentication;
+    }
+
+    /**
+     * The authentication credentials for ssh connection.
+     *
+     * @param authentication the credentials.
+     */
+    public void setAuthentication(Authentication authentication) {
+        this.authentication = authentication;
+    }
+
+    /**
+     * gets the hostname where Gerrit is running.
+     *
+     * @return the hostname.
+     */
+    public String getGerritHostName() {
+        return gerritHostName;
+    }
+
+    /**
+     * Sets the hostname where Gerrit is running.
+     *
+     * @param gerritHostName the hostname.
+     */
+    public void setGerritHostName(String gerritHostName) {
+        this.gerritHostName = gerritHostName;
+    }
+
+    /**
+     * Gets the port for gerrit ssh commands.
+     *
+     * @return the port nr.
+     */
+    public int getGerritSshPort() {
+        return gerritSshPort;
+    }
+
+    /**
+     * Sets the port for gerrit ssh commands.
+     *
+     * @param gerritSshPort the port nr.
+     */
+    public void setGerritSshPort(int gerritSshPort) {
+        this.gerritSshPort = gerritSshPort;
+    }
+
+    /**
+     * Gets the proxy for gerrit ssh commands.
+     *
+     * @return the proxy url.
+     */
+    public String getGerritProxy() {
+        return gerritProxy;
+    }
+
+    /**
+     * Sets the proxy for gerrit ssh commands.
+     *
+     * @param gerritProxy the port nr.
+     */
+    public void setGerritProxy(String gerritProxy) {
+        this.gerritProxy = gerritProxy;
+    }
+
+    /**
+     * Sets the shutdown flag.
+     *
+     * @param isIt true if shutdown is in progress.
+     */
+    private void setShutdownInProgress(boolean isIt) {
+        this.shutdownInProgress = isIt;
+    }
+
+    /**
+     * If the system is shutting down. I.e. the shutdown method has been called.
+     *
+     * @return true if so.
+     */
+    public boolean isShutdownInProgress() {
+        return this.shutdownInProgress;
+    }
+
+    /**
+     * If already connected.
+     * @return true if already connected.
+     */
+    public boolean isConnected() {
+        return connected;
+    }
+
+    @Override
+    public void reconnect() {
+        reconnectCallCount++;
+        if (watchdog != null) {
+            watchdog.shutdown();
+        }
+
+        if (sshConnection.isConnected()) {
+            sshConnection.disconnect();
+        }
+    }
+
+
+    /**
+     * Count how many times {@link #reconnect()} has been called since object creation.
+     *
+     * @return the count.
+     */
+    public int getReconnectCallCount() {
+        return reconnectCallCount;
+    }
+
+    /**
+     * Closes the connection.
+     */
+    public void shutdown() {
+        setShutdownInProgress(true);
+        if (watchdog != null) {
+            watchdog.shutdown();
+        }
+        if (sshConnection != null && sshConnection.isConnected()) {
+            logger.info("Shutting down the ssh connection.");
+            sshConnection.disconnect();
+        } else {
+            logger.warn("Was told to shutdown without a connection.");
+        }
+    }
+
+    /**
+     * Notifies all ConnectionListeners that the connection is down.
+     */
+    protected void notifyConnectionDown() {
+        connected = false;
+        if (handler != null) {
+            handler.handleEvent(GERRIT_CONNECTION_DOWN);
+        }
+    }
+
+    /**
+     * Notifies all ConnectionListeners that the connection is established.
+     */
+    protected void notifyConnectionEstablished() {
+        connected = true;
+        if (handler != null) {
+            handler.handleEvent(GERRIT_CONNECTION_ESTABLISHED);
+        }
+    }
+}

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritConnectionEvent.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritConnectionEvent.java
@@ -1,0 +1,39 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents;
+
+/**
+ * A type of connection events for gerrit.
+ * @author rinrinne &lt;rinrin.ne@gmail.om&gt;
+ */
+public enum GerritConnectionEvent {
+    /**
+     * Event when connection established.
+     */
+    GERRIT_CONNECTION_ESTABLISHED,
+    /**
+     * Event when connection down.
+     */
+    GERRIT_CONNECTION_DOWN
+}

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritHandler.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritHandler.java
@@ -34,41 +34,24 @@ import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.DraftPubli
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.CommentAdded;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.RefUpdated;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.Authentication;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshAuthenticationException;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshConnectException;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshConnection;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshConnectionFactory;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.watchdog.StreamWatchdog;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.Coordinator;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.EventThread;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.GerritEventWork;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.StreamEventsStringWork;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.Work;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.runners.GerritEventRunner;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.runners.StreamEventsStringRunner;
+
+import net.sf.json.JSONObject;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
 import java.io.IOException;
-import java.io.Reader;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CopyOnWriteArraySet;
-import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
-//CS IGNORE LineLength FOR NEXT 7 LINES. REASON: static import.
-import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_AUTH_KEY_FILE;
-import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_AUTH_KEY_FILE_PASSWORD;
-import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_HOSTNAME;
-import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_SSH_PORT;
-import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_PROXY;
-import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_USERNAME;
+//CS IGNORE LineLength FOR NEXT 1 LINES. REASON: static import.
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_NR_OF_RECEIVING_WORKER_THREADS;
 
 /**
@@ -76,413 +59,63 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultV
  *
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
-public class GerritHandler extends Thread implements Coordinator {
+public class GerritHandler implements Handler {
 
-    /**
-     * Time to wait between connection attempts.
-     */
-    public static final int CONNECT_SLEEP = 2000;
-    private static final String CMD_STREAM_EVENTS = "gerrit stream-events";
-    private static final String GERRIT_VERSION_PREFIX = "gerrit version ";
-    private static final String GERRIT_NAME = "gerrit";
-    private static final String GERRIT_PROTOCOL_NAME = "ssh";
-    /**
-     * The amount of milliseconds to pause when brute forcing the shutdown flag to true.
-     */
-    protected static final int PAUSE_SECOND = 1000;
-    /**
-     * How many times to try and set the shutdown flag to true. Noticed during unit tests there seems to be a timing
-     * issue or something so sometimes the {@shutdownInProgress} flag is not set properly. Setting it a number of times
-     * with some delay helped.
-     *
-     * @see #shutdown(boolean)
-     * @see #PAUSE_SECOND
-     */
-    protected static final int BRUTE_FORCE_TRIES = 10;
+    private static final int TIMEOUT_SHUTDOWN_MILLIS = 30000;
+    private static final int RETRY_SHUTDOWN_COUNT = 10;
     private static final Logger logger = LoggerFactory.getLogger(GerritHandler.class);
-    private BlockingQueue<Work> workQueue;
-    private String gerritHostName;
-    private int gerritSshPort;
-    private String gerritProxy;
-    private Authentication authentication;
+    private ExecutorService executorService;
     private int numberOfWorkerThreads;
+    private String ignoreEMail;
     private final Set<GerritEventListener> gerritEventListeners = new CopyOnWriteArraySet<GerritEventListener>();
     private final Set<ConnectionListener> connectionListeners = new CopyOnWriteArraySet<ConnectionListener>();
-    private final List<EventThread> workers;
-    private SshConnection sshConnection;
-    private boolean shutdownInProgress = false;
-    private final Object shutdownInProgressSync = new Object();
-    private boolean connecting = false;
-    private boolean connected = false;
-    private String gerritVersion = null;
-    private String ignoreEMail;
-    private int watchdogTimeoutSeconds;
-    private WatchTimeExceptionData exceptionData;
-    private StreamWatchdog watchdog;
-    private int reconnectCallCount = 0;
-
 
     /**
-     * Creates a GerritHandler with all the default values set.
+     * Creates a GerritHandler with default number of worker threads.
      *
-     * @see GerritDefaultValues#DEFAULT_GERRIT_HOSTNAME
-     * @see GerritDefaultValues#DEFAULT_GERRIT_SSH_PORT
-     * @see GerritDefaultValues#DEFAULT_GERRIT_PROXY
-     * @see GerritDefaultValues#DEFAULT_GERRIT_USERNAME
-     * @see GerritDefaultValues#DEFAULT_GERRIT_AUTH_KEY_FILE
-     * @see GerritDefaultValues#DEFAULT_GERRIT_AUTH_KEY_FILE_PASSWORD
      * @see GerritDefaultValues#DEFAULT_NR_OF_RECEIVING_WORKER_THREADS
      */
     public GerritHandler() {
-        this(DEFAULT_GERRIT_HOSTNAME,
-                DEFAULT_GERRIT_SSH_PORT,
-                DEFAULT_GERRIT_PROXY,
-                new Authentication(DEFAULT_GERRIT_AUTH_KEY_FILE,
-                        DEFAULT_GERRIT_USERNAME,
-                        DEFAULT_GERRIT_AUTH_KEY_FILE_PASSWORD),
-                DEFAULT_NR_OF_RECEIVING_WORKER_THREADS);
-    }
-
-    /**
-     * Creates a GerritHandler with the specified values and default number of worker threads.
-     *
-     * @param gerritHostName the hostName
-     * @param gerritSshPort  the ssh port that the gerrit server listens to.
-     * @param authentication the authentication credentials.
-     */
-    public GerritHandler(String gerritHostName,
-                         int gerritSshPort,
-                         Authentication authentication) {
-        this(gerritHostName,
-                gerritSshPort,
-                authentication,
-                DEFAULT_NR_OF_RECEIVING_WORKER_THREADS);
-    }
-
-    /**
-     * Standard Constructor.
-     *
-     * @param config the configuration containing the connection values.
-     */
-    public GerritHandler(GerritConnectionConfig config) {
-        this(config, DEFAULT_GERRIT_PROXY, 0, null);
-    }
-
-    /**
-     * Standard Constructor.
-     *
-     * @param config the configuration containing the connection values.
-     */
-    public GerritHandler(GerritConnectionConfig2 config) {
-        this(config, config.getGerritProxy(), config.getWatchdogTimeoutSeconds(), config.getExceptionData());
+        this(DEFAULT_NR_OF_RECEIVING_WORKER_THREADS, null);
     }
 
     /**
      * Creates a GerritHandler with the specified values.
      *
-     * @param config                 the configuration containing the connection values.
-     * @param gerritProxy            the proxy url socks5|http://host:port.
-     * @param watchdogTimeoutSeconds number of seconds before the connection watch dog restarts the connection set to 0
-     *                               or less to disable it.
-     * @param exceptionData          time info for when the watch dog's timeout should not be in effect. set to null to
-     *                               disable the watch dog.
-     */
-    public GerritHandler(GerritConnectionConfig config,
-                         String gerritProxy,
-                         int watchdogTimeoutSeconds,
-                         WatchTimeExceptionData exceptionData) {
-        this(config.getGerritHostName(),
-                config.getGerritSshPort(),
-                gerritProxy,
-                config.getGerritAuthentication(),
-                config.getNumberOfReceivingWorkerThreads(),
-                config.getGerritEMail(), watchdogTimeoutSeconds, exceptionData);
-    }
-
-    /**
-     * Standard Constructor.
-     *
-     * @param gerritHostName        the hostName for gerrit.
-     * @param gerritSshPort         the ssh port that the gerrit server listens to.
-     * @param gerritProxy           the proxy url socks5|http://host:port.
-     * @param authentication        the authentication credentials.
      * @param numberOfWorkerThreads the number of event threads.
+     * @param ignoreEMail the e-mail to ignore events from.
      */
-    public GerritHandler(String gerritHostName,
-                         int gerritSshPort,
-                         String gerritProxy,
-                         Authentication authentication,
-                         int numberOfWorkerThreads) {
-        this(gerritHostName, gerritSshPort, gerritProxy, authentication, numberOfWorkerThreads, null, 0, null);
-    }
-
-    /**
-         * Standard Constructor.
-         *
-         * @param gerritHostName        the hostName for gerrit.
-         * @param gerritSshPort         the ssh port that the gerrit server listens to.
-         * @param authentication        the authentication credentials.
-         * @param numberOfWorkerThreads the number of event threads.
-         */
-        public GerritHandler(String gerritHostName,
-                             int gerritSshPort,
-                             Authentication authentication,
-                             int numberOfWorkerThreads) {
-            this(gerritHostName, gerritSshPort, DEFAULT_GERRIT_PROXY, authentication, numberOfWorkerThreads);
-        }
-
-    /**
-     * Standard Constructor.
-     *
-     * @param gerritHostName          the hostName for gerrit.
-     * @param gerritSshPort             the ssh port that the gerrit server listens to.
-     * @param gerritProxy              the proxy url socks5|http://host:port.
-     * @param authentication            the authentication credentials.
-     * @param numberOfWorkerThreads the number of event threads.
-     * @param ignoreEMail              the e-mail to ignore events from.
-     * @param watchdogTimeoutSeconds number of seconds before the connection watch dog restarts the connection
-     *                               set to 0 or less to disable it.
-     * @param exceptionData           time info for when the watch dog's timeout should not be in effect.
-     *                                  set to null to disable the watch dog.
-     */
-    public GerritHandler(String gerritHostName,
-                         int gerritSshPort,
-                         String gerritProxy,
-                         Authentication authentication,
-                         int numberOfWorkerThreads,
-                         String ignoreEMail,
-                         int watchdogTimeoutSeconds,
-                         WatchTimeExceptionData exceptionData) {
-        super("Gerrit Events Reader");
-        this.gerritHostName = gerritHostName;
-        this.gerritSshPort = gerritSshPort;
-        this.gerritProxy = gerritProxy;
-        this.authentication = authentication;
+    public GerritHandler(int numberOfWorkerThreads, String ignoreEMail) {
         this.numberOfWorkerThreads = numberOfWorkerThreads;
         this.ignoreEMail = ignoreEMail;
-        this.watchdogTimeoutSeconds = watchdogTimeoutSeconds;
-        this.exceptionData = exceptionData;
-
-        workQueue = new LinkedBlockingQueue<Work>();
-        workers = new ArrayList<EventThread>(numberOfWorkerThreads);
-        for (int i = 0; i < numberOfWorkerThreads; i++) {
-            workers.add(new EventThread(this, "Gerrit Worker EventThread_" + i));
-        }
+        this.executorService = Executors.newFixedThreadPool(numberOfWorkerThreads);
     }
 
-    /**
-     * The gerrit version we are connected to.
-     *
-     * @return the gerrit version.
-     */
-    public String getGerritVersion() {
-        return gerritVersion;
-    }
-
-    /**
-     * Standard getter for the ignoreEMail.
-     *
-     * @return the e-mail address to ignore CommentAdded events from.
-     */
-    public String getIgnoreEMail() {
-        return ignoreEMail;
-    }
-
-    /**
-     * Standard setter for the ignoreEMail.
-     *
-     * @param ignoreEMail the e-mail address to ignore CommentAdded events from.
-     */
-    public void setIgnoreEMail(String ignoreEMail) {
-        this.ignoreEMail = ignoreEMail;
-    }
-
-    /**
-     * Main loop for connecting and reading Gerrit JSON Events and dispatching them to Workers.
-     */
     @Override
-    public void run() {
-        logger.info("Starting Up...");
-        //Start the workers
-        for (EventThread worker : workers) {
-            //TODO what if nr of workers are increased/decreased in runtime.
-            worker.start();
-        }
-        do {
-            sshConnection = connect();
-            if (sshConnection == null) {
-                //should mean unrecoverable error
-                for (EventThread worker : workers) {
-                    worker.shutdown();
-                }
-                return;
-            }
-            if (watchdogTimeoutSeconds > 0 && exceptionData != null) {
-                watchdog = new StreamWatchdog(this, watchdogTimeoutSeconds, exceptionData);
-            }
-
-            BufferedReader br = null;
-            try {
-                logger.trace("Executing stream-events command.");
-                Reader reader = sshConnection.executeCommandReader(CMD_STREAM_EVENTS);
-                br = new BufferedReader(reader);
-                String line = "";
-                Provider provider = new Provider(
-                        GERRIT_NAME,
-                        gerritHostName,
-                        String.valueOf(gerritSshPort),
-                        GERRIT_PROTOCOL_NAME,
-                        DEFAULT_GERRIT_HOSTNAME,
-                        getGerritVersionString());
-                logger.info("Ready to receive data from Gerrit");
-                notifyConnectionEstablished();
-                do {
-                    logger.debug("Data-line from Gerrit: {}", line);
-                    if (line != null && line.length() > 0) {
-                        try {
-                            StreamEventsStringWork work = new StreamEventsStringWork(
-                                    line, provider);
-                            logger.trace("putting work on queue: {}", work);
-                            workQueue.put(work);
-                        } catch (InterruptedException ex) {
-                            logger.warn("Interrupted while putting work on queue!", ex);
-                            //TODO check if shutdown
-                            //TODO try again since it is important
-                        }
-                    }
-                    logger.trace("Reading next line.");
-                    line = br.readLine();
-                    if (watchdog != null) {
-                        watchdog.signal();
-                    }
-                } while (line != null);
-            } catch (IOException ex) {
-                logger.error("Stream events command error. ", ex);
-            } finally {
-                logger.trace("Connection closed, ended read loop.");
-                try {
-                    sshConnection.disconnect();
-                } catch (Exception ex) {
-                    logger.warn("Error when disconnecting sshConnection.", ex);
-                }
-                sshConnection = null;
-                notifyConnectionDown();
-                if (br != null) {
-                    try {
-                        br.close();
-                    } catch (IOException ex) {
-                        logger.warn("Could not close events reader.", ex);
-                    }
-                }
-            }
-        } while (!isShutdownInProgress());
-
-        for (EventThread worker : workers) {
-            worker.shutdown();
-        }
-        logger.debug("End of GerritHandler Thread.");
-    }
-
-    /**
-     * Connects to the Gerrit server and authenticates as the specified user.
-     *
-     * @return not null if everything is well, null if connect and reconnect failed.
-     */
-    private SshConnection connect() {
-        connecting = true;
-        while (true) { //TODO do not go on forever.
-            if (isShutdownInProgress()) {
-                connecting = false;
-                return null;
-            }
-            SshConnection ssh = null;
-            try {
-                logger.debug("Connecting...");
-                ssh = SshConnectionFactory.getConnection(gerritHostName, gerritSshPort, gerritProxy, authentication);
-                notifyConnectionEstablished();
-                connecting = false;
-                gerritVersion  = formatVersion(ssh.executeCommand("gerrit version"));
-                logger.debug("connection seems ok, returning it.");
-                return ssh;
-            } catch (SshConnectException sshConEx) {
-                logger.error("Could not connect to Gerrit server! "
-                        + "Host: {} Port: {}", gerritHostName, gerritSshPort);
-                logger.error(" Proxy: {}", gerritProxy);
-                logger.error(" User: {} KeyFile: {}", authentication.getUsername(), authentication.getPrivateKeyFile());
-                logger.error("ConnectionException: ", sshConEx);
-                notifyConnectionDown();
-            } catch (SshAuthenticationException sshAuthEx) {
-                logger.error("Could not authenticate to Gerrit server!"
-                        + "\n\tUsername: {}\n\tKeyFile: {}\n\tPassword: {}",
-                        new Object[]{authentication.getUsername(),
-                                authentication.getPrivateKeyFile(),
-                                authentication.getPrivateKeyFilePassword(), });
-                logger.error("AuthenticationException: ", sshAuthEx);
-                notifyConnectionDown();
-            } catch (IOException ex) {
-                logger.error("Could not connect to Gerrit server! "
-                        + "Host: {} Port: {}", gerritHostName, gerritSshPort);
-                logger.error(" Proxy: {}", gerritProxy);
-                logger.error(" User: {} KeyFile: {}", authentication.getUsername(), authentication.getPrivateKeyFile());
-                logger.error("IOException: ", ex);
-                notifyConnectionDown();
-            }
-
-            if (ssh != null) {
-                logger.trace("Disconnecting bad connection.");
-                try {
-                    //The ssh lib used is starting at least one thread for each connection.
-                    //The thread isn't shutdown properly when the connection goes down,
-                    //so we need to close it "manually"
-                    ssh.disconnect();
-                } catch (Exception ex) {
-                    logger.warn("Error when disconnecting bad connection.", ex);
-                } finally {
-                    ssh = null;
-                }
-            }
-
-            if (isShutdownInProgress()) {
-                connecting = false;
-                return null;
-            }
-
-            //If we end up here, sleep for a while and then go back up in the loop.
-            logger.trace("Sleeping for a bit.");
-            try {
-                Thread.sleep(CONNECT_SLEEP);
-            } catch (InterruptedException ex) {
-                logger.warn("Got interrupted while sleeping.", ex);
-            }
+    public void post(String data) {
+        try {
+            executorService.execute(new StreamEventsStringRunner(this, data));
+        } catch (IOException ex) {
+            logger.error(ex.getMessage());
         }
     }
 
-    /**
-     * Removes the "gerrit version " from the start of the response from gerrit.
-     * @param version the response from gerrit.
-     * @return the input string with "gerrit version " removed.
-     */
-    private String formatVersion(String version) {
-        if (version == null) {
-            return version;
+    @Override
+    public void post(String data, Provider provider) {
+        try {
+            executorService.execute(new StreamEventsStringRunner(this, data, provider));
+        } catch (IOException ex) {
+            logger.error(ex.getMessage());
         }
-        String[] split = version.split(GERRIT_VERSION_PREFIX);
-        if (split.length < 2) {
-            return version.trim();
-        }
-        return split[1].trim();
     }
 
-    /**
-     * Gets the gerrit version.
-     * @return the gerrit version as valid string.
-     */
-    private String getGerritVersionString() {
-        String version = getGerritVersion();
-        if (version == null) {
-            version = "";
+    @Override
+    public void post(JSONObject json) {
+        try {
+            executorService.execute(new GerritEventRunner(this, GerritJsonEventFactory.getEvent(json)));
+        } catch (IOException ex) {
+            logger.error(ex.getMessage());
         }
-        return version;
     }
 
     /**
@@ -496,16 +129,6 @@ public class GerritHandler extends Thread implements Coordinator {
                 logger.warn("The listener was doubly-added: {}", listener);
             }
         }
-    }
-
-    /**
-     * Adds all the provided listeners to the internal list of listeners.
-     *
-     * @param listeners the listeners to add.
-     */
-    @Deprecated
-    public void addEventListeners(Map<Integer, GerritEventListener> listeners) {
-        addEventListeners(listeners.values());
     }
 
     /**
@@ -556,34 +179,18 @@ public class GerritHandler extends Thread implements Coordinator {
      * are added later than a connectionestablished/ connectiondown will get the current connection status.
      *
      * @param listener the listener to add.
-     * @return the connection status
      */
-    public boolean addListener(ConnectionListener listener) {
-        synchronized (this) {
-            connectionListeners.add(listener);
-            return connected;
-        }
+    public void addListener(ConnectionListener listener) {
+        connectionListeners.add(listener);
     }
 
-    /**
-     * Adds all ConnectionListeners.
-     *
-     * @param listeners the listener.
-     * @deprecated
-     */
-    @Deprecated
-    public void addConnectionListeners(Map<Integer, ConnectionListener> listeners) {
-        addConnectionListeners(listeners.values());
-    }
     /**
      * Add all ConnectionListeners to the list of listeners.
      *
      * @param listeners the listeners to add.
      */
     public void addConnectionListeners(Collection<? extends ConnectionListener> listeners) {
-        synchronized (this) {
-            connectionListeners.addAll(listeners);
-        }
+        connectionListeners.addAll(listeners);
     }
 
     /**
@@ -592,9 +199,7 @@ public class GerritHandler extends Thread implements Coordinator {
      * @param listener the listener to remove.
      */
     public void removeListener(ConnectionListener listener) {
-        synchronized (this) {
-            connectionListeners.remove(listener);
-        }
+        connectionListeners.remove(listener);
     }
 
     /**
@@ -603,83 +208,9 @@ public class GerritHandler extends Thread implements Coordinator {
      * @return the list of former listeners.
      */
     public Collection<ConnectionListener> removeAllConnectionListeners() {
-        synchronized (this) {
-            Set<ConnectionListener> listeners = new HashSet<ConnectionListener>(connectionListeners);
-            connectionListeners.clear();
-            return listeners;
-        }
-    }
-
-    /**
-     * The authentication credentials for ssh connection.
-     *
-     * @return the credentials.
-     */
-    public Authentication getAuthentication() {
-        return authentication;
-    }
-
-    /**
-     * The authentication credentials for ssh connection.
-     *
-     * @param authentication the credentials.
-     */
-    public void setAuthentication(Authentication authentication) {
-        this.authentication = authentication;
-    }
-
-    /**
-     * gets the hostname where Gerrit is running.
-     *
-     * @return the hostname.
-     */
-    public String getGerritHostName() {
-        return gerritHostName;
-    }
-
-    /**
-     * Sets the hostname where Gerrit is running.
-     *
-     * @param gerritHostName the hostname.
-     */
-    public void setGerritHostName(String gerritHostName) {
-        this.gerritHostName = gerritHostName;
-    }
-
-    /**
-     * Gets the port for gerrit ssh commands.
-     *
-     * @return the port nr.
-     */
-    public int getGerritSshPort() {
-        return gerritSshPort;
-    }
-
-    /**
-     * Sets the port for gerrit ssh commands.
-     *
-     * @param gerritSshPort the port nr.
-     */
-    public void setGerritSshPort(int gerritSshPort) {
-        this.gerritSshPort = gerritSshPort;
-    }
-
-    /**
-     * Gets the proxy for gerrit ssh commands.
-     *
-     * @return the proxy url.
-     */
-    public String getGerritProxy() {
-        return gerritProxy;
-    }
-
-    /**
-     * Sets the proxy for gerrit ssh commands.
-     *
-     * @param gerritProxy the port nr.
-     */
-    public void setGerritProxy(String gerritProxy) {
-        this.gerritProxy = gerritProxy;
+        Set<ConnectionListener> listeners = new HashSet<ConnectionListener>(connectionListeners);
+        connectionListeners.clear();
+        return listeners;
     }
 
     /**
@@ -697,13 +228,42 @@ public class GerritHandler extends Thread implements Coordinator {
      * @param numberOfWorkerThreads the number of threads
      */
     public void setNumberOfWorkerThreads(int numberOfWorkerThreads) {
-        this.numberOfWorkerThreads = numberOfWorkerThreads;
-        //TODO what if nr of workers are increased/decreased in runtime.
+        if (this.numberOfWorkerThreads != numberOfWorkerThreads) {
+            this.numberOfWorkerThreads = numberOfWorkerThreads;
+            updateWorkerThreads();
+        }
     }
 
-    @Override
-    public BlockingQueue<Work> getWorkQueue() {
-        return workQueue;
+    /**
+     * Updates worker threads safely.
+     */
+    public void updateWorkerThreads() {
+        ExecutorService disposedExecutorService = executorService;
+        executorService = Executors.newFixedThreadPool(numberOfWorkerThreads);
+        try {
+            boolean terminated = false;
+            while (!terminated) {
+                terminated = disposedExecutorService.awaitTermination(TIMEOUT_SHUTDOWN_MILLIS, TimeUnit.MILLISECONDS);
+            }
+        } catch (InterruptedException ex) {
+            logger.error("Interrupted while shutdown handler.", ex);
+        }
+    }
+
+    /**
+     * Gets ignore e-mail.
+     * @return the e-mail.
+     */
+    public String getIgnoreEMail() {
+        return ignoreEMail;
+    }
+
+    /**
+     * Sets ignore e-mail.
+     * @param ignoreEMail an e-mail.
+     */
+    public void setIgnoreEMail(String ignoreEMail) {
+        this.ignoreEMail = ignoreEMail;
     }
 
     /**
@@ -714,7 +274,7 @@ public class GerritHandler extends Thread implements Coordinator {
      * @param event the event.
      */
     @Override
-    public void notifyListeners(GerritEvent event) {
+    public void handleEvent(GerritEvent event) {
         //Notify lifecycle listeners.
         if (event instanceof PatchsetCreated) {
             try {
@@ -799,120 +359,20 @@ public class GerritHandler extends Thread implements Coordinator {
         return false;
     }
 
-    /**
-     * Sets the shutdown flag.
-     *
-     * @param isIt true if shutdown is in progress.
-     */
-    private void setShutdownInProgress(boolean isIt) {
-        synchronized (shutdownInProgressSync) {
-            this.shutdownInProgress = isIt;
-        }
-    }
-
-    /**
-     * If the system is shutting down. I.e. the shutdown method has been called.
-     *
-     * @return true if so.
-     */
-    public boolean isShutdownInProgress() {
-        synchronized (shutdownInProgressSync) {
-            return this.shutdownInProgress;
-        }
-    }
-
     @Override
-    public void reconnect() {
-        reconnectCallCount++;
-        if (watchdog != null) {
-            watchdog.shutdown();
-        }
-        sshConnection.disconnect();
-    }
-
-
-    /**
-     * Count how many times {@link #reconnect()} has been called since object creation.
-     *
-     * @return the count.
-     */
-    public int getReconnectCallCount() {
-        return reconnectCallCount;
-    }
-
-    /**
-     * Closes the connection.
-     *
-     * @param join if the method should wait for the thread to finish before returning.
-     */
-    public void shutdown(boolean join) {
-        if (watchdog != null) {
-            watchdog.shutdown();
-        }
-        if (sshConnection != null) {
-            logger.info("Shutting down the ssh connection.");
-            //For some reason the shutdown flag is not correctly set.
-            //So we'll try the brute force way.... and it actually works.
-            for (int i = 0; i < BRUTE_FORCE_TRIES; i++) {
-                setShutdownInProgress(true);
-                if (!isShutdownInProgress()) {
-                    try {
-                        Thread.sleep(PAUSE_SECOND);
-                    } catch (InterruptedException e) {
-                        logger.debug("Interrupted while pausing in the shutdown flag set.");
-                    }
-                } else {
+    public void handleEvent(GerritConnectionEvent event) {
+        for (ConnectionListener listener : connectionListeners) {
+            try {
+                switch(event) {
+                case GERRIT_CONNECTION_ESTABLISHED:
+                    listener.connectionEstablished();
+                    break;
+                case GERRIT_CONNECTION_DOWN:
+                    listener.connectionDown();
+                    break;
+                default:
                     break;
                 }
-            }
-            //Fail terribly if we still couldn't
-            if (!isShutdownInProgress()) {
-                throw new RuntimeException("Failed to set the shutdown flag!");
-            }
-            sshConnection.disconnect();
-            if (join) {
-                try {
-                    this.join();
-                } catch (InterruptedException ex) {
-                    logger.warn("Got interrupted while waiting for shutdown.", ex);
-                }
-            }
-        } else if (connecting) {
-            setShutdownInProgress(true);
-            if (join) {
-                try {
-                    this.join();
-                } catch (InterruptedException ex) {
-                    logger.warn("Got interrupted while waiting for shutdown.", ex);
-                }
-            }
-        } else {
-            logger.warn("Was told to shutdown without a connection.");
-        }
-    }
-
-    /**
-     * Notifies all ConnectionListeners that the connection is down.
-     */
-    protected void notifyConnectionDown() {
-        connected = false;
-        for (ConnectionListener listener : connectionListeners) {
-            try {
-                listener.connectionDown();
-            } catch (Exception ex) {
-                logger.error("ConnectionListener threw Exception. ", ex);
-            }
-        }
-    }
-
-    /**
-     * Notifies all ConnectionListeners that the connection is established.
-     */
-    protected void notifyConnectionEstablished() {
-        connected = true;
-        for (ConnectionListener listener : connectionListeners) {
-            try {
-                listener.connectionEstablished();
             } catch (Exception ex) {
                 logger.error("ConnectionListener threw Exception. ", ex);
             }
@@ -926,12 +386,35 @@ public class GerritHandler extends Thread implements Coordinator {
      * @param event the event to trigger.
      */
     public void triggerEvent(GerritEvent event) {
-        logger.debug("Internally trigger event: {}", event);
         try {
+            logger.debug("Internally trigger event: {}", event);
             logger.trace("putting work on queue.");
-            workQueue.put(new GerritEventWork(event));
-        } catch (InterruptedException ex) {
-            logger.error("Interrupted while putting work on queue!", ex);
+            executorService.execute(new GerritEventRunner(this, event));
+        } catch (IOException ex) {
+            logger.error(ex.getMessage());
         }
+    }
+
+    /**
+     * Shutdown handler.
+     * @return false if still wait termination but all listeners removed.
+     */
+    public boolean shutdown() {
+        int retrycount = RETRY_SHUTDOWN_COUNT;
+        executorService.shutdown();
+        try {
+            while (retrycount > 0) {
+                if (executorService.awaitTermination(TIMEOUT_SHUTDOWN_MILLIS, TimeUnit.MILLISECONDS)) {
+                    break;
+                }
+                retrycount--;
+            }
+        } catch (InterruptedException ex) {
+            logger.error("Interrupted while shutdown handler.", ex);
+        }
+        removeAllEventListeners();
+        removeAllConnectionListeners();
+
+        return (retrycount > 0);
     }
 }

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/Handler.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/Handler.java
@@ -1,0 +1,63 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
+
+import net.sf.json.JSONObject;
+
+/**
+ * A handler to deliver gerrit events and connection ones to listener.
+ *
+ * @author rinrinne &lt;rinrin.ne@gmail.om&gt;
+ */
+public interface Handler {
+    /**
+     * Post string data to working queue.
+     * @param data a line of text from the stream-events stream of events.
+     */
+    void post(String data);
+    /**
+     * Post string data to working queue.
+     * @param data a line of text from the stream-events stream of events.
+     * @param provider the Gerrit server info.
+     */
+    void post(String data, Provider provider);
+    /**
+     * Post json object to working queue.
+     * @param json a json object from the stream-events stream of events.
+     */
+    void post(JSONObject json);
+    /**
+     * Handle a GerritEvent.
+     * @param event the event.
+     */
+    void handleEvent(GerritEvent event);
+    /**
+     * Handle a GerritConnectionEvent.
+     * @param event the connection event.
+     */
+    void handleEvent(GerritConnectionEvent event);
+}

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/runners/GerritEventRunner.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/runners/GerritEventRunner.java
@@ -1,0 +1,97 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents.runners;
+
+import java.io.IOException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.Handler;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+
+/**
+ * Deliver arrived event to handler.
+ * @author rinrinne &lt;rinrin.ne@gmail.com&gt;
+ */
+public class GerritEventRunner implements Runnable {
+
+    private static final Logger logger = LoggerFactory.getLogger(GerritEventRunner.class);
+
+    Handler handler;
+    GerritEvent event;
+    Provider provider;
+
+    /**
+     * Default constructor.
+     *
+     * @param handler a handler.
+     * @param event an event.
+     * @throws IOException raised if handler is null.
+     */
+    public GerritEventRunner(Handler handler, GerritEvent event) throws IOException {
+        this(handler, event, null);
+    }
+
+    /**
+     * Default constructor.
+     *
+     * @param handler a handler.
+     * @param event an event.
+     * @param provider the Gerrit server info.
+     * @throws IOException raised if handler is null.
+     */
+    public GerritEventRunner(Handler handler, GerritEvent event, Provider provider) throws IOException {
+        if (handler == null) {
+            throw(new IOException("handler should not be null."));
+        }
+        this.handler = handler;
+        this.event = event;
+        this.provider = provider;
+    }
+
+    /**
+     * Sets event.
+     *
+     * @param event an event.
+     */
+    public void setEvent(GerritEvent event) {
+        this.event = event;
+    }
+
+    @Override
+    public void run() {
+        if (event != null) {
+            if (event instanceof GerritTriggeredEvent) {
+                ((GerritTriggeredEvent)event).setProvider(provider);
+            }
+            logger.debug("Event is: {}", event);
+            handler.handleEvent(event);
+        } else {
+            logger.debug("No event extracted!");
+        }
+    }
+}

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/runners/StreamEventsStringRunner.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/runners/StreamEventsStringRunner.java
@@ -1,0 +1,90 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents.runners;
+
+import java.io.IOException;
+
+import net.sf.json.JSONObject;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritJsonEventFactory;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.Handler;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
+
+/**
+ * A runner for a line of gerrit stream-events, converts the string to JSON
+ * if it is interesting and usable. Then hands GerritEvent instance over
+ * to {@link GerritEventRunner}.
+ * @author rinrinne &lt;rinrin.ne@gmail.om&gt;
+ */
+public class StreamEventsStringRunner extends GerritEventRunner {
+
+    private static final Logger logger = LoggerFactory.getLogger(StreamEventsStringRunner.class);
+    private String line;
+
+    /**
+     * Default constructor.
+     *
+     * @param handler the handler.
+     * @param line a line of text from the stream-events stream of events.
+     * @throws IOException raised if handler is null.
+     */
+    public StreamEventsStringRunner(Handler handler, String line) throws IOException {
+        this(handler, line, null);
+    }
+
+    /**
+     * Default constructor.
+     *
+     * @param handler the handler.
+     * @param line a line of text from the stream-events stream of events.
+     * @param provider the Gerrit server info.
+     * @throws IOException raised if handler is null.
+     */
+    public StreamEventsStringRunner(Handler handler, String line, Provider provider) throws IOException {
+        super(handler, null, provider);
+        this.line = line;
+    }
+
+    @Override
+    public void run() {
+        JSONObject obj = GerritJsonEventFactory.getJsonObjectIfInterestingAndUsable(line);
+        if (obj != null) {
+            setEvent(GerritJsonEventFactory.getEvent(obj));
+            super.run();
+        }
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder str = new StringBuilder("[");
+        str.append(getClass().getSimpleName());
+        str.append(": \"");
+        str.append(line);
+        str.append("\"]");
+        return str.toString();
+    }
+}

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/watchdog/StreamWatchdog.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/watchdog/StreamWatchdog.java
@@ -24,7 +24,7 @@
 
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.watchdog;
 
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.Coordinator;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.Connector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,35 +57,35 @@ public class StreamWatchdog extends TimerTask {
 
     private long lastSignal;
     private Timer timer;
-    private Coordinator coordinator;
+    private Connector connector;
     private int timeoutSeconds;
     private WatchTimeExceptionData exceptionData;
 
     /**
-     * Standard Constructor. Same as calling <code> StreamWatchdog(coordinator, timeoutSeconds, exceptionData,
+     * Standard Constructor. Same as calling <code> StreamWatchdog(connector, timeoutSeconds, exceptionData,
      * DEFAULT_CHECK_START_DELAY, DEFAULT_CHECK_PERIOD) </code>
      *
-     * @param coordinator    the coordinator who can do the actual restart of the connection.
+     * @param connector    the connector who can do the actual restart of the connection.
      * @param timeoutSeconds number of seconds before a timeout should occur.
      * @param exceptionData  time spans and days when the timeout trigger should not be in effect.
-     * @see #StreamWatchdog(Coordinator, int, WatchTimeExceptionData, long, long)
+     * @see #StreamWatchdog(Connector, int, WatchTimeExceptionData, long, long)
      */
-    public StreamWatchdog(Coordinator coordinator, int timeoutSeconds, WatchTimeExceptionData exceptionData) {
-        this(coordinator, timeoutSeconds, exceptionData, DEFAULT_CHECK_START_DELAY, DEFAULT_CHECK_PERIOD);
+    public StreamWatchdog(Connector connector, int timeoutSeconds, WatchTimeExceptionData exceptionData) {
+        this(connector, timeoutSeconds, exceptionData, DEFAULT_CHECK_START_DELAY, DEFAULT_CHECK_PERIOD);
     }
 
     /**
      * Standard Constructor.
      *
-     * @param coordinator     the coordinator who can do the actual restart of the connection.
+     * @param connector     the connector who can do the actual restart of the connection.
      * @param timeoutSeconds  number of seconds before a timeout should occur.
      * @param exceptionData   time spans and days when the timeout trigger should not be in effect.
      * @param checkStartDelay millis until the first timeout check should be performed
      * @param checkPeriod     millis between timeout checks
      */
-    public StreamWatchdog(Coordinator coordinator, int timeoutSeconds, WatchTimeExceptionData exceptionData,
+    public StreamWatchdog(Connector connector, int timeoutSeconds, WatchTimeExceptionData exceptionData,
                           long checkStartDelay, long checkPeriod) {
-        this.coordinator = coordinator;
+        this.connector = connector;
         this.timeoutSeconds = timeoutSeconds;
         this.exceptionData = exceptionData;
         lastSignal = System.currentTimeMillis();
@@ -100,7 +100,7 @@ public class StreamWatchdog extends TimerTask {
             logger.debug("Quiettime: {}", quietTime);
             if (quietTime > timeoutSeconds) {
                 logger.info("Last data from Gerrit was {} seconds ago; reconnecting.", quietTime);
-                coordinator.reconnect();
+                connector.reconnect();
             }
         }
     }
@@ -128,7 +128,9 @@ public class StreamWatchdog extends TimerTask {
      * Shuts down the watchdog timer. A new StreamWatchdog will need to be created to continue watching it.
      */
     public void shutdown() {
-        timer.cancel();
-        timer = null;
+        if (timer != null) {
+            timer.cancel();
+            timer = null;
+        }
     }
 }

--- a/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritConnectionTest.java
+++ b/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritConnectionTest.java
@@ -1,0 +1,245 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2011 Sony Ericsson Mobile Communications. All rights reserved.
+ * Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+ * Copyright 2012 rinrinne All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents;
+
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.isA;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.PipedReader;
+import java.io.PipedWriter;
+
+import net.sf.json.JSONObject;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.Authentication;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshConnection;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.SshConnectionFactory;
+
+//CS IGNORE MagicNumber FOR NEXT 200 LINES. REASON: TestData
+
+
+/**
+ * Tests for {@link GerritConnection}.
+ *
+ * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(SshConnectionFactory.class)
+public class GerritConnectionTest {
+
+    private static SshConnection sshConnectionMock;
+    private static GerritConnection connection;
+    private static BufferedWriter pipedWriter;
+    private static PipedReader pipedReader;
+    private static Thread connectionThread;
+
+    private static final String FINISH_WORD = "FINISH";
+    private static volatile boolean isFinished = false;
+    /**
+     * Creates a SshConnection mock and starts a GerritConnection with that connection-mock.
+     *
+     * @throws Exception if so.
+     */
+    @BeforeClass
+    public static void setUp() throws Exception {
+        sshConnectionMock = mock(SshConnection.class);
+        when(sshConnectionMock.isAuthenticated()).thenReturn(true);
+        when(sshConnectionMock.isConnected()).thenReturn(true);
+        PipedWriter piped = new PipedWriter();
+        pipedReader = new PipedReader(piped);
+        pipedWriter = new BufferedWriter(piped);
+        when(sshConnectionMock.executeCommand(eq("gerrit version"))).thenReturn("gerrit version 2.5.2");
+        when(sshConnectionMock.executeCommandReader(eq("gerrit stream-events"))).thenReturn(pipedReader);
+        PowerMockito.mockStatic(SshConnectionFactory.class);
+        PowerMockito.doReturn(sshConnectionMock).when(SshConnectionFactory.class, "getConnection",
+                isA(String.class), isA(Integer.class), isA(String.class), isA(Authentication.class));
+        connection = new GerritConnection("localhost", 29418, new Authentication(null, ""));
+        connection.setHandler(new HandlerMock());
+        connectionThread = new Thread(connection);
+        connectionThread.start();
+        try {
+            Thread.sleep(1000); //Lots and lots of timing issues here
+        } catch (InterruptedException e) {
+            System.out.println("Interrupted while sleeping.");
+        }
+    }
+
+    /**
+     * Shuts down the GerritConnection and the mocked connection.
+     */
+    @AfterClass
+    public static void shutDown() {
+        while (!isFinished) {
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                System.out.println("Interrupted while sleeping.");
+            }
+        }
+        if (connection != null) {
+            connection.shutdown();
+            try {
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                System.out.println("Interrupted while sleeping.");
+            }
+            if (!connection.isShutdownInProgress()) {
+                fail("Failed to set shutdown flag!");
+            }
+
+            try {
+                pipedWriter.append("hello");
+                pipedWriter.newLine();
+                pipedWriter.close();
+                connectionThread.join();
+            } catch (InterruptedException e) {
+                System.err.println("interupted while waiting for connection to shut down.");
+            } catch (IOException e) {
+                System.err.println("Could not close the pipe.");
+            }
+        }
+        connection = null;
+        connectionThread = null;
+        sshConnectionMock = null;
+        pipedReader = null;
+        pipedWriter = null;
+    }
+
+    /**
+     * Tests {@link GerritConnection#getGerritVersion()}.
+     */
+    @Test
+    public void testGetGerritVersion() {
+        assertEquals("2.5.2", connection.getGerritVersion());
+    }
+
+    /**
+     * Tests {@link GerritConnection#getGerritHostName()}.
+     */
+    @Test
+    public void testGetGerritHostName() {
+        assertEquals("localhost", connection.getGerritHostName());
+    }
+
+    /**
+     * Tests {@link GerritConnection#getAuthentication()}.
+     */
+    @Test
+    public void testGetAuthentication() {
+        assertEquals(null, connection.getAuthentication().getPrivateKeyFile());
+        assertEquals("", connection.getAuthentication().getUsername());
+        assertEquals(null, connection.getAuthentication().getPrivateKeyFilePassword());
+    }
+
+    /**
+     * Tests {@link GerritConnection#getGerritSshPort()}.
+     */
+    @Test
+    public void testGetGerritSshPort() {
+        assertEquals(29418, connection.getGerritSshPort());
+    }
+
+    /**
+     * Tests {@link GerritConnection#getGerritProxy()}.
+     */
+    @Test
+    public void testGetGerritProxy() {
+        assertEquals("", connection.getGerritProxy());
+    }
+
+    /**
+     * Tests stream event receiver for {@link GerritConnection}.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testReceiveEvent() throws Exception {
+        // String
+        pipedWriter.append("Test");
+        pipedWriter.newLine();
+        pipedWriter.flush();
+        // JSON String
+        pipedWriter.append("{\"say\":\"hello\"}");
+        pipedWriter.newLine();
+        pipedWriter.flush();
+        // Send finish
+        pipedWriter.append(FINISH_WORD);
+        pipedWriter.newLine();
+        pipedWriter.flush();
+    }
+
+    /**
+     * A Handler mock
+     */
+    static class HandlerMock implements Handler {
+
+        @Override
+        public void post(String data) {
+            post(data, null);
+        }
+
+        @Override
+        public void post(String data, Provider provider) {
+            System.out.println("INFO: Posted string: " + data);
+            if (provider != null) {
+                System.out.println("INFO: Posted " + provider);
+            }
+            if (data.equals(FINISH_WORD)) {
+                isFinished = true;
+            }
+        }
+
+        @Override
+        public void post(JSONObject json) {
+            System.out.println("INFO: Posted JSONObject: " + json.toString());
+        }
+
+        @Override
+        public void handleEvent(GerritEvent event) {
+            System.out.println("INFO: Handled gerrit event type: " + event.getEventType());
+        }
+
+        @Override
+        public void handleEvent(GerritConnectionEvent event) {
+            System.out.println("INFO: Handled connection event: " + event.name());
+        }
+    }
+}

--- a/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/runners/GerritEventRunnerTest.java
+++ b/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/runners/GerritEventRunnerTest.java
@@ -1,0 +1,143 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 rinrinne All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents.runners;
+
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.BRANCH;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.EMAIL;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.ID;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.NAME;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.NUMBER;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.OWNER;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.PROJECT;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.REF;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.REVISION;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.SUBJECT;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.URL;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.json.JSONObject;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritConnectionEvent;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.Handler;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.ManualPatchsetCreated;
+
+//CS IGNORE MagicNumber FOR NEXT 400 LINES. REASON: Test data.
+
+/**
+ * Tests for {@link com.sonyericsson.hudson.plugins.gerrit.gerritevents.runner.GerritEventRunner}.
+ * @author rinrinne &lt;rinrin.ne@gmail.com&gt;
+ */
+public class GerritEventRunnerTest {
+
+    private Handler handler;
+    private final List<GerritEvent> handledEvent = new ArrayList<GerritEvent>();
+
+    /**
+     * Setup before each tests.
+     * @throws Exception if so.
+     */
+    @Before
+    public void setUp() throws Exception {
+        handler = new Handler() {
+
+            @Override
+            public void post(JSONObject json) {
+            }
+
+            @Override
+            public void post(String data) {
+            }
+
+            @Override
+            public void post(String data, Provider provider) {
+            }
+
+            @Override
+            public void handleEvent(GerritConnectionEvent event) {
+            }
+
+            @Override
+            public void handleEvent(GerritEvent event) {
+                handledEvent.add(event);
+            }
+        };
+    }
+
+    /**
+     * Cleanup after each tests.
+     * @throws Exception if so.
+     */
+    @After
+    public void tearDown() throws Exception {
+        handledEvent.clear();
+        handler = null;
+    }
+
+    /**
+     * Tests {@link com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.GerritEventRunner}.
+     * With a standard scenario.
+     */
+    @Test
+    public void test() {
+        JSONObject patch = new JSONObject();
+        patch.put(NUMBER, "2");
+        patch.put(REVISION, "ad123456789");
+        patch.put(REF, "refs/changes/00/100/2");
+
+        JSONObject jsonAccount = new JSONObject();
+        jsonAccount.put(EMAIL, "robert.sandell@sonyericsson.com");
+        jsonAccount.put(NAME, "Bobby");
+
+        JSONObject change = new JSONObject();
+        change.put(PROJECT, "project");
+        change.put(BRANCH, "branch");
+        change.put(ID, "I2343434344");
+        change.put(NUMBER, "100");
+        change.put(SUBJECT, "subject");
+        change.put(OWNER, jsonAccount);
+        change.put(URL, "http://localhost:8080");
+
+        ManualPatchsetCreated event = new ManualPatchsetCreated(change, patch, "bobby");
+
+        try {
+            GerritEventRunner runner = new GerritEventRunner(handler, event);
+            runner.run();
+            assertSame(event, handledEvent.get(0));
+        } catch (IOException ex) {
+            fail("IOException!!");
+        }
+    }
+
+}

--- a/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/runners/StreamEventsStringRunnerTest.java
+++ b/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/runners/StreamEventsStringRunnerTest.java
@@ -1,0 +1,153 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2013 rinrinne All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents.runners;
+
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.BRANCH;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.CHANGE;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.EMAIL;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.ID;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.NAME;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.NUMBER;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.OWNER;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.PATCH_SET;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.PROJECT;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.REF;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.REVISION;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.SUBJECT;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.URL;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import net.sf.json.JSONObject;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritConnectionEvent;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.Handler;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.PatchsetCreated;
+
+//CS IGNORE MagicNumber FOR NEXT 400 LINES. REASON: Test data.
+
+/**
+ * Tests for {@link com.sonyericsson.hudson.plugins.gerrit.gerritevents.runner.StreamEventsStringRunner}.
+ * @author rinrinne &lt;rinrin.ne@gmail.com&gt;
+ */
+public class StreamEventsStringRunnerTest {
+
+    private Handler handler;
+    private final List<GerritEvent> handledEvent = new ArrayList<GerritEvent>();
+
+    /**
+     * Setup before each tests.
+     * @throws Exception if so.
+     */
+    @Before
+    public void setUp() throws Exception {
+       handler = new Handler() {
+
+            @Override
+            public void post(JSONObject json) {
+            }
+
+            @Override
+            public void post(String data) {
+            }
+
+            @Override
+            public void post(String data, Provider provider) {
+            }
+
+            @Override
+            public void handleEvent(GerritConnectionEvent event) {
+            }
+
+            @Override
+            public void handleEvent(GerritEvent event) {
+                handledEvent.add(event);
+            }
+        };
+    }
+
+    /**
+     * Cleanup after each tests.
+     * @throws Exception if so.
+     */
+    @After
+    public void tearDown() throws Exception {
+        handledEvent.clear();
+        handler = null;
+    }
+
+    /**
+     * Tests {@link com.sonyericsson.hudson.plugins.gerrit.gerritevents.workers.GerritEventRunner}.
+     * With a standard scenario.
+     */
+    @Test
+    public void test() {
+        JSONObject patch = new JSONObject();
+        patch.put(NUMBER, "2");
+        patch.put(REVISION, "ad123456789");
+        patch.put(REF, "refs/changes/00/100/2");
+
+        JSONObject jsonAccount = new JSONObject();
+        jsonAccount.put(EMAIL, "robert.sandell@sonyericsson.com");
+        jsonAccount.put(NAME, "Bobby");
+
+        JSONObject change = new JSONObject();
+        change.put(PROJECT, "project");
+        change.put(BRANCH, "branch");
+        change.put(ID, "I2343434344");
+        change.put(NUMBER, "100");
+        change.put(SUBJECT, "subject");
+        change.put(OWNER, jsonAccount);
+        change.put(URL, "http://localhost:8080");
+
+        JSONObject jsonEvent = new JSONObject();
+        jsonEvent.put("type", GerritEventType.PATCHSET_CREATED.getTypeValue());
+        jsonEvent.put(CHANGE, change);
+        jsonEvent.put(PATCH_SET, patch);
+
+        try {
+            StreamEventsStringRunner runner = new StreamEventsStringRunner(handler, jsonEvent.toString());
+            runner.run();
+            assertFalse(handledEvent.isEmpty());
+            PatchsetCreated event = (PatchsetCreated)handledEvent.get(0);
+            assertEquals("project", event.getChange().getProject());
+            assertEquals("100", event.getChange().getNumber());
+            assertEquals("2", event.getPatchSet().getNumber());
+        } catch (IOException ex) {
+            fail("IOException!!");
+        }
+    }
+}

--- a/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/watchdog/StreamWatchdogTest.java
+++ b/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/watchdog/StreamWatchdogTest.java
@@ -25,6 +25,7 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.watchdog;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ConnectionListener;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritConnection;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritHandler;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.ssh.Authentication;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.test.SshdServerMock;
@@ -68,12 +69,15 @@ public class StreamWatchdogTest {
         server.returnCommandFor(GERRIT_STREAM_EVENTS, WaitLongTimeCommand.class, true,
                 new Object[]{MINUTES.toMillis(5)}, new Class<?>[]{Long.class});
         server.returnCommandFor(GERRIT_STREAM_EVENTS, SshdServerMock.CommandMock.class);
-        GerritHandler handler = new GerritHandler("localhost", SshdServerMock.GERRIT_SSH_PORT, "",
-                new Authentication(sshKey, "jenkins"), 1, "jenkins@localhost", 20,
+        GerritConnection connection = new GerritConnection("localhost", SshdServerMock.GERRIT_SSH_PORT, "",
+                new Authentication(sshKey, "jenkins"), 20,
                 new WatchTimeExceptionData(new int[0], Collections.<WatchTimeExceptionData.TimeSpan>emptyList()));
+        GerritHandler handler = new GerritHandler();
         Listen connectionListener = new Listen();
         handler.addListener(connectionListener);
-        handler.start();
+        connection.setHandler(handler);
+        Thread connectionThread = new Thread(connection);
+        connectionThread.start();
         server.waitForCommand(GERRIT_STREAM_EVENTS, 8000);
         Thread.sleep(2000);
         assertTrue(connectionListener.isConnectionEstablished());
@@ -82,9 +86,11 @@ public class StreamWatchdogTest {
         server.waitForCommand(GERRIT_STREAM_EVENTS, 8000);
         Thread.sleep(1000);
         assertTrue(connectionListener.isConnectionEstablished());
-        assertEquals(1, handler.getReconnectCallCount());
+        assertEquals(1, connection.getReconnectCallCount());
+        System.out.println("====Shutting down GerritConnection=====");
+        connection.shutdown();
         System.out.println("====Shutting down GerritHandler=====");
-        handler.shutdown(true);
+        handler.shutdown();
         System.out.println("====Shutting down SSHD=====");
         sshd.stop(true);
         System.out.println("====Done=====");


### PR DESCRIPTION
Now GerritHandler handles gerrit event and gerrit connection.
Even if you want to use event handle feature only, actual connection
is always needed.
To decrease network dependency, This patch isolates connection
features from GerritHandler.
