### PR TITLE
Allow to send messages to Gerrit not in the same message as the build result

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/GerritMessageProvider.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/GerritMessageProvider.java
@@ -69,4 +69,13 @@ public abstract class GerritMessageProvider implements Serializable, ExtensionPo
     public static List<GerritMessageProvider> all() {
         return Hudson.getInstance().getExtensionList(GerritMessageProvider.class);
     }
+
+    /**
+     * Method allowing plug-ins to send the message separately on build complete.
+     *
+     * @return whether the message is sent separately or not
+     */
+    public boolean isSeparateMessageBuildCompleted() {
+        return false;
+    }
 }

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/GerritNotifier.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/GerritNotifier.java
@@ -121,6 +121,23 @@ public class GerritNotifier {
                     logger.error("Something wrong during parameter extraction. "
                             + "Gerrit will not be notified of BuildCompleted");
                 }
+
+                Iterable<String> separateCommands =
+                        parameterExpander.getSeparateBuildCompletedCommands(memoryImprint, listener);
+                for (String separateCommand : separateCommands) {
+                    if (separateCommand != null) {
+                        if (!separateCommand.isEmpty()) {
+                            logger.info("Notifying BuildCompleted to gerrit: {}", separateCommand);
+                            cmdRunner.sendCommand(separateCommand);
+                        } else {
+                            logger.info(
+                                    "BuildCompleted command is empty.  Gerrit will not be notified of BuildCompleted");
+                        }
+                    } else {
+                        logger.error("Something wrong during parameter extraction. "
+                                + "Gerrit will not be notified of BuildCompleted");
+                    }
+                }
             }
         } catch (Exception ex) {
             logger.error("Could not complete BuildCompleted notification!", ex);


### PR DESCRIPTION
This allows to contribute tests that will contain useful informations
in the first line, making it visible without having to expand the message in Gerrit.
