### PR TITLE
builds: removes future jobs when one of the jobs fail

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
@@ -117,6 +117,10 @@ public class ToGerritRunListener extends RunListener<AbstractBuild> {
                         logger.warn("InterruptedException while obtaining failure message for build: "
                                 + r.getDisplayName(), e);
                     }
+                    // Purge future jobs when one job fails. This improves throughput when
+                    // triggering multiple jobs where one job has lower throughput than
+                    // the others. The first failing job will purge other queued jobs.
+                    GerritTrigger.getTrigger(r.getProject()).notifyBuildEnded(event);
                 }
 
                 updateTriggerContexts(r);


### PR DESCRIPTION
improves throughput by purging future jobs when the first job fails.

This  pull request is a shot in the dark, I don't know this code at all...
