### PR TITLE
Add a trigger for comment containing a specified RegEx

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,7 +62,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.1.0</version>
+            <version>2.2.0</version>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
         </dependency>
         <dependency>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -55,6 +55,7 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritS
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.SkipVote;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.TriggerContext;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedContainsEvent;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginDraftPublishedEvent;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginGerritEvent;
@@ -908,7 +909,7 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
      * @param event the event.
      * @return true if the event matches the approval category and value configured.
      */
-    private boolean matchesApproval(CommentAdded event) {
+    private boolean commentAddedMatch(CommentAdded event) {
         PluginCommentAddedEvent commentAdded = null;
         for (PluginGerritEvent e : triggerOnEvents) {
             if (e instanceof PluginCommentAddedEvent) {
@@ -919,6 +920,11 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
                         || ("+" + approval.getValue()).equals(commentAdded.getCommentAddedTriggerApprovalValue()))) {
                     return true;
                     }
+                }
+            }
+            if (e instanceof PluginCommentAddedContainsEvent) {
+                if (((PluginCommentAddedContainsEvent)e).match(event)) {
+                    return true;
                 }
             }
         }
@@ -936,8 +942,8 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
             logger.trace("Already building.");
             return;
         }
-        if (isInteresting(event) && matchesApproval(event)) {
-            logger.trace("The event is interesting.");
+        if (isInteresting(event) && commentAddedMatch(event)) {
+            logger.info("The event is interesting.");
             notifyOnTriggered(event);
             schedule(new GerritCause(event, silentMode), event);
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedContainsEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedContainsEvent.java
@@ -1,0 +1,116 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2013 Criteo SA. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events;
+
+import hudson.Extension;
+
+import java.io.Serializable;
+import java.util.regex.Pattern;
+
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.CommentAdded;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+
+/**
+ * An event configuration that trigger the build when a comment is added and
+ * contains a message matching a configurable RegEx.
+ *
+ * @author Francois Visconte &lt;f.visconte@criteo.com&gt;
+ */
+public class PluginCommentAddedContainsEvent extends PluginGerritEvent
+        implements Serializable {
+
+    /**
+     * The descriptor for PluginCommentAddedContainsEvent.
+     */
+    @Extension
+    public static class PluginCommentAddedContainsEventDescriptor extends
+            PluginGerritEventDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.CommentAddedContainsDisplayName();
+        }
+    }
+
+    private static final long serialVersionUID = -1190562081236235820L;
+
+    private String commentAddedCommentContains;
+
+    private static final Logger logger = LoggerFactory
+            .getLogger(PluginCommentAddedContainsEvent.class);
+
+    /**
+     * Empty constructor for serializer.
+     */
+    public PluginCommentAddedContainsEvent() {
+    }
+
+    /**
+     * Standard DataBoundConstructor.
+     *
+     * @param commentAddedCommentContains a string containg a regular expression.
+     */
+    @DataBoundConstructor
+    public PluginCommentAddedContainsEvent(String commentAddedCommentContains) {
+        this.commentAddedCommentContains = commentAddedCommentContains;
+
+    }
+
+    /**
+     * Get the regular expression to match against comment.
+     * @return a string containg a regex.
+     */
+    public String getCommentAddedCommentContains() {
+        return commentAddedCommentContains;
+    }
+
+    /**
+     * Gets related event class.
+     * @return a Class
+     */
+    @Override
+    public Class getCorrespondingEventClass() {
+        return CommentAdded.class;
+    }
+
+    /**
+     * Check if the comment added match configured regular expression.
+     * @param event a GerritTriggeredEvent.
+     * @return true or false.
+     */
+    public boolean match(GerritTriggeredEvent event) {
+        if (!super.shouldTriggerOn(event)) {
+            return false;
+        }
+        Pattern p = Pattern
+                .compile(commentAddedCommentContains, Pattern.DOTALL);
+        CommentAdded ca = (CommentAdded)event;
+        return p.matcher(ca.getComment()).find();
+    }
+}

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -84,6 +84,8 @@ CommentAddedDisplayName=\
   Comment Added
 PatchsetCreatedDisplayName=\
   Patchset Created
+CommentAddedContainsDisplayName=\
+  Comment Added Contains Regular Expression
 DraftPublishedDisplayName=\
   Draft Published
 RefUpdatedDisplayName=\

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedContainsEvent/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedContainsEvent/config.jelly
@@ -1,0 +1,28 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+    <f:entry title="${%Value}" field="commentAddedCommentContains">
+        <f:textbox name="commentAddedCommentContains" field="commentAddedCommentContains"/>
+    </f:entry>
+</j:jelly>


### PR DESCRIPTION
This patch add a trigger that will trigger jenkins build on comment containing
a specified regular expression.

This can be usefull for user to specify a comment to run a build (eg.  Please test this )
