### PR TITLE
Fix topic rule for empty topic

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/Topic.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/Topic.java
@@ -92,7 +92,10 @@ public class Topic extends AbstractDescribableImpl<Topic> {
      * @return true if the topic match.
      */
     public boolean isInteresting(String topic) {
-        if (topic != null && compareType.matches(pattern, topic)) {
+        if (topic == null){
+            topic = "";
+        }
+        if (compareType.matches(pattern, topic)) {
             return true;
         }
         return false;


### PR DESCRIPTION
When a topic is empty, topic regular expression never match even if
regular expression is '.*'.

Null topic are now considered a empty topic string.
