### PR TITLE
Fixed @link annotation in javadoc.

### DIFF
--- a/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/RefReplicatedTest.java
+++ b/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/RefReplicatedTest.java
@@ -34,7 +34,7 @@ import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
 
 /**
- * Tests {@linkcom.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.RefReplicated}.
+ * Tests {@link com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.RefReplicated}.
  * @author Hugo Arès &lt;hugo.ares@ericsson.com&gt;
  */
 public class RefReplicatedTest {

--- a/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/RefReplicationDoneTest.java
+++ b/gerrit-events/src/test/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/RefReplicationDoneTest.java
@@ -34,7 +34,7 @@ import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
 
 /**
- * Tests {@linkcom.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.RefReplicationDone}.
+ * Tests {@link com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.RefReplicationDone}.
  * @author Hugo Arès &lt;hugo.ares@ericsson.com&gt;
  */
 public class RefReplicationDoneTest {


### PR DESCRIPTION
Add missing space after @link annotation in the RefReplicatedTest and
RefReplicationDoneTest.
