### PR TITLE
Added a "Forbidden Files" optional parameter to Gerrit Projects

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
@@ -60,6 +60,7 @@ public final class GerritDynamicUrlProcessor {
     private static final String SHORTNAME_BRANCH = "b";
     private static final String SHORTNAME_TOPIC = "t";
     private static final String SHORTNAME_FILE = "f";
+    private static final String SHORTNAME_FORBIDDEN_FILE = "o";
     private static final int SOCKET_READ_TIMEOUT = 10000;
 
     /**
@@ -85,6 +86,7 @@ public final class GerritDynamicUrlProcessor {
               + "|" + SHORTNAME_BRANCH
               + "|" + SHORTNAME_TOPIC
               + "|" + SHORTNAME_FILE
+              + "|" + SHORTNAME_FORBIDDEN_FILE
               + ")";
       String operators = "(";
       boolean firstoperator = true;
@@ -119,6 +121,7 @@ public final class GerritDynamicUrlProcessor {
       List<Branch> branches = null;
       List<Topic> topics = null;
       List<FilePath> filePaths = null;
+      List<FilePath> forbiddenFilePaths = null;
       GerritProject dynamicGerritProject = null;
 
       String line = "";
@@ -169,7 +172,8 @@ public final class GerritDynamicUrlProcessor {
           branches = new ArrayList<Branch>();
           topics = new ArrayList<Topic>();
           filePaths = new ArrayList<FilePath>();
-          dynamicGerritProject = new GerritProject(type, text, branches, topics, filePaths);
+          forbiddenFilePaths = new ArrayList<FilePath>();
+          dynamicGerritProject = new GerritProject(type, text, branches, topics, filePaths, forbiddenFilePaths);
         } else if (SHORTNAME_BRANCH.equals(item)) { // Branch
           if (branches == null) {
             throw new ParseException("Line " + lineNr + ": attempt to use 'Branch' before 'Project'", lineNr);
@@ -184,13 +188,20 @@ public final class GerritDynamicUrlProcessor {
             Topic topic = new Topic(type, text);
             topics.add(topic);
             dynamicGerritProject.setTopics(topics);
-        } else { // FilePath (because it must be an 'f')
+        } else if (SHORTNAME_FILE.equals(item)) { // FilePath
           if (filePaths == null) {
             throw new ParseException("Line " + lineNr + ": attempt to use 'FilePath' before 'Project'", lineNr);
           }
           FilePath filePath = new FilePath(type, text);
           filePaths.add(filePath);
           dynamicGerritProject.setFilePaths(filePaths);
+        } else if (SHORTNAME_FORBIDDEN_FILE.equals(item)) { // ForbiddenFilePath
+          if (forbiddenFilePaths == null) {
+            throw new ParseException("Line " + lineNr + ": attempt to use 'ForbiddenFilePath' before 'Project'", lineNr);
+          }
+          FilePath filePath = new FilePath(type, text);
+          forbiddenFilePaths.add(filePath);
+          dynamicGerritProject.setForbiddenFilePaths(filePaths);
         }
       }
 

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
@@ -53,7 +53,7 @@ public class GerritProject implements Describable<GerritProject> {
     private List<Branch> branches;
     private List<FilePath> filePaths;
     private List<Topic> topics;
-
+    private List<FilePath> forbiddenFilePaths;
 
     /**
      * Default empty constructor.
@@ -69,6 +69,7 @@ public class GerritProject implements Describable<GerritProject> {
      * @param branches the branch-rules
      * @param topics the topic-rules
      * @param filePaths the file-path rules.
+     * @param forbiddenFilePaths the forbidden file-path rules.
      */
     @DataBoundConstructor
     public GerritProject(
@@ -76,13 +77,15 @@ public class GerritProject implements Describable<GerritProject> {
             String pattern,
             List<Branch> branches,
             List<Topic> topics,
-            List<FilePath> filePaths) {
+            List<FilePath> filePaths,
+            List<FilePath> forbiddenFilePaths) {
 
         this.compareType = compareType;
         this.pattern = pattern;
         this.branches = branches;
         this.topics = topics;
         this.filePaths = filePaths;
+        this.forbiddenFilePaths = forbiddenFilePaths;
     }
 
     /**
@@ -166,6 +169,22 @@ public class GerritProject implements Describable<GerritProject> {
     }
 
     /**
+     * The list of the forbidden file-path rules.
+     * @return the forbidden file-path rules.
+     */
+    public List<FilePath> getForbiddenFilePaths() {
+        return forbiddenFilePaths;
+    }
+
+    /**
+     * The list of the forbidden file-path rules.
+     * @param forbiddenFilePaths the forbidden file-path rules.
+     */
+    public void setForbiddenFilePaths(List<FilePath> forbiddenFilePaths) {
+        this.forbiddenFilePaths = forbiddenFilePaths;
+    }
+
+    /**
      * Compares the project, branch and files to see if the rules specified is a match.
      * @param project the Gerrit project
      * @param branch the branch.
@@ -177,6 +196,13 @@ public class GerritProject implements Describable<GerritProject> {
         if (compareType.matches(pattern, project)) {
             for (Branch b : branches) {
                 if (b.isInteresting(branch)) {
+                    if ( forbiddenFilePaths != null ) {
+                        for (FilePath ffp : forbiddenFilePaths) {
+                            if (ffp.isInteresting(files)) {
+                                return false;
+                            }
+                        }
+                    }
                     if (isInterestingTopic(topic) && isInterestingFile(files)) {
                         return true;
                     }

--- a/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -333,6 +333,39 @@
                             </f:repeatable>
                             </td>
                         </tr>
+                         <tr>
+                            <td colspan="4" valign="top" style="border-left: 1px solid black; border-right: 1px solid black; border-bottom: 1px solid black;">
+                                <f:repeatable var="ff" field="forbiddenFilePaths" add="${%Add Forbidden File path}" minimum="0" header="">
+                                <table width="100%">
+                                    <tr>
+                                        <td width="60">
+                                        ${%Forbidden File}
+                                        </td>
+                                        <td width="80">
+                                            <select class="setting-input" name="_.compareType">
+                                                <j:forEach items="${types}" var="me">
+                                                    <j:choose>
+                                                        <j:when test="${loop.getCompareType().name()==me.name()}">
+                                                            <option value="${me.name()}" selected="true">${me.getDisplayName()}</option>
+                                                        </j:when>
+                                                        <j:otherwise>
+                                                            <option value="${me.name()}">${me.getDisplayName()}</option>
+                                                        </j:otherwise>
+                                                    </j:choose>
+                                                </j:forEach>
+                                                </select>
+                                        </td>
+                                        <td minwidth="150">
+                                            <f:textbox field="pattern" value="${b.pattern}" default=""/>
+                                        </td>
+                                        <td width="65">
+                                            <f:repeatableDeleteButton/>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </f:repeatable>
+                            </td>
+                        </tr>
                     </j:if>
                 </table>
             </f:repeatable>

--- a/gerrithudsontrigger/src/main/webapp/trigger/help-DynamicTriggerConfiguration.html
+++ b/gerrithudsontrigger/src/main/webapp/trigger/help-DynamicTriggerConfiguration.html
@@ -24,8 +24,9 @@ b^**</code></pre>
     b for branch<br/>
     t for topic<br />
     f for file<br/>
+    o for forbidden file<br/>
     = for plain syntax<br/>
     ^ for ANT style syntax<br/>
     ~ for regexp syntax<br/>
-    Branch, topic and file lines are assumed to be part of the closest preceding project line.
+    Branch, topic, file and forbidden file lines are assumed to be part of the closest preceding project line.
 </p>


### PR DESCRIPTION
This forbidden file allows the project not to trigger if any forbidden
file has been impacted. This is very useful in chained scenarios. For
example, let's assume projectA upstream triggers projectB downstream.
Then if a commit affects both A and B, you may (depending on
configuration) want that A triggers and B wait for A to finish, and then
trigger B. This would be the case in particular if B uses artifacts from
A. Since A is triggering B anyways, no need for B to trigger. In that
case, this commit allows you to define the files in "A" as forbidden to
trigger a gerrit event in B. This means that such a commit affecting
both projects A and B will only trigger A. B will be built as usual as a
downstream element of A. Yet, a commit affecting only B will still
trigger a build of B. This is a very specific use case, but in this use
case, only this pull request can satisfy the requirement.
