### PR TITLE
Added a "Forbidden Files" optional parameter to Gerrit Projects [FIXED JENKINS-21232]

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
@@ -60,6 +60,7 @@ public final class GerritDynamicUrlProcessor {
     private static final String SHORTNAME_BRANCH = "b";
     private static final String SHORTNAME_TOPIC = "t";
     private static final String SHORTNAME_FILE = "f";
+    private static final String SHORTNAME_FORBIDDEN_FILE = "o";
     private static final int SOCKET_READ_TIMEOUT = 10000;
 
     /**
@@ -85,6 +86,7 @@ public final class GerritDynamicUrlProcessor {
               + "|" + SHORTNAME_BRANCH
               + "|" + SHORTNAME_TOPIC
               + "|" + SHORTNAME_FILE
+              + "|" + SHORTNAME_FORBIDDEN_FILE
               + ")";
       String operators = "(";
       boolean firstoperator = true;
@@ -119,6 +121,7 @@ public final class GerritDynamicUrlProcessor {
       List<Branch> branches = null;
       List<Topic> topics = null;
       List<FilePath> filePaths = null;
+      List<FilePath> forbiddenFilePaths = null;
       GerritProject dynamicGerritProject = null;
 
       String line = "";
@@ -169,7 +172,8 @@ public final class GerritDynamicUrlProcessor {
           branches = new ArrayList<Branch>();
           topics = new ArrayList<Topic>();
           filePaths = new ArrayList<FilePath>();
-          dynamicGerritProject = new GerritProject(type, text, branches, topics, filePaths);
+          forbiddenFilePaths = new ArrayList<FilePath>();
+          dynamicGerritProject = new GerritProject(type, text, branches, topics, filePaths, forbiddenFilePaths);
         } else if (SHORTNAME_BRANCH.equals(item)) { // Branch
           if (branches == null) {
             throw new ParseException("Line " + lineNr + ": attempt to use 'Branch' before 'Project'", lineNr);
@@ -184,13 +188,20 @@ public final class GerritDynamicUrlProcessor {
             Topic topic = new Topic(type, text);
             topics.add(topic);
             dynamicGerritProject.setTopics(topics);
-        } else { // FilePath (because it must be an 'f')
+        } else if (SHORTNAME_FILE.equals(item)) { // FilePath
           if (filePaths == null) {
             throw new ParseException("Line " + lineNr + ": attempt to use 'FilePath' before 'Project'", lineNr);
           }
           FilePath filePath = new FilePath(type, text);
           filePaths.add(filePath);
           dynamicGerritProject.setFilePaths(filePaths);
+        } else if (SHORTNAME_FORBIDDEN_FILE.equals(item)) { // ForbiddenFilePath
+          if (forbiddenFilePaths == null) {
+            throw new ParseException("Line " + lineNr + ": attempt to use 'ForbiddenFilePath' before 'Project'", lineNr);
+          }
+          FilePath filePath = new FilePath(type, text);
+          forbiddenFilePaths.add(filePath);
+          dynamicGerritProject.setForbiddenFilePaths(filePaths);
         }
       }
 

--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
@@ -53,7 +53,7 @@ public class GerritProject implements Describable<GerritProject> {
     private List<Branch> branches;
     private List<FilePath> filePaths;
     private List<Topic> topics;
-
+    private List<FilePath> forbiddenFilePaths;
 
     /**
      * Default empty constructor.
@@ -69,6 +69,7 @@ public class GerritProject implements Describable<GerritProject> {
      * @param branches the branch-rules
      * @param topics the topic-rules
      * @param filePaths the file-path rules.
+     * @param forbiddenFilePaths the forbidden file-path rules.
      */
     @DataBoundConstructor
     public GerritProject(
@@ -76,13 +77,15 @@ public class GerritProject implements Describable<GerritProject> {
             String pattern,
             List<Branch> branches,
             List<Topic> topics,
-            List<FilePath> filePaths) {
+            List<FilePath> filePaths,
+            List<FilePath> forbiddenFilePaths) {
 
         this.compareType = compareType;
         this.pattern = pattern;
         this.branches = branches;
         this.topics = topics;
         this.filePaths = filePaths;
+        this.forbiddenFilePaths = forbiddenFilePaths;
     }
 
     /**
@@ -166,6 +169,22 @@ public class GerritProject implements Describable<GerritProject> {
     }
 
     /**
+     * The list of the forbidden file-path rules.
+     * @return the forbidden file-path rules.
+     */
+    public List<FilePath> getForbiddenFilePaths() {
+        return forbiddenFilePaths;
+    }
+
+    /**
+     * The list of the forbidden file-path rules.
+     * @param forbiddenFilePaths the forbidden file-path rules.
+     */
+    public void setForbiddenFilePaths(List<FilePath> forbiddenFilePaths) {
+        this.forbiddenFilePaths = forbiddenFilePaths;
+    }
+
+    /**
      * Compares the project, branch and files to see if the rules specified is a match.
      * @param project the Gerrit project
      * @param branch the branch.
@@ -177,6 +196,13 @@ public class GerritProject implements Describable<GerritProject> {
         if (compareType.matches(pattern, project)) {
             for (Branch b : branches) {
                 if (b.isInteresting(branch)) {
+                    if (forbiddenFilePaths != null) {
+                        for (FilePath ffp : forbiddenFilePaths) {
+                            if (ffp.isInteresting(files)) {
+                                return false;
+                            }
+                        }
+                    }
                     if (isInterestingTopic(topic) && isInterestingFile(files)) {
                         return true;
                     }

--- a/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/gerrithudsontrigger/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -333,6 +333,39 @@
                             </f:repeatable>
                             </td>
                         </tr>
+                         <tr>
+                            <td colspan="4" valign="top" style="border-left: 1px solid black; border-right: 1px solid black; border-bottom: 1px solid black;">
+                                <f:repeatable var="ff" field="forbiddenFilePaths" add="${%Add Forbidden File path}" minimum="0" header="">
+                                <table width="100%">
+                                    <tr>
+                                        <td width="60">
+                                        ${%Forbidden File}
+                                        </td>
+                                        <td width="80">
+                                            <select class="setting-input" name="_.compareType">
+                                                <j:forEach items="${types}" var="me">
+                                                    <j:choose>
+                                                        <j:when test="${loop.getCompareType().name()==me.name()}">
+                                                            <option value="${me.name()}" selected="true">${me.getDisplayName()}</option>
+                                                        </j:when>
+                                                        <j:otherwise>
+                                                            <option value="${me.name()}">${me.getDisplayName()}</option>
+                                                        </j:otherwise>
+                                                    </j:choose>
+                                                </j:forEach>
+                                                </select>
+                                        </td>
+                                        <td minwidth="150">
+                                            <f:textbox field="pattern" value="${b.pattern}" default=""/>
+                                        </td>
+                                        <td width="65">
+                                            <f:repeatableDeleteButton/>
+                                        </td>
+                                    </tr>
+                                </table>
+                            </f:repeatable>
+                            </td>
+                        </tr>
                     </j:if>
                 </table>
             </f:repeatable>

--- a/gerrithudsontrigger/src/main/webapp/trigger/help-DynamicTriggerConfiguration.html
+++ b/gerrithudsontrigger/src/main/webapp/trigger/help-DynamicTriggerConfiguration.html
@@ -24,8 +24,9 @@ b^**</code></pre>
     b for branch<br/>
     t for topic<br />
     f for file<br/>
+    o for forbidden file<br/>
     = for plain syntax<br/>
     ^ for ANT style syntax<br/>
     ~ for regexp syntax<br/>
-    Branch, topic and file lines are assumed to be part of the closest preceding project line.
+    Branch, topic, file and forbidden file lines are assumed to be part of the closest preceding project line.
 </p>

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJobHudsonTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJobHudsonTest.java
@@ -79,7 +79,7 @@ public class BuildCompletedRestCommandJobHudsonTest extends HudsonTestCase {
         trigger.setGerritProjects(Collections.singletonList(
                 new GerritProject(CompareType.PLAIN, event.getChange().getProject(),
                         Collections.singletonList(new Branch(CompareType.PLAIN, event.getChange().getBranch())),
-                        null, null)
+                        null, null, null)
         ));
         trigger.setSilentMode(false);
         trigger.setGerritBuildSuccessfulCodeReviewValue(1);

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectListTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectListTest.java
@@ -63,7 +63,7 @@ public class GerritProjectListTest {
         List<Branch> branches = new LinkedList<Branch>();
         Branch branch = new Branch(compareType, "master");
         branches.add(branch);
-        GerritProject config = new GerritProject(CompareType.PLAIN, pattern, branches, null, null);
+        GerritProject config = new GerritProject(CompareType.PLAIN, pattern, branches, null, null, null);
         return config;
     }
 

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
@@ -75,20 +75,20 @@ public class GerritProjectInterestingTest {
         List<Topic> topics = new LinkedList<Topic>();
         Branch branch = new Branch(CompareType.PLAIN, "master");
         branches.add(branch);
-        GerritProject config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null);
+        GerritProject config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "origin/master", null, true), });
 
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
         branches = new LinkedList<Branch>();
@@ -96,7 +96,7 @@ public class GerritProjectInterestingTest {
         branches.add(branch);
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
         branches.add(branch);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
         branches = new LinkedList<Branch>();
@@ -104,14 +104,14 @@ public class GerritProjectInterestingTest {
         branches.add(branch);
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
         branches.add(branch);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "feature/mymaster", null, true), });
 
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
-        config = new GerritProject(CompareType.ANT, "vendor/**/project", branches, topics, null);
+        config = new GerritProject(CompareType.ANT, "vendor/**/project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "vendor/semc/master/project", "origin/master", null, true), });
 
@@ -121,20 +121,20 @@ public class GerritProjectInterestingTest {
         topics = new LinkedList<Topic>();
         Topic topic = new Topic(CompareType.PLAIN, "topic");
         topics.add(topic);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", "topic", true)});
 
         topics = new LinkedList<Topic>();
         topic = new Topic(CompareType.ANT, "**/topic");
         topics.add(topic);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "master", "team/topic", true), });
 
         topics = new LinkedList<Topic>();
         topic = new Topic(CompareType.REG_EXP, ".*_topic");
         topics.add(topic);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "master", "team-wolf_topic", true), });
 

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
@@ -76,7 +76,9 @@ public class GerritProjectWithFilesInterestingTest {
         List<FilePath> filePaths = new LinkedList<FilePath>();
         FilePath filePath = new FilePath(CompareType.PLAIN, "test.txt");
         filePaths.add(filePath);
-        GerritProject config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths);
+        List<FilePath> forbiddenFilePaths = null;
+        GerritProject config = new GerritProject(
+                CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths);
         List<String> files = new LinkedList<String>();
         files.add("test.txt");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
