### PR TITLE
Fix session management in manual trigger page

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -74,6 +74,8 @@ ManualGerritTrigger=\
   Query and Trigger Gerrit Patches
 ErrorSelectSomethingToBuild=\
   Please select something to build.
+ErrorSessionAlreadyClosed=\
+  Session is already closed. Please search again.
 GerritPermissionGroup=\
   Gerrit
 ManualTriggerPermissionDescription=\

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages_ja.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages_ja.properties
@@ -74,6 +74,8 @@ ManualGerritTrigger=\
   Gerrit\u30d1\u30c3\u30c1\u306e\u30af\u30a8\u30ea\u3068\u30c8\u30ea\u30ac\u30fc
 ErrorSelectSomethingToBuild=\
   \u30d3\u30eb\u30c9\u3092\u9078\u629e\u3057\u3066\u304f\u3060\u3055\u3044
+ErrorSessionAlreadyClosed=\
+  \u30bb\u30c3\u30b7\u30e7\u30f3\u304c\u5207\u308c\u307e\u3057\u305f\u3002\u518d\u5ea6\u691c\u7d22\u3057\u3066\u304f\u3060\u3055\u3044
 GerritPermissionGroup=\
   Gerrit
 ManualTriggerPermissionDescription=\


### PR DESCRIPTION
In ManualTriggerAction, session is always created if nothing.
It might be issue if session is closed before build.

This patch creates session once then reuse it.

Fix for JENKINS-19013

Task-Url: https://issues.jenkins-ci.org/browse/JENKINS-19013
