### PR TITLE
Rework GerritEventListener interface, only keep method with GerritEvent

### DIFF
--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritEventListener.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritEventListener.java
@@ -25,20 +25,18 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.ChangeAbandoned;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.ChangeMerged;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.ChangeRestored;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.CommentAdded;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.DraftPublished;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.PatchsetCreated;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.RefUpdated;
 
 /**
  * Base Listener interface for those that are interested in Gerrit events.
- *
+ * <p>
+ * The event firering mechanism is using some reflection magic to try and find the best suitable method
+ * to call the listener on. So for example if the listener class is implementing a method with the signature
+ * {@code public void gerritEvent(com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.PatchsetCreated event) }
+ * that method will be called directly for every PatchsetAdded event.
+ * <p>
  * The method {@link #gerritEvent(com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent) }
  * is a fallback method if no other suitable method could be found.
- *
+ * <p>
  * The events are fired on one of the event worker threads so any listener needs to handle that two or more events
  * theoretically could be fired at the same time.
  *
@@ -50,46 +48,4 @@ public interface GerritEventListener {
      * @param event the event
      */
     void gerritEvent(GerritEvent event);
-
-    /**
-     * Called when a Patchset created event has arrived.
-     * @param event the event.
-     */
-    void gerritEvent(PatchsetCreated event);
-
-    /**
-     * Called when a draft published event has arrived.
-     * @param event the event.
-     */
-    void gerritEvent(DraftPublished event);
-
-    /**
-     * Called when a change abandoned event has arrived.
-     * @param event the event.
-     */
-    void gerritEvent(ChangeAbandoned event);
-
-    /**
-     * Called when a change merged event has arrived.
-     * @param event the event.
-     */
-    void gerritEvent(ChangeMerged event);
-
-    /**
-     * Called when a change restored event has arrived.
-     * @param event the event.
-     */
-    void gerritEvent(ChangeRestored event);
-
-    /**
-     * Called when a comment added event has arrived.
-     * @param event the event.
-     */
-    void gerritEvent(CommentAdded event);
-
-    /**
-     * Called when a ref updated event has arrived.
-     * @param event the event.
-     */
-    void gerritEvent(RefUpdated event);
 }

--- a/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritHandlerTest.java
+++ b/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/GerritHandlerTest.java
@@ -50,12 +50,15 @@ import java.util.concurrent.TimeUnit;
 
 import static org.hamcrest.collection.IsIn.isIn;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
 
