### PR TITLE
enclose whole value with quote if space is included

### DIFF
--- a/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/gerrithudsontrigger/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -239,15 +239,18 @@ public enum GerritTriggerParameters {
             parameters.remove(parameter);
         }
         String stringValue;
-        if (escapeQuotes) {
-            stringValue = StringUtil.escapeQuotes(value);
+        if (value != null && value.indexOf(' ') != -1) {
+            stringValue = "\"" + StringUtil.escapeQuotes(value) + "\"";
         } else {
-            stringValue = value;
+            if (escapeQuotes) {
+                stringValue = StringUtil.escapeQuotes(value);
+            } else {
+                stringValue = value;
+            }
         }
         if (stringValue == null) {
             stringValue = "";
         }
-
         parameter = new StringParameterValue(this.name(), stringValue, description);
         parameters.add(parameter);
     }

--- a/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParametersTest.java
+++ b/gerrithudsontrigger/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParametersTest.java
@@ -93,6 +93,22 @@ public class GerritTriggerParametersTest {
 
     /**
      * Tests {@link GerritTriggerParameters#setOrCreateParameters(GerritTriggeredEvent, AbstractProject, List)}.
+     * The {@link GerritTriggerParameters#GERRIT_CHANGE_OWNER} should be escaped correctly.
+     *
+     * @throws Exception if so
+     */
+    @Test
+    public void setOrCreateParametersChangeOwner() throws Exception {
+        PatchsetCreated created = Setup.createPatchsetCreated();
+        LinkedList<ParameterValue> parameters = new LinkedList<ParameterValue>();
+        GerritTriggerParameters.setOrCreateParameters(created, null, parameters);
+        StringParameterValue param = findParameter(GerritTriggerParameters.GERRIT_CHANGE_OWNER, parameters);
+        assertNotNull(param);
+        assertTrue("\"\\\"Name\\\" <email@domain.com>\"".equals(param.value));
+    }
+
+    /**
+     * Tests {@link GerritTriggerParameters#setOrCreateParameters(GerritTriggeredEvent, AbstractProject, List)}.
      * The {@link GerritTriggerParameters#GERRIT_CHANGE_URL} should contain the base url from the project trigger.
      *
      * @throws Exception if so


### PR DESCRIPTION
If a space is included in parameter value, The whole value should be
quoted. Also quote in value should be escaped.

Linux:

```
$ export FOO="1 2 3"
$ echo $FOO
1 2 3
$ echo "$FOO"
1 2 3
```

Windows:

```
> set FOO="1 2 3"
> echo %FOO%
"1 2 3"
> echo "%FOO%"
""1 2 3""
```

This difference would cause escape issue...
