### PR TITLE
Set optional flag to GerritTriggerBuildChooser extension

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
@@ -189,7 +189,7 @@ public class GerritTriggerBuildChooser extends BuildChooser {
     /**
      * Descriptor for GerritTriggerBuildChooser.
      */
-    @Extension
+    @Extension(optional = true)
     public static final class DescriptorImpl extends BuildChooserDescriptor {
         @Override
         public String getDisplayName() {


### PR DESCRIPTION
Git plugin is optional, So any loading error should not be logged.

Fix for JENKINS-22813: Warning when clean install and restart 
https://issues.jenkins-ci.org/browse/JENKINS-22813
