### PR TITLE
Delayed approval mechanism

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDelayedApprover.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDelayedApprover.java
@@ -1,0 +1,182 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2010 Sony Ericsson Mobile Communications. All rights reserved.
+ *  Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
+
+
+import hudson.Extension;
+import hudson.Util;
+//import org.slf4j.Logger;
+//import org.slf4j.LoggerFactory;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.kohsuke.stapler.StaplerRequest;
+import net.sf.json.JSONObject;
+import hudson.tasks.BuildStepDescriptor;
+import hudson.tasks.BuildStepMonitor;
+import hudson.tasks.Notifier;
+import hudson.tasks.Publisher;
+import hudson.model.AbstractProject;
+import hudson.model.AbstractBuild;
+import hudson.model.BuildListener;
+import hudson.model.Hudson;
+import java.io.IOException;
+import java.util.Map;
+import hudson.Launcher;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ToGerritRunListener;
+
+
+/**
+ * Triggers a build previously run to send its report to Gerrit, if it hadn't yet.
+ *
+ * @author Yannick Bréhon &lt;yannick.brehon@smartmatic.com&gt;
+ */
+
+public class GerritDelayedApprover extends Notifier {
+
+    //private static final Logger logger = LoggerFactory.getLogger(GerritDelayedApprover.class);
+    private String delayedJob;
+    private String delayedBuildNumber;
+
+
+    /**
+     * Default DataBound Constructor.
+     *
+    */
+    @DataBoundConstructor
+    public GerritDelayedApprover(
+            String delayedJob,
+            String delayedBuildNumber) {
+        this.delayedJob = delayedJob;
+        this.delayedBuildNumber = delayedBuildNumber;
+    }
+    /**
+     * The delayedBuildNumber, ie number of the build which may need a delayed approval
+     *
+     * @return the delayedBuildNumber
+     */
+    public String getDelayedBuildNumber() {
+        return delayedBuildNumber;
+    }
+
+    /**
+     * Set the delayedBuildNumber
+     *
+     * @param delayedBuildNumber
+     *         the delayedBuildNumber
+     */
+    public void setDelayedBuildNumber(String delayedBuildNumber) {
+        this.delayedBuildNumber = delayedBuildNumber;
+    }
+
+    /**
+     * The delayedJob, ie the name of the job which may need a delayed approval.
+     *
+     * @return the delayedJob
+     */
+    public String getDelayedJob() {
+        return delayedJob;
+    }
+
+    /**
+     * Set the delayedJob
+     *
+     * @param delayedJob
+     *         the delayedJob
+     */
+    public void setDelayedJob(String delayedJob) {
+        this.delayedJob = delayedJob;
+    }
+
+    public BuildStepMonitor getRequiredMonitorService() {
+        return BuildStepMonitor.NONE;
+    }
+
+    @Override
+    public boolean needsToRunAfterFinalized() {
+        return true;
+    }
+
+    public boolean perform(final AbstractBuild<?, ?> build, final Launcher launcher, final BuildListener listener)
+                                        throws InterruptedException, IOException {
+        //logger.info("Running Gerrit Delayed Approval");
+        Map<String,String> buildVars = build.getBuildVariables();
+        String jobName = Util.replaceMacro(delayedJob,buildVars);
+        String numberStr = Util.replaceMacro(delayedBuildNumber,buildVars);
+        int number = Integer.parseInt(numberStr);
+
+        //String jobName = (String) build.getBuildVariables().get(jobParameterName);
+        //int number = Integer.parseInt((String)build.getBuildVariables().get(buildNumParameterName));
+        AbstractProject initiatingJob = Hudson.getInstance().getItemByFullName(jobName, AbstractProject.class);
+        if (initiatingJob==null) return false;
+        AbstractBuild initiatingBuild = (AbstractBuild)initiatingJob.getBuildByNumber(number);
+        GerritCause cause = (GerritCause)initiatingBuild.getCause(GerritCause.class);
+        if (cause==null) return false;
+        ToGerritRunListener thelistener = ToGerritRunListener.getInstance();
+        thelistener.allBuildsCompleted(cause.getEvent(), cause, null);
+        return true;
+    }
+
+    /*---------------------------------*/
+    /* ----- Descriptor stuff -------- */
+    /*---------------------------------*/
+
+    @Override
+    public BuildStepDescriptor<Publisher> getDescriptor() {
+        return DESCRIPTOR;
+    }
+
+    public static final GerritDelayedApproverDescriptor DESCRIPTOR = new GerritDelayedApproverDescriptor();
+
+    @Extension
+    public static final class GerritDelayedApproverDescriptor extends
+            BuildStepDescriptor<Publisher> {
+
+        //private static final Logger logger = LoggerFactory.getLogger(GerritDelayedApproverDescriptor.class);
+
+        public GerritDelayedApproverDescriptor() {
+            super(GerritDelayedApprover.class);
+            load();
+        }
+
+        @Override
+        public String getDisplayName() {
+            return "Send a delayed Gerrit approval";
+        }
+
+        /*public DescriptorExtensionList<BuildDescriptor,Descriptor<BuildDescriptor>> getBuildSelectorDescriptors(){
+            return Jenkins.getInstance().<BuildDescriptor,Descriptor<BuildDescriptor>>getDescriptorList(BuildDescriptor.class);
+        }*/
+
+        @Override
+        public boolean isApplicable(Class<? extends AbstractProject> jobType) {
+            return true;
+        }
+
+        /*@Override
+        public String getHelpFile() {
+            return "/plugin/build-publisher/help/config/publish.html";
+        }*/
+        
+    }
+}

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -123,6 +123,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
     private Integer gerritBuildNotBuiltVerifiedValue;
     private Integer gerritBuildNotBuiltCodeReviewValue;
     private boolean silentMode;
