### PR TITLE
Don't trigger builds triggered by the same event

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
@@ -326,6 +326,21 @@ public class ToGerritRunListener extends RunListener<AbstractBuild> {
     }
 
     /**
+     * Checks the memory if the project is triggered by the event.
+     *
+     * @param project the project.
+     * @param event the event.
+     * @return true if so.
+     */
+    public boolean isTriggered(AbstractProject project, GerritTriggeredEvent event) {
+        if (project == null || event == null) {
+            return false;
+        } else {
+            return memory.isTriggered(event, project);
+        }
+    }
+
+    /**
      * Finds the GerritCause for a build if there is one.
      *
      * @param build the build to look in.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -835,6 +835,14 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
             return false;
         }
 
+        if (ToGerritRunListener.getInstance().isProjectTriggeredAndIncomplete(myProject, event)) {
+            logger.trace("Already triggered and imcompleted.");
+            return false;
+        } else if (ToGerritRunListener.getInstance().isTriggered(myProject, event)) {
+            logger.trace("Already triggered.");
+            return false;
+        }
+
         if (!shouldTriggerOnEventType(event)) {
             return false;
         }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
@@ -1057,7 +1057,7 @@ public class GerritTriggerTest {
 
         trigger.gerritEvent(event);
 
-        verifyZeroInteractions(listener);
+        verify(listener, never()).onTriggered(same(project), same(event));
         verify(project).isBuildable();
         verifyNoMoreInteractions(project);
     }
@@ -1129,7 +1129,7 @@ public class GerritTriggerTest {
 
         trigger.gerritEvent(event);
 
-        verifyNoMoreInteractions(listener);
+        verify(listener, never()).onTriggered(same(project), same(event));
 
         verify(project).scheduleBuild2(
                 anyInt(),
@@ -1167,7 +1167,7 @@ public class GerritTriggerTest {
 
         trigger.gerritEvent(event);
 
-        verifyNoMoreInteractions(listener);
+        verify(listener, never()).onTriggered(same(project), same(event));
 
         verify(project).scheduleBuild2(
                 anyInt(),


### PR DESCRIPTION
Now any builds are triggered even if existing builds triggerd by the same
event are running.

This patch prevents to trigger build according to the below policy:
- Project has triggered/running build triggered by the same event.
- The event trigger builds has still running build.

This would fix JENKINS-24445.

Fix for JENKINS-24445

Task-Url: https://issues.jenkins-ci.org/browse/JENKINS-24445
