### PR TITLE
Wrong cast in RabbitMQ implementation

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImpl.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImpl.java
@@ -90,22 +90,22 @@ public class RabbitMQMessageListenerImpl extends MessageQueueListener {
             Provider provider = new Provider();
             if (headers != null) {
                 if (headers.containsKey(GERRIT_NAME)) {
-                    provider.setName((String)headers.get(GERRIT_NAME));
+                    provider.setName(headers.get(GERRIT_NAME).toString());
                 }
                 if (headers.containsKey(GERRIT_HOST)) {
-                    provider.setHost((String)headers.get(GERRIT_HOST));
+                    provider.setHost(headers.get(GERRIT_HOST).toString());
                 }
                 if (headers.containsKey(GERRIT_SCHEME)) {
-                    provider.setScheme((String)headers.get(GERRIT_SCHEME));
+                    provider.setScheme(headers.get(GERRIT_SCHEME).toString());
                 }
                 if (headers.containsKey(GERRIT_PORT)) {
-                    provider.setPort((String)headers.get(GERRIT_PORT));
+                    provider.setPort(headers.get(GERRIT_PORT).toString());
                 }
                 if (headers.containsKey(GERRIT_FRONT_URL)) {
-                    provider.setUrl((String)headers.get(GERRIT_FRONT_URL));
+                    provider.setUrl(headers.get(GERRIT_FRONT_URL).toString());
                 }
                 if (headers.containsKey(GERRIT_VERSION)) {
-                    provider.setVersion((String)headers.get(GERRIT_VERSION));
+                    provider.setVersion(headers.get(GERRIT_VERSION).toString());
                 }
             }
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImplTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImplTest.java
@@ -44,6 +44,7 @@ import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.doReturn;
 import static org.powermock.api.mockito.PowerMockito.doThrow;
 
+import com.rabbitmq.client.impl.LongStringHelper;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.api.GerritTriggerApi;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.api.exception.PluginNotFoundException;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.api.exception.PluginStatusException;
@@ -95,11 +96,11 @@ public class RabbitMQMessageListenerImplTest {
         Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
 
         Map<String, Object> header = new HashMap<String, Object>();
-        header.put("gerrit-name", "gerrit1");
-        header.put("gerrit-host", "gerrit1.localhost");
-        header.put("gerrit-port", "29418");
-        header.put("gerrit-scheme", "ssh");
-        header.put("gerrit-front-url", "http://gerrit1.localhost");
+        header.put("gerrit-name", LongStringHelper.asLongString("gerrit1"));
+        header.put("gerrit-host", LongStringHelper.asLongString("gerrit1.localhost"));
+        header.put("gerrit-port", LongStringHelper.asLongString("29418"));
+        header.put("gerrit-scheme", LongStringHelper.asLongString("ssh"));
+        header.put("gerrit-front-url", LongStringHelper.asLongString("http://gerrit1.localhost"));
         header.put("gerrit-version", "2.8.4");
 
         listener.onBind("TEST");
@@ -107,12 +108,12 @@ public class RabbitMQMessageListenerImplTest {
         verify(handlerMock).post(
                 "test message",
                 new Provider(
-                        (String)header.get("gerrit-name"),
-                        (String)header.get("gerrit-host"),
-                        (String)header.get("gerrit-port"),
-                        (String)header.get("gerrit-scheme"),
-                        (String)header.get("gerrit-front-url"),
-                        (String)header.get("gerrit-version")));
+                        header.get("gerrit-name").toString(),
+                        header.get("gerrit-host").toString(),
+                        header.get("gerrit-port").toString(),
+                        header.get("gerrit-scheme").toString(),
+                        header.get("gerrit-front-url").toString(),
+                        header.get("gerrit-version").toString()));
     }
 
     /**


### PR DESCRIPTION
Header values in RabbitMQ message is not String but library defined
ByteArray. So it cannot be cast.

Fix for JENKINS-24012

Task-Url: https://issues.jenkins-ci.org/browse/JENKINS-24012
