### PR TITLE
Enclose whole value in double quote

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtil.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtil.java
@@ -25,6 +25,8 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.utils;
 
 import com.sonyericsson.hudson.plugins.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 /**
@@ -123,7 +125,12 @@ public final class StringUtil {
         if (value == null) {
             return null;
         } else {
-            return QUOTES_PATTERN.matcher(value).replaceAll("\\\\\"");
+            Matcher m = QUOTES_PATTERN.matcher(value);
+            if (m.find()) {
+                return  "\"" + m.replaceAll("\\\\\"") + "\"";
+            } else {
+                return value;
+            }
         }
     }
 }

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtilTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtilTest.java
@@ -18,7 +18,7 @@ public class StringUtilTest {
 
         String valueOfParameter = "xxx\"xxx\"xxxx";
         String escapedString = StringUtil.escapeQuotes(valueOfParameter);
-        String expectedString = "xxx\\\"xxx\\\"xxxx";
+        String expectedString = "\"xxx\\\"xxx\\\"xxxx\"";
         Assert.assertEquals(expectedString, escapedString);
 
 


### PR DESCRIPTION
Some parameter values escape double quote. But whole value is not
quoted. It causes platform dependent issue.

This patch quotes whole value if more than one double quote is actually
escaped.

Perhaps this is root cause for windows.
