### PR TITLE
Fix tests

### DIFF
--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritAdministrativeMonitorTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritAdministrativeMonitorTest.java
@@ -74,6 +74,7 @@ public class GerritAdministrativeMonitorTest {
     @Test
     public void testIsSendQueueWarningWithUnderThreshold() throws Exception {
         GerritAdministrativeMonitor monitor = new GerritAdministrativeMonitor();
+        monitor = spy(monitor);
         when(monitor.getSendQueueSize()).thenReturn(GerritSendCommandQueue.SEND_QUEUE_SIZE_WARNING_THRESHOLD - 1);
         assertFalse(monitor.isSendQueueWarning());
     }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersHudsonTestCase.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersHudsonTestCase.java
@@ -79,7 +79,9 @@ public class DuplicateGerritListenersHudsonTestCase extends HudsonTestCase {
             getServer(PluginImpl.DEFAULT_SERVER_NAME), GerritHandler.class);
         Collection<GerritEventListener> gerritEventListeners =
                 Whitebox.getInternalState(handler, "gerritEventListeners");
-        assertEquals(2, gerritEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(3, gerritEventListeners.size());
     }
 
     /**
@@ -95,7 +97,9 @@ public class DuplicateGerritListenersHudsonTestCase extends HudsonTestCase {
             getServer(PluginImpl.DEFAULT_SERVER_NAME), GerritHandler.class);
         Collection<GerritEventListener> gerritEventListeners =
                 Whitebox.getInternalState(handler, "gerritEventListeners");
-        assertEquals(2, gerritEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(3, gerritEventListeners.size());
     }
 
     /**
@@ -117,7 +121,9 @@ public class DuplicateGerritListenersHudsonTestCase extends HudsonTestCase {
             getServer(PluginImpl.DEFAULT_SERVER_NAME), GerritHandler.class);
         Collection<GerritEventListener> gerritEventListeners =
                 Whitebox.getInternalState(handler, "gerritEventListeners");
-        assertEquals(2, gerritEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(3, gerritEventListeners.size());
     }
 
     /**
@@ -141,7 +147,9 @@ public class DuplicateGerritListenersHudsonTestCase extends HudsonTestCase {
         assertNull(connection);
         Collection<GerritEventListener> savedEventListeners =
                 Whitebox.getInternalState(handler, "gerritEventListeners");
-        assertEquals(2, savedEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(3, savedEventListeners.size());
         Config config = (Config)server.getConfig();
         config.setGerritAuthKeyFile(keyFile.getPublicKey());
         config.setGerritHostName("localhost");
@@ -153,7 +161,9 @@ public class DuplicateGerritListenersHudsonTestCase extends HudsonTestCase {
         handler = Whitebox.getInternalState(server, GerritHandler.class);
         Collection<GerritEventListener> gerritEventListeners =
                 Whitebox.getInternalState(handler, "gerritEventListeners");
-        assertEquals(2, gerritEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(3, gerritEventListeners.size());
         connection = Whitebox.getInternalState(server, GerritConnection.class);
         assertNotNull(connection);
     }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersPreloadedProjectHudsonTestCase.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersPreloadedProjectHudsonTestCase.java
@@ -61,7 +61,9 @@ public class DuplicateGerritListenersPreloadedProjectHudsonTestCase extends Huds
             getServer(PluginImpl.DEFAULT_SERVER_NAME), GerritHandler.class);
         Collection<GerritEventListener> gerritEventListeners =
                 Whitebox.getInternalState(handler, "gerritEventListeners");
-        assertEquals(2, gerritEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(3, gerritEventListeners.size());
     }
 
     /**
@@ -77,7 +79,9 @@ public class DuplicateGerritListenersPreloadedProjectHudsonTestCase extends Huds
             getServer(PluginImpl.DEFAULT_SERVER_NAME), GerritHandler.class);
         Collection<GerritEventListener> gerritEventListeners =
                 Whitebox.getInternalState(handler, "gerritEventListeners");
-        assertEquals(3, gerritEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(4, gerritEventListeners.size());
     }
 
     /**
@@ -92,8 +96,12 @@ public class DuplicateGerritListenersPreloadedProjectHudsonTestCase extends Huds
             getServer(PluginImpl.DEFAULT_SERVER_NAME), GerritHandler.class);
         Collection<GerritEventListener> gerritEventListeners =
                 Whitebox.getInternalState(handler, "gerritEventListeners");
-        assertEquals(3, gerritEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(4, gerritEventListeners.size());
         configRoundtrip((Item)p);
-        assertEquals(3, gerritEventListeners.size()); //ReplicationQueueTaskDispatcher adds 1 listener
+        // DependencyQueueTaskDispatcher adds 1 listener
+        // ReplicationQueueTaskDispatcher adds 1 listener
+        assertEquals(4, gerritEventListeners.size());
     }
 }


### PR DESCRIPTION
- Missing spy object in GerritAdministrativeMonitorTest
- DependencyQueueTaskDispatcher addes 1 listener
