### PR TITLE
Upgrade Jsch library to version 0.1.50.

### DIFF
--- a/gerrit-events/pom.xml
+++ b/gerrit-events/pom.xml
@@ -80,7 +80,7 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jsch</artifactId>
-            <version>0.1.49</version>
+            <version>0.1.50</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Upgrade to version 0.1.50 to fix JSchException: verify: false that
from time to time.

Updating this library is not enough to really fix this issue: since Gerrit-trigger depends on git-client(optional) which also include an older version of jsch (0.1.46 at the time of writing this), gerrit-trigger will end up using the jsch library from git-client if installed (Jenkins load libraries for core first, next from dependencies if any and then from the plugin lib folder last). Until a new version of git-client that uses a new version of jgit that use jsch 0.1.50 is available, you need to put jsch version 0.1.50 in the ${JENKINS_HOME}/war/WEB-INF/lib folder.
