### PR TITLE
Warn about missing SSH 'notify' parameters

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -51,6 +51,7 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.ArrayList;
 import java.util.Calendar;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -107,6 +108,7 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.UnreviewedPa
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritSlave;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.version.GerritVersionChecker;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.version.GerritVersionChecker.Feature;
 
 /**
  * Every instance of this class represents a Gerrit server having its own unique name,
@@ -1050,6 +1052,64 @@ public class GerritServer implements Describable<GerritServer>, Action {
             }
         }
         return new LinkedList<GerritVersionChecker.Feature>();
+    }
+
+    /**
+     * @return whether any version-related warnings exist
+     */
+    public boolean hasVersionWarnings() {
+        return warnAboutMissingNotifyParameter();
+    }
+
+    /**
+     * @return the list for version-related warnings
+     */
+    public List<String> getVersionWarnings() {
+        if (warnAboutMissingNotifyParameter()) {
+            return Collections.singletonList(Messages.NotificationSshParameterMissing(
+                    Feature.notifyParameterInSSH.getDisplayName(), "--notify ALL",
+                    getConfig().getGerritFrontEndUrlForDocumentation("cmd-review.html")));
+        }
+        return Collections.emptyList();
+    }
+
+    /**
+     * Returns whether we should warn about the 'notify' SSH parameter not being present in
+     * the review commands.  Its absence will lead to no emails being sent in Gerrit 2.9 and above.
+     *
+     * @return whether there should be a warning
+     */
+    private boolean warnAboutMissingNotifyParameter() {
+        if (gerritConnectionListener.isConnected()
+                && gerritConnectionListener.supportsFeature(Feature.notifyParameterInSSH)) {
+            IGerritHudsonTriggerConfig cfg = getConfig();
+            // presence of 'notify' in at least one command indicates the user has already taken action,
+            // so only warn if it doesn't appear in neither command
+            if (!atLeastOneContains("--notify",
+                    cfg.getGerritCmdBuildStarted(),
+                    cfg.getGerritCmdBuildSuccessful(),
+                    cfg.getGerritCmdBuildUnstable(),
+                    cfg.getGerritCmdBuildNotBuilt(),
+                    cfg.getGerritCmdBuildFailed())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Returns if any of the given strings contains the query string.
+     * @param query the string to look for
+     * @param strings the strings to search in
+     * @return true if any of the strings contains the query string
+     */
+    private static boolean atLeastOneContains(String query, String... strings) {
+        for (String string : strings) {
+            if (string.contains(query)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -53,6 +53,7 @@ import java.util.concurrent.TimeUnit;
 
 
 
+
 //CS IGNORE LineLength FOR NEXT 11 LINES. REASON: static import.
 import static com.sonymobile.tools.gerrit.gerritevents.GerritDefaultValues.DEFAULT_BUILD_SCHEDULE_DELAY;
 import static com.sonymobile.tools.gerrit.gerritevents.GerritDefaultValues.DEFAULT_DYNAMIC_CONFIG_REFRESH_INTERVAL;
@@ -838,6 +839,14 @@ public class Config implements IGerritHudsonTriggerConfig {
         if (event instanceof ChangeBasedEvent) {
             str.append(((ChangeBasedEvent)event).getChange().getNumber());
         }
+        return str.toString();
+    }
+
+    @Override
+    public String getGerritFrontEndUrlForDocumentation(String pathInDocumentation) {
+        StringBuilder str = new StringBuilder(getGerritFrontEndUrl());
+        str.append("Documentation/");
+        str.append(pathInDocumentation);
         return str.toString();
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
@@ -166,6 +166,13 @@ public interface IGerritHudsonTriggerConfig extends GerritConnectionConfig2 {
     String getGerritFrontEndUrlFor(GerritTriggeredEvent event);
 
     /**
+     * Creates a URL to the provided documentation document.
+     * @param pathInDocumentation the path below the 'Documentation' URL
+     * @return the documentation URL
+     */
+    String getGerritFrontEndUrlForDocumentation(String pathInDocumentation);
+
+    /**
      * Get the list of available VerdictCategories.
      * @return the list.
      */

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritConnectionListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritConnectionListener.java
@@ -49,6 +49,7 @@ public class GerritConnectionListener implements ConnectionListener {
     private boolean connected;
     private boolean gerritSnapshotVersion;
     private List<GerritVersionChecker.Feature> disabledFeatures;
+    private List<GerritVersionChecker.Feature> enabledFeatures;
 
     /**
      * Default constructor.
@@ -105,6 +106,16 @@ public class GerritConnectionListener implements ConnectionListener {
     }
 
     /**
+     * Whether the given feature is supported by the Gerrit version denoted by this connection.
+     *
+     * @param feature the feature in question
+     * @return supported or not
+     */
+    public boolean supportsFeature(GerritVersionChecker.Feature feature) {
+        return enabledFeatures.contains(feature);
+    }
+
+    /**
      * @see ConnectionListener#connectionEstablished()
      */
     @Override
@@ -145,13 +156,17 @@ public class GerritConnectionListener implements ConnectionListener {
         if (connected) {
             GerritVersionNumber version =
                     GerritVersionChecker.createVersionNumber(getVersionString());
-            List<GerritVersionChecker.Feature> list = new LinkedList<GerritVersionChecker.Feature>();
+            List<GerritVersionChecker.Feature> disabled = new LinkedList<GerritVersionChecker.Feature>();
+            List<GerritVersionChecker.Feature> enabled = new LinkedList<GerritVersionChecker.Feature>();
             for (GerritVersionChecker.Feature f : GerritVersionChecker.Feature.values()) {
-                if (!GerritVersionChecker.isCorrectVersion(version, f)) {
-                    list.add(f);
+                if (GerritVersionChecker.isCorrectVersion(version, f)) {
+                    enabled.add(f);
+                } else {
+                    disabled.add(f);
                 }
             }
-            disabledFeatures = list;
+            enabledFeatures = enabled;
+            disabledFeatures = disabled;
             gerritSnapshotVersion = version.isSnapshot();
         } else {
             disabledFeatures = null;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
@@ -56,7 +56,13 @@ public final class GerritVersionChecker {
         /**
          * Replication events, added in Gerrit 2.9.
          */
-        replicationEvents("Replication events", "2.9");
+        replicationEvents("Replication events", "2.9"),
+
+        /**
+         * 'notify' parameter for SSH review command, added in Gerrit 2.9.
+         * Note that 'notify' in REST API was added in Gerrit 2.8 already.
+         */
+        notifyParameterInSSH("'notify' SSH parameter", "2.9");
 
         private final String displayName;
         private final String version;
@@ -92,8 +98,6 @@ public final class GerritVersionChecker {
             return version;
         }
     }
-
-    ;
 
     /**
      * Private constructor to prevent instantiation of the util class.

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.jelly
@@ -20,4 +20,14 @@
             </ul>
         </div>
     </j:if>
+    <j:if test="${it.hasVersionWarnings()}">
+        <div class="warning">
+            ${%VersionWarning}
+            <ul>
+                <j:forEach items="${it.getVersionWarnings()}" var="warning">
+                    <li>${warning}</li>
+                </j:forEach>
+            </ul>
+        </div>
+    </j:if>
 </j:jelly>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.properties
@@ -8,3 +8,5 @@ DisabledFeaturesWarning=\
   The following features have been disabled:
 SpecificVersionRequiredWarning=\
   {0} requires {1}
+VersionWarning=\
+  Some configuration data can cause issues with this Gerrit version:

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -165,3 +165,5 @@ NotificationLevel_OWNER_REVIEWERS=\
  Owner and reviewers
 NotificationLevel_ALL=\
  All
+NotificationSshParameterMissing=\
+ {0} is missing in the review commands.  No review notification emails will we sent in this Gerrit version.  Add ''{1}'' to restore the original behavior.  See <a href="{2}" target="_blank">Gerrit documentation</a> for possible values.

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -232,6 +232,11 @@ public class MockGerritHudsonTriggerConfig implements
     }
 
     @Override
+    public String getGerritFrontEndUrlForDocumentation(String pathInDocumentation) {
+        return getGerritFrontEndUrl() + "Documentation/" + pathInDocumentation;
+    }
+
+    @Override
     public List<VerdictCategory> getCategories() {
         return new LinkedList<VerdictCategory>();
     }


### PR DESCRIPTION
Gerrit 2.9 supports '--notify' parameter in SSH review commands.
However, if the parameter is absent, it sends _no_ emails, causing
regressions with existing Jenkins server configurations.  This change
adds a warning if none of the commands contains '--notify' and the
server is 2.9 or higher.
