### PR TITLE
Remove duplicated implements GerritJsonEvent

### DIFF
--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/ChangeAbandoned.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/ChangeAbandoned.java
@@ -26,7 +26,6 @@ package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.ABANDONER;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 import net.sf.json.JSONObject;
 
@@ -34,7 +33,7 @@ import net.sf.json.JSONObject;
  * A DTO representation of the change-abandoned Gerrit Event.
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
-public class ChangeAbandoned extends ChangeBasedEvent implements GerritJsonEvent {
+public class ChangeAbandoned extends ChangeBasedEvent {
 
     /**
      * The person who triggered this event.

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/ChangeMerged.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/ChangeMerged.java
@@ -25,7 +25,6 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 
 import net.sf.json.JSONObject;
@@ -37,7 +36,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  *
  * @author David Pursehouse &lt;david.pursehouse@sonyericsson.com&gt;
  */
-public class ChangeMerged extends ChangeBasedEvent implements GerritJsonEvent {
+public class ChangeMerged extends ChangeBasedEvent {
 
     /**
      * Default constructor.

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/ChangeRestored.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/ChangeRestored.java
@@ -25,14 +25,13 @@ package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.RESTORER;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 import net.sf.json.JSONObject;
 
 /**
  * A DTO representation of the change-restored Gerrit Event.
  */
-public class ChangeRestored extends ChangeBasedEvent implements GerritJsonEvent {
+public class ChangeRestored extends ChangeBasedEvent {
 
     /**
      * The person who triggered this event.

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/CommentAdded.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/CommentAdded.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Approval;
 import net.sf.json.JSONObject;
@@ -40,7 +39,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  * A DTO representation of the comment-added Gerrit Event.
  * @author James E. Blair &lt;jeblair@hp.com&gt;
  */
-public class CommentAdded extends ChangeBasedEvent implements GerritJsonEvent {
+public class CommentAdded extends ChangeBasedEvent {
     private List<Approval> approvals = new ArrayList<Approval>();
 
     @Override

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/DraftPublished.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/DraftPublished.java
@@ -24,7 +24,6 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 import net.sf.json.JSONObject;
 
@@ -35,7 +34,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  *
  * @author David Pursehouse &lt;david.pursehouse@sonymobile.com&gt;
  */
-public class DraftPublished extends ChangeBasedEvent implements GerritJsonEvent {
+public class DraftPublished extends ChangeBasedEvent {
 
     /* Uploader has been replaced by GerritTriggeredEvent.account.
      * This allows old builds to deserialize without warnings. */

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/GerritTriggeredEvent.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/GerritTriggeredEvent.java
@@ -27,7 +27,6 @@ package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.PROVIDER;
 import net.sf.json.JSONObject;
 
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
@@ -38,7 +37,7 @@ import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Provider;
  *
  * @author David Pursehouse &lt;david.pursehouse@sonyericsson.com&gt;
  */
-public abstract class GerritTriggeredEvent implements GerritEvent, GerritJsonEvent {
+public abstract class GerritTriggeredEvent implements GerritJsonEvent {
 
 
 

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/PatchsetCreated.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/PatchsetCreated.java
@@ -25,7 +25,6 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 import net.sf.json.JSONObject;
 
@@ -36,7 +35,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  *
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
-public class PatchsetCreated extends ChangeBasedEvent implements GerritJsonEvent {
+public class PatchsetCreated extends ChangeBasedEvent {
 
     /* Uploader has been replaced by GerritTriggeredEvent.account.
      * This allows old builds to deserialize without warnings. */

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/RefUpdated.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/RefUpdated.java
@@ -24,7 +24,6 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
-import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritJsonEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.RefUpdate;
 import net.sf.json.JSONObject;
@@ -36,7 +35,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  * A DTO representation of the ref-updated Gerrit Event.
  * @author jeblair
  */
-public class RefUpdated extends GerritTriggeredEvent implements GerritJsonEvent {
+public class RefUpdated extends GerritTriggeredEvent {
 
     /**
      * The Gerrit ref update the event is related to.


### PR DESCRIPTION
All events extends GerritTriggeredEvent which implements GerritJsonEvent,
no need for event to implements the same interface.
