### PR TITLE
Reduce level from info to debug

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcher.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcher.java
@@ -92,7 +92,7 @@ public class DependencyQueueTaskDispatcher extends QueueTaskDispatcher
         } else {
             gerritHandler.addListener(this);
         }
-        logger.info("Registered to gerrit events");
+        logger.debug("Registered to gerrit events");
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcher.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcher.java
@@ -83,7 +83,7 @@ public class ReplicationQueueTaskDispatcher extends QueueTaskDispatcher implemen
         blockedItems = new ConcurrentHashMap<Integer, BlockedItem>();
         this.replicationCache = replicationCache;
         gerritHandler.addListener(this);
-        logger.info("Registered to gerrit events");
+        logger.debug("Registered to gerrit events");
     }
 
     @Override


### PR DESCRIPTION
In constructor of DependencyQueueTaskDispatcher and
ReplicationQueueTaskDispatcher.

Fix for JENKINS-22814: Some infomations are logged from constructor on
startup 
https://issues.jenkins-ci.org/browse/JENKINS-22814
