### PR TITLE
Get gerrit events from RabbitMQ as message queue service

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -84,6 +84,12 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>rabbitmq-consumer</artifactId>
+            <version>2.2</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
             <version>2.0</version>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImpl.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImpl.java
@@ -1,0 +1,125 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2014 rinrinne a.k.a. rin_ne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.impls;
+
+import hudson.Extension;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
+import org.jenkinsci.plugins.rabbitmqconsumer.extensions.MessageQueueListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.api.GerritTriggerApi;
+import com.sonymobile.tools.gerrit.gerritevents.Handler;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
+
+/**
+ * A listener for gerrit events as RabbitMQ message.
+ *
+ * @author rinrinne a.k.a. rin_ne (rinrin.ne@gmail.com)
+ */
+@Extension(optional = true)
+public class RabbitMQMessageListenerImpl extends MessageQueueListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(RabbitMQMessageListenerImpl.class);
+
+    private static final String PLUGIN_NAME = "Gerrit Trigger";
+    private static final String PLUGIN_APPID = "gerrit";
+    private static final String JSON_CONTENTTYPE = "application/json";
+
+    private static final String GERRIT_NAME      = "gerrit-name";
+    private static final String GERRIT_HOST      = "gerrit-host";
+    private static final String GERRIT_SCHEME    = "gerrit-scheme";
+    private static final String GERRIT_PORT      = "gerrit-port";
+    private static final String GERRIT_FRONT_URL = "gerrit-front-url";
+    private static final String GERRIT_VERSION   = "gerrit-version";
+
+    private GerritTriggerApi api = null;
+    private Set<String> queueNames = new CopyOnWriteArraySet<String>();
+
+    @Override
+    public String getName() {
+        return PLUGIN_NAME;
+    }
+
+    @Override
+    public String getAppId() {
+        return PLUGIN_APPID;
+    }
+
+    @Override
+    public void onBind(String queueName) {
+        logger.info("Binded to " + queueName);
+        queueNames.add(queueName);
+    }
+
+    @Override
+    public void onUnbind(String queueName) {
+        logger.info("Unbinded from " + queueName);
+        queueNames.remove(queueName);
+    }
+
+    @Override
+    public void onReceive(String queueName, String contentType, Map<String, Object> headers, byte[] body) {
+        if (queueNames.contains(queueName) && JSON_CONTENTTYPE.equals(contentType)) {
+            logger.debug("Message received.");
+            Provider provider = new Provider();
+            if (headers != null) {
+                if (headers.containsKey(GERRIT_NAME)) {
+                    provider.setName((String)headers.get(GERRIT_NAME));
+                }
+                if (headers.containsKey(GERRIT_HOST)) {
+                    provider.setHost((String)headers.get(GERRIT_HOST));
+                }
+                if (headers.containsKey(GERRIT_SCHEME)) {
+                    provider.setScheme((String)headers.get(GERRIT_SCHEME));
+                }
+                if (headers.containsKey(GERRIT_PORT)) {
+                    provider.setPort((String)headers.get(GERRIT_PORT));
+                }
+                if (headers.containsKey(GERRIT_FRONT_URL)) {
+                    provider.setUrl((String)headers.get(GERRIT_FRONT_URL));
+                }
+                if (headers.containsKey(GERRIT_VERSION)) {
+                    provider.setVersion((String)headers.get(GERRIT_VERSION));
+                }
+            }
+
+            if (api == null) {
+                api = new GerritTriggerApi();
+            }
+            try {
+                Handler handler = api.getHandler();
+                handler.post(new String(body, "UTF-8"), provider);
+            } catch (Exception ex) {
+                logger.warn("No handler for Gerrit Trigger. Message would be lost.");
+            }
+        } else {
+            logger.debug("Message from unknown queue or unknown content type. This will be discarded.");
+        }
+    }
+}

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImplTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImplTest.java
@@ -1,0 +1,222 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2014 Ericsson.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.impls;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.Assert.fail;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.doReturn;
+import static org.powermock.api.mockito.PowerMockito.doThrow;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.api.GerritTriggerApi;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.api.exception.PluginNotFoundException;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.api.exception.PluginStatusException;
+import com.sonymobile.tools.gerrit.gerritevents.Handler;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
+
+//CS IGNORE MagicNumber FOR NEXT 1000 LINES. REASON: testdata.
+/**
+ * Tests {@link com.sonyericsson.hudson.plugins.gerrit.trigger.impls.RabbitMQMessageListenerImpl}.
+ *
+ * @author rinrinne a.k.a. rin_ne (rinrin.ne@gmail.com)
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest(GerritTriggerApi.class)
+public class RabbitMQMessageListenerImplTest {
+
+    GerritTriggerApi apiMock = mock(GerritTriggerApi.class);
+
+    /**
+     * Tests if received event.
+     *
+     * @throws PluginNotFoundException throw if plugin is not found.
+     * @throws PluginStatusException throw if plugin status is wrong.
+     */
+    @Test
+    public void onReceiveTest() throws PluginNotFoundException, PluginStatusException {
+        Handler handlerMock = mock(Handler.class);
+        doReturn(handlerMock).when(apiMock).getHandler();
+
+        RabbitMQMessageListenerImpl listener = new RabbitMQMessageListenerImpl();
+        Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
+        listener.onBind("TEST");
+        listener.onReceive("TEST", "application/json", null, "test message".getBytes());
+        verify(handlerMock).post("test message", new Provider(null, null, null, null, null, null));
+    }
+
+    /**
+     * Tests if received event with header.
+     *
+     * @throws PluginNotFoundException throw if plugin is not found.
+     * @throws PluginStatusException throw if plugin status is wrong.
+     */
+    @Test
+    public void onReceiveWithHeaderTest() throws PluginNotFoundException, PluginStatusException {
+        Handler handlerMock = mock(Handler.class);
+        doReturn(handlerMock).when(apiMock).getHandler();
+
+        RabbitMQMessageListenerImpl listener = new RabbitMQMessageListenerImpl();
+        Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
+
+        Map<String, Object> header = new HashMap<String, Object>();
+        header.put("gerrit-name", "gerrit1");
+        header.put("gerrit-host", "gerrit1.localhost");
+        header.put("gerrit-port", "29418");
+        header.put("gerrit-scheme", "ssh");
+        header.put("gerrit-front-url", "http://gerrit1.localhost");
+        header.put("gerrit-version", "2.8.4");
+
+        listener.onBind("TEST");
+        listener.onReceive("TEST", "application/json", header, "test message".getBytes());
+        verify(handlerMock).post(
+                "test message",
+                new Provider(
+                        (String)header.get("gerrit-name"),
+                        (String)header.get("gerrit-host"),
+                        (String)header.get("gerrit-port"),
+                        (String)header.get("gerrit-scheme"),
+                        (String)header.get("gerrit-front-url"),
+                        (String)header.get("gerrit-version")));
+    }
+
+    /**
+     * Tests if received event from unknown queue.
+     *
+     * @throws PluginNotFoundException throw if plugin is not found.
+     * @throws PluginStatusException throw if plugin status is wrong.
+     */
+    @Test
+    public void onReceiveFromUnknownQueueTest() throws PluginNotFoundException, PluginStatusException {
+        Handler handlerMock = mock(Handler.class);
+        doReturn(handlerMock).when(apiMock).getHandler();
+
+        RabbitMQMessageListenerImpl listener = new RabbitMQMessageListenerImpl();
+        Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
+
+        listener.onBind("TEST");
+        listener.onReceive("OTHER", "application/json", null, "test message".getBytes());
+        verify(handlerMock, never()).post(anyString(), any(Provider.class));
+    }
+
+    /**
+     * Tests if received message with unknown content type.
+     *
+     * @throws PluginNotFoundException throw if plugin is not found.
+     * @throws PluginStatusException throw if plugin status is wrong.
+     */
+    @Test
+    public void onReceiveWithUnknownContentTypeTest() throws PluginNotFoundException, PluginStatusException {
+        Handler handlerMock = mock(Handler.class);
+        doReturn(handlerMock).when(apiMock).getHandler();
+
+        RabbitMQMessageListenerImpl listener = new RabbitMQMessageListenerImpl();
+        Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
+
+        listener.onBind("TEST");
+        listener.onReceive("TEST", "text/plain", null, "test message".getBytes());
+        verify(handlerMock, never()).post(anyString(), any(Provider.class));
+    }
+
+    /**
+     * Tests if received message after unbind queue.
+     *
+     * @throws PluginNotFoundException throw if plugin is not found.
+     * @throws PluginStatusException throw if plugin status is wrong.
+     */
+    @Test
+    public void onReceiveAfterUnbindTest() throws PluginNotFoundException, PluginStatusException {
+        Handler handlerMock = mock(Handler.class);
+        doReturn(handlerMock).when(apiMock).getHandler();
+
+        RabbitMQMessageListenerImpl listener = new RabbitMQMessageListenerImpl();
+        Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
+
+        listener.onBind("TEST");
+        listener.onReceive("TEST", "application/json", null, "test message".getBytes());
+
+        listener.onUnbind("TEST");
+        listener.onReceive("TEST", "application/json", null, "test message2".getBytes());
+        verify(handlerMock, times(1)).post(eq("test message"), any(Provider.class));
+        verify(handlerMock, never()).post(eq("test message2"), any(Provider.class));
+    }
+
+    /**
+     * Tests if received message with
+     * {@link com.sonyericsson.hudson.plugins.gerrit.trigger.api.exception.PluginNotFoundException}.
+     *
+     * @throws PluginNotFoundException throw if plugin is not found.
+     * @throws PluginStatusException throw if plugin status is wrong.
+     */
+    @Test
+    public void onReceiveWithPluginNotFoundException() throws PluginNotFoundException, PluginStatusException {
+        doThrow(new PluginNotFoundException()).when(apiMock).getHandler();
+
+        RabbitMQMessageListenerImpl listener = new RabbitMQMessageListenerImpl();
+        Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
+
+        listener.onBind("TEST");
+        try {
+            listener.onReceive("TEST", "application/json", null, "test message".getBytes());
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+
+    /**
+     * Tests if received message with
+     * {@link com.sonyericsson.hudson.plugins.gerrit.trigger.api.exception.PluginStatusException}.
+     *
+     * @throws PluginNotFoundException throw if plugin is not found.
+     * @throws PluginStatusException throw if plugin status is wrong.
+     */
+    @Test
+    public void onReceiveWithPluginStatusException() throws PluginNotFoundException, PluginStatusException {
+        doThrow(new PluginStatusException()).when(apiMock).getHandler();
+
+        RabbitMQMessageListenerImpl listener = new RabbitMQMessageListenerImpl();
+        Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
+
+        listener.onBind("TEST");
+        try {
+            listener.onReceive("TEST", "application/json", null, "test message".getBytes());
+        } catch (Exception ex) {
+            fail();
+        }
+    }
+}


### PR DESCRIPTION
This patch adds implementation of MessageQueueListener extension in
RabbitMQ Consumer Plugin.

https://wiki.jenkins-ci.org/display/JENKINS/RabbitMQ+Consumer+Plugin

Using this feature, we can trigger job by gerrit event in message queue.

At first, I had plan to release this as independent plugin. But after some study,
I concluded that it should be implemented to this plugin.
- Very simple code
- Optional flags to ignore NoClassDefException related to other plugins
  - No impact if those are not installed

So I would be glad if you merge this.