-//CS IGNORE MagicNumber FOR NEXT 400 LINES. REASON: Test data.
+//CS IGNORE MagicNumber FOR NEXT 600 LINES. REASON: Test data.
 
 /**
  * Tests for {@link GerritHandler}.
@@ -321,43 +324,211 @@ public class GerritHandlerTest {
         }
 
         @Override
-        public void gerritEvent(PatchsetCreated event) {
-
-        }
-
-        @Override
-        public void gerritEvent(DraftPublished event) {
-
-        }
-
-        @Override
-        public void gerritEvent(ChangeAbandoned event) {
-
-        }
-
-        @Override
-        public void gerritEvent(ChangeMerged event) {
-
-        }
-
-        @Override
-        public void gerritEvent(ChangeRestored event) {
-
-        }
-
-        @Override
-        public void gerritEvent(CommentAdded event) {
-
-        }
-
-        @Override
-        public void gerritEvent(RefUpdated event) {
-
-        }
-
-        @Override
         public int hashCode() {
             return code;
         }
     }
+
+    /**
+     * Tests that event notification using the default method.
+     */
+    @Test
+    public void testEventNotificationWithDefaultListenerImplemention() {
+        GerritEventListener listenerMock = mock(GerritEventListener.class);
+        handler.addListener(listenerMock);
+
+        ChangeAbandoned changeAbandoned = new ChangeAbandoned();
+        handler.notifyListeners(changeAbandoned);
+        verify(listenerMock, times(1)).gerritEvent(changeAbandoned);
+
+        ChangeMerged changeMerged = new ChangeMerged();
+        handler.notifyListeners(changeMerged);
+        verify(listenerMock, times(1)).gerritEvent(changeMerged);
+
+        ChangeRestored changeRestored = new ChangeRestored();
+        handler.notifyListeners(changeRestored);
+        verify(listenerMock, times(1)).gerritEvent(changeRestored);
+
+        CommentAdded commentAdded = new CommentAdded();
+        handler.notifyListeners(commentAdded);
+        verify(listenerMock, times(1)).gerritEvent(commentAdded);
+
+        DraftPublished draftPublished = new DraftPublished();
+        handler.notifyListeners(draftPublished);
+        verify(listenerMock, times(1)).gerritEvent(draftPublished);
+
+        PatchsetCreated patchsetCreated = new PatchsetCreated();
+        handler.notifyListeners(patchsetCreated);
+        verify(listenerMock, times(1)).gerritEvent(patchsetCreated);
+
+        RefUpdated refUpdated = new RefUpdated();
+        handler.notifyListeners(refUpdated);
+        verify(listenerMock, times(1)).gerritEvent(refUpdated);
+    }
+
+    /**
+     * Tests that ChangeAbandoned event are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerChangeAbandonedMethodSignature() {
+        SpecificEventListener changeAbandonedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(ChangeAbandoned event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(changeAbandonedListener, new ChangeAbandoned());
+    }
+
+    /**
+     * Tests that ChangeMerged event are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerChangeMergedMethodSignature() {
+        SpecificEventListener changeMergedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(ChangeMerged event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(changeMergedListener, new ChangeMerged());
+    }
+
+    /**
+     * Tests that ChangeRestored event are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerChangeRestoredMethodSignature() {
+        SpecificEventListener changeRestoredListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(ChangeRestored event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(changeRestoredListener, new ChangeRestored());
+    }
+
+    /**
+     * Tests that CommentAdded event are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerCommentAddedMethodSignature() {
+        SpecificEventListener commentAddedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(CommentAdded event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(commentAddedListener, new CommentAdded());
+    }
+
+    /**
+     * Tests that DraftPublished event are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerDraftPublishedMethodSignature() {
+        SpecificEventListener draftPublishedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(DraftPublished event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(draftPublishedListener, new DraftPublished());
+    }
+
+    /**
+     * Tests that PatchsetCreated event are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerPatchsetCreatedMethodSignature() {
+        SpecificEventListener patchsetCreatedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(PatchsetCreated event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(patchsetCreatedListener, new PatchsetCreated());
+    }
+
+    /**
+     * Tests that RefUpdated event are going in the method with
+     * that type as parameter and that other type of events are going
+     * in the default method.
+     */
+    @Test
+    public void testEventNotificationWithListenerRefUpdatedMethodSignature() {
+        SpecificEventListener refUpdatedListener = new SpecificEventListener() {
+            @SuppressWarnings("unused") //method is called by reflection
+            public void gerritEvent(RefUpdated event) {
+                specificMethodCalled = true;
+            }
+        };
+        testListenerWithSpecificSignature(refUpdatedListener, new RefUpdated());
+    }
+
+    /**
+     * Base test listener implementation.
+     */
+    private abstract static class SpecificEventListener implements GerritEventListener {
+        boolean defautMethodCalled = false;
+        boolean specificMethodCalled = false;
+        @Override
+        public void gerritEvent(GerritEvent event) {
+            defautMethodCalled = true;
+        }
+        /**
+         * Reset the listener.
+         */
+        public void reset() {
+            defautMethodCalled = false;
+            specificMethodCalled = false;
+        }
+    }
+
+    /**
+     * Test that the specific method of a listener is called for the specific
+     * type and that any the default method of the listener is called for any
+     * other type of events.
+     * @param listener the specific listener
+     * @param specificEvent the specific event
+     */
+    private void testListenerWithSpecificSignature(SpecificEventListener listener, GerritEvent specificEvent) {
+        GerritEvent[] allEvents =  new GerritEvent[]{new ChangeAbandoned(),
+                                                     new ChangeMerged(),
+                                                     new ChangeRestored(),
+                                                     new ChangeAbandoned(),
+                                                     new DraftPublished(),
+                                                     new PatchsetCreated(),
+                                                     new RefUpdated(), };
+        handler.addListener(listener);
+
+        // Validate that event was sent to the specific method
+        handler.notifyListeners(specificEvent);
+        assertFalse(listener.defautMethodCalled);
+        assertTrue(listener.specificMethodCalled);
+        listener.reset();
+
+        // Validate that other events are going in the default method
+        for (GerritEvent gerritEvent : allEvents) {
+            if (gerritEvent.getEventType() != specificEvent.getEventType()) {
+                handler.notifyListeners(gerritEvent);
+                assertTrue(listener.defautMethodCalled);
+                assertFalse(listener.specificMethodCalled);
+                listener.reset();
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
Having one method per type of event is a problem because every time we want
to add a new type, we will break backward compatibility. Brought back
reflection removed a long time ago to allow GerritEventListener implementors
to define method taking a specific type as argument and this method will
be called instead when an event of the specific type is received.

Also clean up duplicated code related to event processing in GerritTrigger.
