### PR TITLE
Provide notification level to gerrit command

### DIFF
--- a/src/main/webapp/help-GerritNotificationLevel.html
+++ b/src/main/webapp/help-GerritNotificationLevel.html
@@ -3,4 +3,5 @@ Defines to whom email notifications should be sent.
 This can either be nobody, the change owner, reviewers plus change owner, or all interested users
 (owning, reviewing, watching, and starring).
 <p/>
-This setting only applies if the Gerrit REST API is enabled in the server configuration.
+This setting applies implicitly if the Gerrit REST API is enabled in the server configuration.
+If not use REST API, you need to add option to Gerrit command configuration in server configuration.

--- a/src/main/webapp/help-GerritVerifiedCmdBuildFailed.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildFailed.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: The URL to the build.</li>
     <li><strong>VERIFIED</strong>: The verified vote.</li>
     <li><strong>CODE_REVIEW</strong>: The code review vote.</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: The notification level.</li>
 </ul>
 <p>
     <strong>The following special &lt;PARAMETER&gt; values are available:</strong>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildFailed_ja.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildFailed_ja.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: ビルド結果へのURL</li>
     <li><strong>VERIFIED</strong>: Verifiedスコア</li>
     <li><strong>CODE_REVIEW</strong>: Code-Reviewスコア</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: 通知レベル</li>
 </ul>
 <p>
     <strong>利用可能なスペシャルパラメータ</strong>
@@ -29,5 +30,5 @@
     </li>
 </ul>
 <p>
-    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。 
+    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。
 </p>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildNotBuilt.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildNotBuilt.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: The URL to the build.</li>
     <li><strong>VERIFIED</strong>: The verified vote.</li>
     <li><strong>CODE_REVIEW</strong>: The code review vote.</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: The notification level.</li>
 </ul>
 <p>
     <strong>The following special &lt;PARAMETER&gt; values are available:</strong>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildNotBuilt_ja.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildNotBuilt_ja.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: ビルド結果へのURL</li>
     <li><strong>VERIFIED</strong>: Verifiedスコア</li>
     <li><strong>CODE_REVIEW</strong>: Code-Reviewスコア</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: 通知レベル</li>
 </ul>
 <p>
     <strong>利用可能なスペシャルパラメータ</strong>
@@ -29,5 +30,5 @@
     </li>
 </ul>
 <p>
-    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。 
+    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。
 </p>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildStarted.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildStarted.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: The URL to the build.</li>
     <li><strong>VERIFIED</strong>: The verified vote.</li>
     <li><strong>CODE_REVIEW</strong>: The code review vote.</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: The notification level. (always ALL)</li>
 </ul>
 <p>
     <strong>The following special &lt;PARAMETER&gt; values are available:</strong>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildStarted_ja.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildStarted_ja.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: ビルド結果へのURL</li>
     <li><strong>VERIFIED</strong>: Verifiedスコア</li>
     <li><strong>CODE_REVIEW</strong>: Code-Reviewスコア</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: 通知レベル（常にALL）</li>
 </ul>
 <p>
     <strong>利用可能なスペシャルパラメータ</strong>
@@ -30,5 +31,5 @@
     </li>
 </ul>
 <p>
-    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。 
+    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。
 </p>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildSuccessful.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildSuccessful.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: The URL to the build.</li>
     <li><strong>VERIFIED</strong>: The verified vote.</li>
     <li><strong>CODE_REVIEW</strong>: The code review vote.</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: The notification level.</li>
 </ul>
 <p>
     <strong>The following special &lt;PARAMETER&gt; values are available:</strong>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildSuccessful_ja.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildSuccessful_ja.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: ビルド結果へのURL</li>
     <li><strong>VERIFIED</strong>: Verifiedスコア</li>
     <li><strong>CODE_REVIEW</strong>: Code-Reviewスコア</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: 通知レベル</li>
 </ul>
 <p>
     <strong>利用可能なスペシャルパラメータ</strong>
@@ -29,5 +30,5 @@
     </li>
 </ul>
 <p>
-    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。 
+    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。
 </p>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildUnstable.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildUnstable.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: The URL to the build.</li>
     <li><strong>VERIFIED</strong>: The verified vote.</li>
     <li><strong>CODE_REVIEW</strong>: The code review vote.</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: The notification level.</li>
 </ul>
 <p>
     <strong>The following special &lt;PARAMETER&gt; values are available:</strong>

