### PR TITLE
Fix NPE for ChangeIdAnnotator

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/ChangeIdAnnotator.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/ChangeIdAnnotator.java
@@ -23,6 +23,7 @@ public class ChangeIdAnnotator extends ChangeLogAnnotator {
         for (SubText token : text.findTokens(CHANGE_ID)) {
             GerritCause gerritCause = build.getCause(GerritCause.class);
             if (gerritCause != null
+                && gerritCause.getEvent() != null
                 && gerritCause.getEvent().getProvider() != null
                 && gerritCause.getEvent().getProvider().getUrl() != null
                 && !gerritCause.getEvent().getProvider().getUrl().trim().isEmpty()) {


### PR DESCRIPTION
Check whether gerritCause.getEvent() returns null or not.

Fix for JENKINS-22634
https://issues.jenkins-ci.org/browse/JENKINS-22634
