### PR TITLE
Add RepositoryModifiedEvent interface

### DIFF
--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/RepositoryModifiedEvent.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/RepositoryModifiedEvent.java
@@ -1,0 +1,41 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 Ericsson
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto;
+
+/**
+ * Represents any event raised by a ref created/changed in the git
+ * repository.
+ * For example, PatchsetCreated implements this interface but CommentAdded
+ * does not.
+ * @author Hugo Arès &lt;hugo.ares@ericsson.com&gt;
+ */
+public interface RepositoryModifiedEvent {
+
+    /**
+     * The repository modified ref.
+     * @return the modified ref
+     */
+    String getModifiedRef();
+}

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/attr/RefUpdate.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/attr/RefUpdate.java
@@ -38,6 +38,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  */
 public class RefUpdate implements GerritJsonDTO {
 
+    private static final String REFS_HEADS = "refs/heads/";
     /**
      * Project path in Gerrit.
      */
@@ -192,5 +193,16 @@ public class RefUpdate implements GerritJsonDTO {
     @Override
     public String toString() {
         return "RefUpdate: " + getNewRev() + " " + getProject() + " " + getRefName();
+    }
+
+    /**
+     * Returns the ref (refspec) representing this RefUpdate.
+     * @return the ref
+     */
+    public String getRef() {
+        if (refName != null) {
+            return REFS_HEADS + refName;
+        }
+        return null;
     }
 }

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/DraftPublished.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/DraftPublished.java
@@ -24,9 +24,10 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.RepositoryModifiedEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
-import net.sf.json.JSONObject;
 
+import net.sf.json.JSONObject;
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.UPLOADER;
 
 /**
@@ -34,7 +35,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  *
  * @author David Pursehouse &lt;david.pursehouse@sonymobile.com&gt;
  */
-public class DraftPublished extends ChangeBasedEvent {
+public class DraftPublished extends ChangeBasedEvent implements RepositoryModifiedEvent {
 
     /* Uploader has been replaced by GerritTriggeredEvent.account.
      * This allows old builds to deserialize without warnings. */
@@ -62,5 +63,13 @@ public class DraftPublished extends ChangeBasedEvent {
     @Override
     public String toString() {
         return "DraftPublished: " + change + " " + patchSet;
+    }
+
+    @Override
+    public String getModifiedRef() {
+        if (patchSet != null) {
+            return patchSet.getRef();
+        }
+        return null;
     }
 }

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/PatchsetCreated.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/PatchsetCreated.java
@@ -25,9 +25,10 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.RepositoryModifiedEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
-import net.sf.json.JSONObject;
 
+import net.sf.json.JSONObject;
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.UPLOADER;
 
 /**
@@ -35,7 +36,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  *
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
-public class PatchsetCreated extends ChangeBasedEvent {
+public class PatchsetCreated extends ChangeBasedEvent implements RepositoryModifiedEvent {
 
     /* Uploader has been replaced by GerritTriggeredEvent.account.
      * This allows old builds to deserialize without warnings. */
@@ -63,5 +64,13 @@ public class PatchsetCreated extends ChangeBasedEvent {
     @Override
     public String toString() {
         return "PatchsetCreated: " + change + " " + patchSet;
+    }
+
+    @Override
+    public String getModifiedRef() {
+        if (patchSet != null) {
+            return patchSet.getRef();
+        }
+        return null;
     }
 }

--- a/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/RefUpdated.java
+++ b/gerrit-events/src/main/java/com/sonyericsson/hudson/plugins/gerrit/gerritevents/dto/events/RefUpdated.java
@@ -24,10 +24,11 @@
 package com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventType;
+import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.RepositoryModifiedEvent;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.Account;
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.attr.RefUpdate;
-import net.sf.json.JSONObject;
 
+import net.sf.json.JSONObject;
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.REFUPDATE;
 import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEventKeys.SUBMITTER;
 
@@ -35,7 +36,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.GerritEven
  * A DTO representation of the ref-updated Gerrit Event.
  * @author jeblair
  */
-public class RefUpdated extends GerritTriggeredEvent {
+public class RefUpdated extends GerritTriggeredEvent implements RepositoryModifiedEvent {
 
     /**
      * The Gerrit ref update the event is related to.
@@ -114,5 +115,13 @@ public class RefUpdated extends GerritTriggeredEvent {
             return false;
         }
         return true;
+    }
+
+    @Override
+    public String getModifiedRef() {
+        if (refUpdate != null) {
+            return refUpdate.getRef();
+        }
+        return null;
     }
 }


### PR DESCRIPTION
RepositoryModifiedEvent represents any event raised by a ref created/changed in
the git repository (PatchsetCreated, DraftCreated and RefUpdated).

An example of usage is the gerrit-trigger: to implement wait for
replication feature, when a GerritEvent is interesting, it must wait
for replication to be complete before starting the build but only for
events that created/changed a ref in the git repository.
