### PR TITLE
Fix file path not showing up on UI problem.

### DIFF
--- a/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -1,7 +1,7 @@
  <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <!--<j:set var="descriptor" value="${it.descriptor}" />-->
     <j:set var="types" value="${descriptor.getCompareTypes()}"/>
-    <j:set var="fileTriggerEnabled" value="${it.isFileTriggerEnabled()}"/>
+    <j:set var="fileTriggerEnabled" value="${instance.isFileTriggerEnabled()}"/>
     <j:invokeStatic var="trigger" method="getTrigger" className="com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger">
         <j:arg type="hudson.model.AbstractProject" value="${it}" />
     </j:invokeStatic>


### PR DESCRIPTION
Make jelly file call the method in Describable instead of Descriptor (which no longer exists).

Change-Id: I6567b590b47f68b48740d97f8377a2898e19288f
