### PR TITLE
Update to filter ChangeKind in PatchsetCreatedEvents

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.0.1</version>
+            <version>2.1.0</version>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
         </dependency>
         <dependency>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
@@ -26,4 +26,14 @@
              field="excludeDrafts">
         <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Exclude Trivial Rebase}"
+             field="excludeTrivialRebase"
+             help="/plugin/gerrit-trigger/trigger/help-ExcludeTrivialRebase.html">
+        <f:checkbox/>
+    </f:entry>
+    <f:entry title="${%Exclude No Code Change}"
+             field="excludeNoCodeChange"
+             help="/plugin/gerrit-trigger/trigger/help-ExcludeNoCodeChange.html">
+        <f:checkbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/webapp/trigger/help-ExcludeNoCodeChange.html
+++ b/src/main/webapp/trigger/help-ExcludeNoCodeChange.html
@@ -1,0 +1,9 @@
+<p>
+    Exclude changes without code change from triggering build
+</p>
+<p>
+    If set, this will ignore any patchset which Gerrit considers without any
+    code changes from triggering this build.  These patches did not contain any
+    differences in code from the previous patchset and did not change the parent
+    commit.
+</p>

--- a/src/main/webapp/trigger/help-ExcludeTrivialRebase.html
+++ b/src/main/webapp/trigger/help-ExcludeTrivialRebase.html
@@ -1,0 +1,8 @@
+<p>
+    Exclude trivial rebases from triggering build
+</p>
+<p>
+    If set, this will ignore any patchset which Gerrit considers a &quot;trivial
+    rebase&quot; from triggering this build.  These patches were able to be
+    rebased without conflict by Gerrit.
+</p>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Test;
 
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 
@@ -21,7 +22,7 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldFireOnAllTypeOfPatchset() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false);
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false, false, false);
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
 
@@ -36,13 +37,45 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldNotFireOnDraftPatchsetWhenExcluded() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true);
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, false, false);
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
 
         //should fire only on regular patchset (no drafts)
         assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
         patchsetCreated.getPatchSet().setDraft(true);
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+    }
+
+    /**
+     * Tests that it should not fire on trivial rebase when they are excluded.
+     * @author Doug Kelly &lt;dougk.ff7@gmail.com&gt;
+     */
+    @Test
+    public void shouldNotFireOnTrivialRebaseWhenExcluded() {
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false, true, false);
+        PatchsetCreated patchsetCreated = new PatchsetCreated();
+        patchsetCreated.setPatchset(new PatchSet());
+
+        //should fire only on regular patchset (no drafts)
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+        patchsetCreated.getPatchSet().setKind(GerritChangeKind.TRIVIAL_REBASE);
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+    }
+
+    /**
+     * Tests that it should not fire on no code changes when they are excluded.
+     * @author Doug Kelly &lt;dougk.ff7@gmail.com&gt;
+     */
+    @Test
+    public void shouldNotFireOnNoCodeChangeWhenExcluded() {
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false, false, true);
+        PatchsetCreated patchsetCreated = new PatchsetCreated();
+        patchsetCreated.setPatchset(new PatchSet());
+
+        //should fire only on regular patchset (no drafts)
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+        patchsetCreated.getPatchSet().setKind(GerritChangeKind.NO_CODE_CHANGE);
         assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
     }
 }


### PR DESCRIPTION
ChangeKind is now exposed by Gerrit, which gives Jenkins the ability
to filter for changes that are trivial rebases or changes that do not
impact code.

Depends on https://github.com/sonyxperiadev/gerrit-events/pull/17
