### PR TITLE
Add new attribute

### DIFF
--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/GerritEventKeys.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/GerritEventKeys.java
@@ -155,7 +155,14 @@ public abstract class GerritEventKeys {
      * version.
      */
     public static final String VERSION = "version";
-
+    /**
+     * misc.
+     */
+    public static final String MISC = "misc";
+    /**
+     * event id.
+     */
+    public static final String EVENT_ID = "event_id";
     /**
      * Empty default constructor to hinder instantiation.
      */

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/attr/Misc.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/attr/Misc.java
@@ -1,0 +1,92 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 rinrinne. All rights reserved.
+ *  Copyright 2013 Sony Mobile Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr;
+
+import net.sf.json.JSONObject;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritJsonEventFactory.getString;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.EVENT_ID;
+
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonDTO;
+
+/**
+ * Represents a Gerrit JSON Provider DTO.
+ * An Misc that is related to an event or attribute.
+ * Used for additional information.
+ *
+ * @author rinrinne &lt;rinrin.ne@gmail.com&gt;
+ */
+public class Misc implements GerritJsonDTO {
+
+    /**
+     * The event id.
+     * Suppose SHA-256 hash from a line of stream-events.
+     */
+    private String eventId;
+
+    /**
+     * Default constructor.
+     */
+    public Misc() {
+    }
+
+    /**
+     * Constructor that fills with data directly.
+     *
+     * @param json the JSON Object with data.
+     * @see #fromJson(net.sf.json.JSONObject)
+     */
+    public Misc(JSONObject json) {
+        fromJson(json);
+    }
+
+    /**
+     * For easier testing.
+     * @param eventId the event id.
+     */
+    public Misc(String eventId) {
+        this.eventId = eventId;
+    }
+
+    @Override
+    public void fromJson(JSONObject json) {
+        eventId = getString(json, EVENT_ID);
+    }
+
+    /**
+     * Get event id.
+     * @return the event id.
+     */
+    public String getEventId() {
+        return eventId;
+    }
+
+    /**
+     * Set event id.
+     * @param eventId the event id.
+     */
+    public void setEventId(String eventId) {
+        this.eventId = eventId;
+    }
+}

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/GerritTriggeredEvent.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/GerritTriggeredEvent.java
@@ -25,11 +25,13 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.PROVIDER;
+import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.MISC;
 import net.sf.json.JSONObject;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Misc;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.lifecycle.GerritEventLifecycle;
 
@@ -53,6 +55,10 @@ public abstract class GerritTriggeredEvent extends GerritEventLifecycle implemen
      */
     protected Provider provider;
 
+    /**
+     * The misc that provide the event.
+     */
+    protected Misc misc;
 
     /**
      * The account that triggered the event.
@@ -90,10 +96,31 @@ public abstract class GerritTriggeredEvent extends GerritEventLifecycle implemen
         this.provider = provider;
     }
 
+    /**
+     * The misc that provide the event.
+     *
+     * @return the misc.
+     */
+    public Misc getMisc() {
+        return misc;
+    }
+
+    /**
+     * The misc that provide the event.
+     *
+     * @param misc the misc.
+     */
+    public void setMisc(Misc misc) {
+        this.misc = misc;
+    }
+
     @Override
     public void fromJson(JSONObject json) {
         if (json.containsKey(PROVIDER)) {
             provider = new Provider(json.getJSONObject(PROVIDER));
+        }
+        if (json.containsKey(MISC)) {
+            misc = new Misc(json.getJSONObject(MISC));
         }
     }
 }


### PR DESCRIPTION
New attribute is added by this patch.
This has mainly external information related event.

Now added event_id into this. Supposed value is SHA-256 hash created
from arrived line via stream-events. The same one can be generated
if stream-events can be received. So this id could enable to share
information with external services.

Note that class and key name "Misc" is tentative.
I could not give a good name to general purpose feature like this...

So please let me know if you have a good name.