@@ -90,7 +92,8 @@ public class GerritProjectWithFilesInterestingTest {
         filePaths.add(filePath);
         files = new LinkedList<String>();
         files.add("tests/test.txt");
-        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths);
+        forbiddenFilePaths = null;
+        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "projectNumber5", "feature/mymaster", null, files, true), });
 
@@ -100,7 +103,9 @@ public class GerritProjectWithFilesInterestingTest {
         filePaths = new LinkedList<FilePath>();
         filePath = new FilePath(CompareType.ANT, "**/*test*");
         filePaths.add(filePath);
-        config = new GerritProject(CompareType.ANT, "vendor/**/project", branches, topics, filePaths);
+        forbiddenFilePaths = null;
+        config = new GerritProject(
+                CompareType.ANT, "vendor/**/project", branches, topics, filePaths, forbiddenFilePaths);
         files = new LinkedList<String>();
         files.add("resources/test.xml");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
@@ -114,9 +119,61 @@ public class GerritProjectWithFilesInterestingTest {
         filePaths.add(filePath);
         files = new LinkedList<String>();
         files.add("notintests/test.txt");
-        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths);
+        forbiddenFilePaths = null;
+        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "projectNumber5", "feature/mymaster", null, files, false), });
+
+        //Testing with Forbidden File Paths now
+        branches = new LinkedList<Branch>();
+        branch = new Branch(CompareType.PLAIN, "master");
+        branches.add(branch);
+        topics = new LinkedList<Topic>();
+        filePaths = new LinkedList<FilePath>();
+        filePath = new FilePath(CompareType.PLAIN, "test.txt");
+        filePaths.add(filePath);
+        forbiddenFilePaths = new LinkedList<FilePath>();
+        FilePath forbiddenFilePath = new FilePath(CompareType.PLAIN, "test2.txt");
+        forbiddenFilePaths.add(forbiddenFilePath);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths);
+        files = new LinkedList<String>();
+        files.add("test.txt");
+        files.add("test2.txt");
+        parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
+                config, "project", "master", null, files, false), });
+
+        branches = new LinkedList<Branch>();
+        branch = new Branch(CompareType.REG_EXP, "feature/.*master");
+        branches.add(branch);
+        filePaths = new LinkedList<FilePath>();
+        filePath = new FilePath(CompareType.REG_EXP, "tests/.*");
+        filePaths.add(filePath);
+        forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePath = new FilePath(CompareType.REG_EXP, "tests/.*2.*");
+        forbiddenFilePaths.add(forbiddenFilePath);
+        files = new LinkedList<String>();
+        files.add("tests/test.txt");
+        files.add("tests/test2.txt");
+        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
+        parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
+                config, "projectNumber5", "feature/mymaster", null, files, false), });
+
+        branches = new LinkedList<Branch>();
+        branch = new Branch(CompareType.ANT, "**/master");
+        branches.add(branch);
+        filePaths = new LinkedList<FilePath>();
+        filePath = new FilePath(CompareType.ANT, "**/*test*");
+        filePaths.add(filePath);
+        forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePath = new FilePath(CompareType.ANT, "**/*skip*");
+        forbiddenFilePaths.add(forbiddenFilePath);
+        config = new GerritProject(
+                CompareType.ANT, "vendor/**/project", branches, topics, filePaths, forbiddenFilePaths);
+        files = new LinkedList<String>();
+        files.add("resources/test.xml");
+        files.add("files/skip.txt");
+        parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
+                config, "vendor/semc/master/project", "origin/master", null, files, false), });
 
         return parameters;
     }

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
@@ -88,7 +88,7 @@ public abstract class DuplicatesUtil {
         FreeStyleProject p = base.hudson.createProject(FreeStyleProject.class, projectName);
         List<GerritProject> projects = new LinkedList<GerritProject>();
         projects.add(new GerritProject(CompareType.ANT, "**",
-                Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null));
+                Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null));
         p.addTrigger(new GerritTrigger(projects, null,
                 null, null, null, null, null, null, null, null, null, null,
                 false, true, false, null, null, null, null, null, null, null,
@@ -157,7 +157,7 @@ public abstract class DuplicatesUtil {
         FreeStyleProject p = base.hudson.createProject(FreeStyleProject.class, name);
         List<GerritProject> projects = new LinkedList<GerritProject>();
         projects.add(new GerritProject(CompareType.ANT, "**",
-                Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null));
+                Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null));
         PluginCommentAddedEvent event = new PluginCommentAddedEvent("CRVW", "1");
         List<PluginGerritEvent> list = new LinkedList<PluginGerritEvent>();
         list.add(event);


### PR DESCRIPTION
This forbidden file allows the project not to trigger if any forbidden
file has been impacted. This is very useful in chained scenarios. For
example, let's assume projectA upstream triggers projectB downstream.
Then if a commit affects both A and B, you may (depending on
configuration) want that A triggers and B wait for A to finish, and then
trigger B. This would be the case in particular if B uses artifacts from
A. Since A is triggering B anyways, no need for B to trigger. In that
case, this commit allows you to define the files in "A" as forbidden to
trigger a gerrit event in B. This means that such a commit affecting
both projects A and B will only trigger A. B will be built as usual as a
downstream element of A. Yet, a commit affecting only B will still
trigger a build of B. This is a very specific use case, but in this use
case, only this commit can satisfy the requirement.

Amends: broken style-checks fixed and forgotten test changes added
