### PR TITLE
Permit the setting of Build Schedule Delay to "0". Delay not needed with Replication Events

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -338,8 +338,8 @@ public class Config implements IGerritHudsonTriggerConfig {
         buildScheduleDelay = formData.optInt(
                 "buildScheduleDelay",
                 DEFAULT_BUILD_SCHEDULE_DELAY);
-        if (buildScheduleDelay <= DEFAULT_BUILD_SCHEDULE_DELAY) {
-            buildScheduleDelay = DEFAULT_BUILD_SCHEDULE_DELAY;
+        if (buildScheduleDelay < 0) {
+            buildScheduleDelay = 0;
         }
         dynamicConfigRefreshInterval = formData.optInt(
                 "dynamicConfigRefreshInterval",

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/BecauseWaitingToEnsureOtherJobsAreInQueue.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/BecauseWaitingToEnsureOtherJobsAreInQueue.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Ericsson.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.dependency;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+
+import hudson.model.queue.CauseOfBlockage;
+
+/**
+ * Build is blocked because it is waiting to ensure other jobs are in queue.
+ *
+ * @author Scott Hebert &lt;scott.hebert@ericsson.com&gt;
+ */
+public class BecauseWaitingToEnsureOtherJobsAreInQueue extends CauseOfBlockage {
+
+    @Override
+    public String getShortDescription() {
+        return Messages.WaitingToEnsureOtherJobsAreInQueue();
+    }
+
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -666,7 +666,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
      */
     public int getBuildScheduleDelay() {
         if (isAnyServer()) {
-            int max = DEFAULT_BUILD_SCHEDULE_DELAY;
+            int max = 0;
             for (GerritServer server : PluginImpl.getInstance().getServers()) {
                 if (server.getConfig() != null) {
                     max = Math.max(max, server.getConfig().getBuildScheduleDelay());
@@ -679,7 +679,8 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
         } else {
             int buildScheduleDelay = PluginImpl.getInstance().getServer(serverName).getConfig()
                     .getBuildScheduleDelay();
-            return Math.max(buildScheduleDelay, DEFAULT_BUILD_SCHEDULE_DELAY);
+            //check if less than zero
+            return Math.max(0, buildScheduleDelay);
         }
 
     }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -215,7 +215,7 @@
                             <f:textbox name="buildScheduleDelay"
                                        value="${it.config.buildScheduleDelay}"
                                        default="${com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_BUILD_SCHEDULE_DELAY}"
-                                       checkUrl="'${rootURL}/${serverURL}/positiveIntegerCheck?value='+escape(this.value)"/>
+                                       checkUrl="'${rootURL}/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"/>
                         </f:entry>
                         <f:entry title="${%Dynamic Config Refresh Interval}"
                                  help="/plugin/gerrit-trigger/help-DynamicTriggerConfigRefreshInterval.html">

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -150,6 +150,8 @@ CannotAddSelfAsDependency=\
   Cannot add a project to its own set of dependencies
 WaitingForDependencyProjectsToTrigger=\
   Waiting for all projects to finish gerrit-triggering to make sure no dependencies need to build first.
+WaitingToEnsureOtherJobsAreInQueue=\
+  Waiting to ensure all dependent jobs are in queue.
 NotificationLevel_DefaultValue=\
   (Server default)
 NotificationLevel_DefaultValueFromServer=\

--- a/src/main/webapp/help-BuildScheduleDelay.html
+++ b/src/main/webapp/help-BuildScheduleDelay.html
@@ -1,1 +1,2 @@
-<p><strong>Build Schedule Delay</strong> delays the scheduling of the build by the specified number of seconds. The default and minimum <strong>Build Schedule Delay</strong> is 3 seconds. A longer delay can be needed if the changes are to be built from Gerrit mirrors, since the replication takes time.</p>
+<p><strong>Build Schedule Delay</strong> delays the scheduling of the build by the specified number of seconds. The default <strong>Build Schedule Delay</strong> is 3 seconds.
+A longer delay can be needed if the changes are to be built from Gerrit mirrors, since the replication takes time. However, if you are using replication events to trigger your jobs, you may set this value to 0 to disable the <strong>Build Schedule Delay</strong></p>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ConfigTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ConfigTest.java
@@ -26,6 +26,7 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.config;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Notify;
+import com.sonymobile.tools.gerrit.gerritevents.GerritDefaultValues;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.Setup;
 
 import net.sf.json.JSONObject;
@@ -118,6 +119,7 @@ public class ConfigTest {
         assertEquals(6, config.getNumberOfReceivingWorkerThreads());
         assertEquals(4, config.getNumberOfSendingWorkerThreads());
         assertEquals(Notify.OWNER, config.getNotificationLevel());
+        assertEquals(GerritDefaultValues.DEFAULT_BUILD_SCHEDULE_DELAY, config.getBuildScheduleDelay());
     }
 
     //CS IGNORE MagicNumber FOR NEXT 100 LINES. REASON: Mocks tests.
@@ -155,6 +157,7 @@ public class ConfigTest {
                 + "\"gerritProxy\":\"\","
                 + "\"gerritUserName\":\"gerrit\","
                 + "\"numberOfSendingWorkerThreads\":\"4\","
+                + "\"buildScheduleDelay\":\"0\","
                 + "\"numberOfReceivingWorkerThreads\":\"6\"}";
         JSONObject form = (JSONObject)JSONSerializer.toJSON(formString);
         Config initialConfig = new Config(form);
@@ -194,6 +197,7 @@ public class ConfigTest {
         assertEquals("gerrit", config.getGerritUserName());
         assertEquals(6, config.getNumberOfReceivingWorkerThreads());
         assertEquals(4, config.getNumberOfSendingWorkerThreads());
+        assertEquals(0, config.getBuildScheduleDelay());
     }
 
     /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
@@ -330,8 +330,47 @@ public class GerritTriggerTest {
         doReturn("http://mock.url").when(gerritCause).getUrl();
         trigger.schedule(gerritCause, event);
         verify(project).scheduleBuild2(
-                //negative value will be reset into default value 3
-                eq(3),
+                //negative value will be reset to 0
+                eq(0),
+                same(gerritCause),
+                isA(Action.class),
+                isA(Action.class),
+                isA(Action.class),
+                isA(Action.class));
+    }
+
+    /**
+     * Tests the schedule method of GerritTrigger.
+     * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
+     * gets called with an negative buildScheduleDelay -20.
+     */
+    @Test
+    public void testScheduleWithNoBuildScheduleDelay() {
+        AbstractProject project = PowerMockito.mock(AbstractProject.class);
+        when(project.getFullDisplayName()).thenReturn("MockedProject");
+        when(project.getFullName()).thenReturn("MockedProject");
+        PowerMockito.mockStatic(PluginImpl.class);
+        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
+        GerritServer server = mock(GerritServer.class);
+        when(plugin.getServer(any(String.class))).thenReturn(server);
+        IGerritHudsonTriggerConfig config = Setup.createConfig();
+        config = spy(config);
+        doReturn("http://mock.url").when(config).getGerritFrontEndUrlFor(any(String.class), any(String.class));
+        when(server.getConfig()).thenReturn(config);
+        GerritHandler handler = mock(GerritHandler.class);
+        when(plugin.getHandler()).thenReturn(handler);
+        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
+        when(config.getBuildScheduleDelay()).thenReturn(0);
+
+        GerritTrigger trigger = Setup.createDefaultTrigger(project);
+        when(project.getTrigger(GerritTrigger.class)).thenReturn(trigger);
+        PatchsetCreated event = Setup.createPatchsetCreated();
+        GerritCause gerritCause = new GerritCause(event, true);
+        gerritCause = spy(gerritCause);
+        doReturn("http://mock.url").when(gerritCause).getUrl();
+        trigger.schedule(gerritCause, event);
+        verify(project).scheduleBuild2(
+                eq(0),
                 same(gerritCause),
                 isA(Action.class),
                 isA(Action.class),


### PR DESCRIPTION
When using Replication Events, a build schedule delay is not needed since the build will only start once the replication is complete. This PR removes the minimum value 3 seconds BUT keeps the 3 seconds as the default when no value is entered for Build Schedule Delay. 
