### PR TITLE
Removed unnecessary description attribute

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -3,7 +3,7 @@
     <j:set var="types" value="${descriptor.getCompareTypes()}"/>
     <j:set var="fileTriggerEnabled" value="${instance.isFileTriggerEnabled()}"/>
     <f:section title="${%Gerrit Trigger}">
-        <f:entry title="${%Choose a Server}" description="${it.description}" field="serverName">
+        <f:entry title="${%Choose a Server}" field="serverName">
             <f:select/>
         </f:entry>
         <j:if test="${descriptor.isSlaveSelectionAllowedInJobs()}">


### PR DESCRIPTION
`it` object is kind of project instance, so when you have description for the project then it will be duplicated in Gerrit Trigger section. 

The issue is very annoying when you have a large description with HTML formatting for some project in Jenkins.