### PR TITLE
Add one-off executor to search list for cancel job

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1980,7 +1980,10 @@ public class GerritTrigger extends Trigger<AbstractProject> implements GerritEve
 
             // Interrupt any currently running jobs.
             for (Computer c : Hudson.getInstance().getComputers()) {
-                for (Executor e : c.getExecutors()) {
+                List<Executor> executors = new ArrayList<Executor>();
+                executors.addAll(c.getOneOffExecutors());
+                executors.addAll(c.getExecutors());
+                for (Executor e : executors) {
                     if (e.getCurrentExecutable() instanceof Actionable) {
                         Actionable a = (Actionable)e.getCurrentExecutable();
                         List<ParametersAction> params = a.getActions(ParametersAction.class);


### PR DESCRIPTION
By "Build Current Pathcset Only" feature, running and queued jobs with
the same change are canceled. These are found in queue items and
executors.

But MatrixJob uses one-off executor. It is not included in executors. So
it cannot be canceled.

This patch adds one-off executors to executor's list.

Fix for JENKINS-24295

Task-Url: https://issues.jenkins-ci.org/browse/JENKINS-24295
