### PR TITLE
Add option to exclude drafts when triggering on patchset created event.

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -512,7 +512,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
             return false;
         }
         for (PluginGerritEvent e : triggerOnEvents) {
-            if (e.getCorrespondingEventClass().isInstance(event)) {
+            if (e.shouldTriggerOn(event)) {
                 return true;
             }
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginGerritEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginGerritEvent.java
@@ -24,6 +24,7 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events;
 
 
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.Descriptor;
 
@@ -33,12 +34,23 @@ import hudson.model.Descriptor;
  */
 public abstract class PluginGerritEvent extends AbstractDescribableImpl<PluginGerritEvent> {
 
-       /**
+    /**
      * Getter for the corresponding gerrit event class.
      * @return the gerrit event class.
      */
     public abstract Class getCorrespondingEventClass();
 
+    /**
+     * Return if it should trigger build for the specified event.
+     * Default implementation only check if the specified event is an instance of the corresponding event class.
+     * Sub class can override to add additional validation.
+     *
+     * @param event The event to validate.
+     * @return true if it should trigger on the specified event, otherwise false.
+     */
+    public boolean shouldTriggerOn(GerritTriggeredEvent event) {
+        return getCorrespondingEventClass().isInstance(event);
+    }
 
     /**
      * The Descriptor for the PluginGerritEvent.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -23,6 +23,7 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events;
 
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
 import hudson.Extension;
@@ -39,11 +40,22 @@ import java.io.Serializable;
 public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Serializable {
     private static final long serialVersionUID = 970946986242309088L;
 
+    private boolean excludeDrafts = false;
+
+    /**
+     * Default constructor.
+     */
+    public PluginPatchsetCreatedEvent() {
+        this(false);
+    }
+
     /**
      * Standard DataBoundConstructor.
+     * @param excludeDrafts if drafts should be excluded or not.
      */
     @DataBoundConstructor
-    public PluginPatchsetCreatedEvent() {
+    public PluginPatchsetCreatedEvent(boolean excludeDrafts) {
+        this.excludeDrafts = excludeDrafts;
     }
 
     /**
@@ -57,6 +69,25 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
     @Override
     public Class getCorrespondingEventClass() {
         return PatchsetCreated.class;
+    }
+
+    /**
+     * Getter for the excludeDrafts field.
+     * @return excludeDrafts
+     */
+    public boolean isExcludeDrafts() {
+        return excludeDrafts;
+    }
+
+    @Override
+    public boolean shouldTriggerOn(GerritTriggeredEvent event) {
+        if (!super.shouldTriggerOn(event)) {
+            return false;
+        }
+        if (excludeDrafts && ((PatchsetCreated)event).getPatchSet().isDraft()) {
+            return false;
+        }
+        return true;
     }
 
     /**

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
@@ -21,5 +21,9 @@
   ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
   ~ THE SOFTWARE.
   -->
-<j:jelly xmlns:j="jelly:core">
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Exclude Drafts}"
+             field="excludeDrafts">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
@@ -1,0 +1,48 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.event;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+
+/**
+ * Tests for {@link PluginPatchsetCreatedEvent}.
+ *
+ * @author Hugo Arès &lt;hugo.ares@ericsson.com&gt;
+ */
+public class PluginPatchsetCreatedEventTest {
+
+    /**
+     * Tests that it should fire on all type of patchset.
+     */
+    @Test
+    public void shouldFireOnAllTypeOfPatchset() {
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false);
+        PatchsetCreated patchsetCreated = new PatchsetCreated();
+        patchsetCreated.setPatchset(new PatchSet());
+
+        //should fire on regular patchset and drafts
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+        patchsetCreated.getPatchSet().setDraft(true);
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+    }
+
+    /**
+     * Tests that it should not fire on draft patchset when they are excluded.
+     */
+    @Test
+    public void shouldNotFireOnDraftPatchsetWhenExcluded() {
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true);
+        PatchsetCreated patchsetCreated = new PatchsetCreated();
+        patchsetCreated.setPatchset(new PatchSet());
+
+        //should fire only on regular patchset (no drafts)
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+        patchsetCreated.getPatchSet().setDraft(true);
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+    }
+}


### PR DESCRIPTION
Gerrit support draft changes and draft patchsets. Gerrit Trigger was able
to trigger a build when a draft change is published (transitioned from draft to
regular change) but it was missing an option to allow user to exclude draft
patchsets when triggering on patchset created event.

This change add a checkbox in the patchset created type of trigger to exclude
draft patchsets. By default, this option is not enabled to be compatible with behaviour
prior to this change.