+    private boolean delayedApproval;
     private boolean escapeQuotes;
     private boolean noNameAndEmailParameters;
     private String buildStartMessage;
@@ -210,6 +211,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
             Integer gerritBuildNotBuiltVerifiedValue,
             Integer gerritBuildNotBuiltCodeReviewValue,
             boolean silentMode,
+            boolean delayedApproval,
             boolean escapeQuotes,
             boolean noNameAndEmailParameters,
             String buildStartMessage,
@@ -237,6 +239,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
         this.gerritBuildNotBuiltVerifiedValue = gerritBuildNotBuiltVerifiedValue;
         this.gerritBuildNotBuiltCodeReviewValue = gerritBuildNotBuiltCodeReviewValue;
         this.silentMode = silentMode;
+        this.delayedApproval = delayedApproval;
         this.escapeQuotes = escapeQuotes;
         this.noNameAndEmailParameters = noNameAndEmailParameters;
         this.buildStartMessage = buildStartMessage;
@@ -1235,6 +1238,16 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
     }
 
     /**
+     * If delayed approval is on or off. When delayed approval is on there will be no automatic result of the build 
+     * sent back to Gerrit. This will have to be sent using a different mechanism. Default is false.
+     *
+     * @return true if silent mode is on.
+     */
+    public boolean isDelayedApproval() {
+        return delayedApproval;
+    }
+
+    /**
      * if escapeQuotes is on or off. When escapeQuotes is on this plugin will escape quotes in Gerrit event parameter
      * string Default is true
      *
@@ -1338,6 +1351,16 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
      */
     public void setSilentMode(boolean silentMode) {
         this.silentMode = silentMode;
+    }
+
+    /**
+     * Sets delayed approval to on or off. When delayed approval is on there will be no automatic result of the 
+     * build sent back to Gerrit. This will have to be sent using a different mechanism. Default is false.
+     *
+     * @param silentMode true if silent mode should be on.
+     */
+    public void setDelayedApproval(boolean delayedApproval) {
+        this.delayedApproval = delayedApproval;
     }
 
     /**

--- a/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDelayedApprover/config.jelly
+++ b/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDelayedApprover/config.jelly
@@ -1,0 +1,8 @@
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry name="delayedJob" title="Name of the job name which may need a delayed approval" field="delayedJob">
+        <f:textbox name="delayedJob" value="${instance.delayedJob==null?'$JOB_TO_GERRITCOMPLETE':instance.delayedJob}"/>
+    </f:entry>
+    <f:entry name="delayedBuildNumber" title="Build number which may need a delayed approval" field="delayedBuildNumber">
+        <f:textbox name="delayedBuildNumber" value="${instance.delayedBuildNumber==null?'$BUILD_TO_GERRITCOMPLETE':instance.delayedBuildNumber}"/>
+    </f:entry>
+</j:jelly>

--- a/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -15,6 +15,10 @@
                  help="/plugin/gerrit-trigger/trigger/help-NoNameAndEmailParameters.html">
                 <f:checkbox name="noNameAndEmailParameters" default="false" checked="${it.noNameAndEmailParameters}"/>
             </f:entry>
+            <f:entry title="${%Delayed Approval}"  field="delayedApproval"
+                     help="/plugin/gerrit-trigger/trigger/help-DelayedApproval.html">
+                <f:checkbox name="delayedApproval" default="false" checked="${it.delayedApproval}"/>
+            </f:entry>
             <f:section title="${%Gerrit Reporting Values}">
                 <f:entry title="${%URL to post}"
                          field="customUrl"

--- a/gerrithudsontrigger/src/main/webapp/trigger/help-DelayedApproval.html
+++ b/gerrithudsontrigger/src/main/webapp/trigger/help-DelayedApproval.html
@@ -1,0 +1,1 @@
+Select this option to prevent Jenkins from sending the approval at the end of this build. A post-build "delayed approval" will be necessary to have the result sent back to Gerrit.


### PR DESCRIPTION
This patch introduces the possibility for a delayed approval to be sent
back to Gerrit. This is a relatively advanced use case, so the setting
has been placed in the Advanced section for the Trigger settings.
When one selects "delayed approval", the completion of the build will
NOT send an approval back to Gerrit. Instead, the triggering event stays
open, and needs to be closed later on. This can be done by using the new
post-build action "Send a Gerrit delayed approval". At the moment, this
notifier expects to read the name of the job and build number from build
variables. If these point to an existing build which has a Gerrit event
as a trigger, which has not been submitted due to "delayed approval",
then that approval will be sent. In particular, this allows to modify
the status of that build through other job (e.g., using Groovy scripts),
and mark it UNSTABLE (e.g., if a subsequent build were to fail), which
is a way one can change the result of the Approval in Gerrit.