--- a/src/main/webapp/help-GerritVerifiedCmdBuildUnstable_ja.html
+++ b/src/main/webapp/help-GerritVerifiedCmdBuildUnstable_ja.html
@@ -18,6 +18,7 @@
     <li><strong>BUILDURL</strong>: ビルド結果へのURL</li>
     <li><strong>VERIFIED</strong>: Verifiedスコア</li>
     <li><strong>CODE_REVIEW</strong>: Code-Reviewスコア</li>
+    <li><strong>NOTIFICATION_LEVEL</strong>: 通知レベル</li>
 </ul>
 <p>
     <strong>利用可能なスペシャルパラメータ</strong>
@@ -29,5 +30,5 @@
     </li>
 </ul>
 <p>
-    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。 
+    最初のビルドが始まってから定義された環境変数は<strong>$ENV_VAR</strong>の形で参照できます。
 </p>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
@@ -108,6 +108,7 @@ public class ParameterExpanderTest {
         assertTrue("Missing PATCHSET", result.indexOf("PATCHSET=1") >= 0);
         assertTrue("Missing VERIFIED", result.indexOf("VERIFIED=1") >= 0);
         assertTrue("Missing CODEREVIEW", result.indexOf("CODEREVIEW=32") >= 0);
+        assertTrue("Missing NOTIFICATION_LEVEL", result.indexOf("NOTIFICATION_LEVEL=ALL") >= 0);
         assertTrue("Missing REFSPEC", result.indexOf("REFSPEC=" + expectedRefSpec) >= 0);
         assertTrue("Missing ENV_BRANCH", result.indexOf("ENV_BRANCH=branch") >= 0);
         assertTrue("Missing ENV_CHANGE", result.indexOf("ENV_CHANGE=1000") >= 0);
@@ -439,6 +440,7 @@ public class ParameterExpanderTest {
         assertTrue("Missing PATCHSET", result.indexOf("PATCHSET=1") >= 0);
         assertTrue("Missing VERIFIED", result.indexOf("VERIFIED=" + expectedVerifiedVote) >= 0);
         assertTrue("Missing CODEREVIEW", result.indexOf("CODEREVIEW=" + expectedCodeReviewVote) >= 0);
+        assertTrue("Missing NOTIFICATION_LEVEL", result.indexOf("NOTIFICATION_LEVEL=ALL") >= 0);
         assertTrue("Missing REFSPEC", result.indexOf("REFSPEC=" + expectedRefSpec) >= 0);
         assertTrue("Missing ENV_BRANCH", result.indexOf("ENV_BRANCH=branch") >= 0);
         assertTrue("Missing ENV_CHANGE", result.indexOf("ENV_CHANGE=1000") >= 0);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -56,6 +56,7 @@ public class MockGerritHudsonTriggerConfig implements
                 + " PATCHSET=<PATCHSET>"
                 + " VERIFIED=<VERIFIED>"
                 + " CODEREVIEW=<CODE_REVIEW>"
+                + " NOTIFICATION_LEVEL=<NOTIFICATION_LEVEL>"
                 + " REFSPEC=<REFSPEC> MSG=I started a build."
                 + " BUILDURL=<BUILDURL>"
                 + " STARTED_STATS=<STARTED_STATS>"
@@ -73,6 +74,7 @@ public class MockGerritHudsonTriggerConfig implements
                 + " PATCHSET=<PATCHSET>"
                 + " VERIFIED=<VERIFIED>"
                 + " CODEREVIEW=<CODE_REVIEW>"
+                + " NOTIFICATION_LEVEL=<NOTIFICATION_LEVEL>"
                 + " REFSPEC=<REFSPEC> MSG='Your friendly butler says OK. BS=<BUILDS_STATS>'"
                 + " BUILDURL=<BUILDURL>"
                 + " STARTED_STATS=<STARTED_STATS>"
@@ -147,7 +149,7 @@ public class MockGerritHudsonTriggerConfig implements
 
     @Override
     public Notify getNotificationLevel() {
-        throw new UnsupportedOperationException("Not supported yet.");
+        return Notify.ALL;
     }
 
     @Override


### PR DESCRIPTION
Now notification level feature is provided to REST API only.

This patch provides this feature to Gerrit command as parameter
named 'NOTIFICATION_LEVEL'.

Note that this parameter always 'ALL' at build started.
It's a default value if ReviewInput has no Notify attribute.
