### PR TITLE
GerritTrigger.equals/hashCode -- don't use AbstractProject

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -626,7 +626,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
         if (myProject == null) {
             return super.hashCode();
         } else {
-            return myProject.hashCode();
+            return myProject.getFullName().hashCode();
         }
     }
 
@@ -634,7 +634,11 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
     public boolean equals(Object obj) {
         if (obj instanceof GerritTrigger) {
             GerritTrigger that = (GerritTrigger)obj;
-            return this.myProject == that.myProject;
+            if (myProject == null || that.myProject == null) {
+                return super.equals(obj);
+            } else {
+                return myProject.getFullName().equals(that.myProject.getFullName());
+            }
         }
         return false;
     }


### PR DESCRIPTION
AbstractProjects are very temporary and shouldn't be used for comparison.
Instead, AbstractProject.getFullName() should be used.

JENKINS-10709: multiple builds are triggered for one change in Gerrit

This is an attempt to do _something_ for bug
[JENKINS-10709](https://issues.jenkins-ci.org/browse/JENKINS-10709).
It's based on the comments of @jglick on [jenkinsci-dev mailing list](https://groups.google.com/forum/#!topic/jenkinsci-dev/CwbsCJAzcOY).

I'm not really a Java programmer, so I didn't fully remove the `myProject` variable (which
stores an `AbstractProject`).  I also didn't know how to fetch an `AbstractProject` from
Jenkins given only a `fullName`.
