### PR TITLE
Copy REST API config

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -933,7 +933,11 @@ public class Config implements IGerritHudsonTriggerConfig {
 
     @Override
     public String getGerritHttpPassword() {
-        return Secret.toString(gerritHttpPassword);
+        if (gerritHttpPassword != null) {
+            return Secret.toString(gerritHttpPassword);
+        } else {
+            return "";
+        }
     }
 
     /**


### PR DESCRIPTION
This patch copies config for REST API when create new server by copying
existing server.

Fix for JENKINS-23189
