### PR TITLE
Copy REST API setting

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -200,6 +200,9 @@ public class Config implements IGerritHudsonTriggerConfig {
         notificationLevel = config.getNotificationLevel();
         gerritAuthKeyFile = new File(config.getGerritAuthKeyFile().getPath());
         gerritAuthKeyFilePassword = config.getGerritAuthKeyFilePassword();
+        useRestApi = config.isUseRestApi();
+        gerritHttpUserName = config.getGerritHttpUserName();
+        gerritHttpPassword = Secret.fromString(config.getGerritHttpPassword());
         gerritBuildCurrentPatchesOnly = config.isGerritBuildCurrentPatchesOnly();
         numberOfWorkerThreads = config.getNumberOfReceivingWorkerThreads();
         numberOfSendingWorkerThreads = config.getNumberOfSendingWorkerThreads();
@@ -930,7 +933,11 @@ public class Config implements IGerritHudsonTriggerConfig {
 
     @Override
     public String getGerritHttpPassword() {
-        return Secret.toString(gerritHttpPassword);
+        if (gerritHttpPassword == null) {
+            return "";
+        } else {
+            return gerritHttpPassword.getPlainText();
+        }
     }
 
     /**
@@ -960,7 +967,11 @@ public class Config implements IGerritHudsonTriggerConfig {
 
     @Override
     public Credentials getHttpCredentials() {
-        return new UsernamePasswordCredentials(gerritHttpUserName, Secret.toString(gerritHttpPassword));
+        if (gerritHttpPassword == null) {
+            return new UsernamePasswordCredentials(gerritHttpUserName, "");
+        } else {
+            return new UsernamePasswordCredentials(gerritHttpUserName, gerritHttpPassword.getPlainText());
+        }
     }
 
 }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ConfigTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ConfigTest.java
@@ -31,7 +31,9 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.Setup;
 import net.sf.json.JSONObject;
 import net.sf.json.JSONSerializer;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
 
 import java.io.File;
 
@@ -42,6 +44,13 @@ import static org.junit.Assert.assertEquals;
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
 public class ConfigTest {
+
+    /**
+     * Jenkins rule instance.
+     */
+    // CS IGNORE VisibilityModifier FOR NEXT 3 LINES. REASON: Mocks tests.
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     //CS IGNORE MagicNumber FOR NEXT 100 LINES. REASON: Mocks tests.
 
@@ -77,6 +86,7 @@ public class ConfigTest {
                 + "\"gerritSshPort\":\"1337\","
                 + "\"gerritProxy\":\"\","
                 + "\"gerritUserName\":\"gerrit\","
+                + "\"useRestApi\":{\"gerritHttpUserName\":\"httpgerrit\",\"gerritHttpPassword\":\"httppass\"},"
                 + "\"numberOfSendingWorkerThreads\":\"4\","
                 + "\"numberOfReceivingWorkerThreads\":\"6\","
                 + "\"notificationLevel\":\"OWNER\"}";
@@ -115,6 +125,9 @@ public class ConfigTest {
         assertEquals(1337, config.getGerritSshPort());
         assertEquals("", config.getGerritProxy());
         assertEquals("gerrit", config.getGerritUserName());
+        assertEquals(true, config.isUseRestApi());
+        assertEquals("httpgerrit", config.getGerritHttpUserName());
+        assertEquals("httppass", config.getGerritHttpPassword());
         assertEquals(6, config.getNumberOfReceivingWorkerThreads());
         assertEquals(4, config.getNumberOfSendingWorkerThreads());
         assertEquals(Notify.OWNER, config.getNotificationLevel());
@@ -154,6 +167,7 @@ public class ConfigTest {
                 + "\"gerritSshPort\":\"1337\","
                 + "\"gerritProxy\":\"\","
                 + "\"gerritUserName\":\"gerrit\","
+                + "\"useRestApi\":{\"gerritHttpUserName\":\"httpgerrit\",\"gerritHttpPassword\":\"httppass\"},"
                 + "\"numberOfSendingWorkerThreads\":\"4\","
                 + "\"numberOfReceivingWorkerThreads\":\"6\"}";
         JSONObject form = (JSONObject)JSONSerializer.toJSON(formString);
@@ -192,6 +206,9 @@ public class ConfigTest {
         assertEquals(1337, config.getGerritSshPort());
         assertEquals("", config.getGerritProxy());
         assertEquals("gerrit", config.getGerritUserName());
+        assertEquals(true, config.isUseRestApi());
+        assertEquals("httpgerrit", config.getGerritHttpUserName());
+        assertEquals("httppass", config.getGerritHttpPassword());
         assertEquals(6, config.getNumberOfReceivingWorkerThreads());
         assertEquals(4, config.getNumberOfSendingWorkerThreads());
     }


### PR DESCRIPTION
when create new server by copying existing ones, REST API settings are
not copied.

This patch can copy REST API settings.

As a side note, Secret.fromString() calls Jenkins instance to use
confidencial key. So ConfigTest have to use it.

Fix for JENKINS-23189
