### PR TITLE
JENKINS-21547: Add information to console log

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -76,6 +76,7 @@ import hudson.model.ParameterValue;
 import hudson.model.ParametersAction;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.model.Queue;
+import hudson.model.Result;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
 import hudson.util.FormValidation;
@@ -1758,7 +1759,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
                         List<ParametersAction> params = a.getActions(ParametersAction.class);
                         for (ParametersAction param : params) {
                             if (param.equals(parameters)) {
-                                e.interrupt();
+                                e.interrupt(Result.ABORTED, new NewPatchSetInterruption());
                             }
                         }
                     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/NewPatchSetInterruption.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/NewPatchSetInterruption.java
@@ -1,0 +1,39 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2014 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+
+import jenkins.model.CauseOfInterruption;
+
+/**
+ * A cause class for new patchset interruption.
+ * @author rinrinne (rinrin.ne@gmail.com)
+ */
+public final class NewPatchSetInterruption extends CauseOfInterruption {
+    @Override
+    public String getShortDescription() {
+        return Messages.AbortedByNewPatchSet();
+    }
+}

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -140,3 +140,5 @@ WaitingForReplicationTimeout=\
 Waiting for replication of {0} to {1} timed out.
 ReplicationFailed=\
 Replication of {0} to {1} failed.
+AbortedByNewPatchSet=\
+  Aborted by new patch set.


### PR DESCRIPTION
This patch adds message to console when a job is aborted by gerrit.
