### PR TITLE
Findbugs: null pointer dereference fixes.

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
@@ -75,7 +75,11 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
      * Add the current list updater as a listener to the GerritServer object.
      */
     private void addThisAsListener() {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        PluginImpl plugin = PluginImpl.getInstance();
+        if (plugin == null) {
+            return;
+        }
+        GerritServer server = plugin.getServer(serverName);
         if (server != null) {
             server.addListener(this);
             connected = server.isConnected();
@@ -133,7 +137,7 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
                 break;
             }
         }
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
              server.removeListener(this);
         } else {
@@ -146,16 +150,19 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
      * @return the server config or null if config not found.
      */
     private IGerritHudsonTriggerConfig getConfig() {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
-        if (server != null) {
-            IGerritHudsonTriggerConfig config = server.getConfig();
-            if (config != null) {
-                return config;
+        PluginImpl plugin = PluginImpl.getInstance();
+        if (plugin != null) {
+            GerritServer server = plugin.getServer(serverName);
+            if (server != null) {
+                IGerritHudsonTriggerConfig config = server.getConfig();
+                if (config != null) {
+                    return config;
+                } else {
+                    logger.error("Could not find the server config");
+                }
             } else {
-                logger.error("Could not find the server config");
+                logger.error("Could not find server {}", serverName);
             }
-        } else {
-            logger.error("Could not find server {}", serverName);
         }
         return null;
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
@@ -141,7 +141,7 @@ public class PluginImpl extends Plugin {
         if (jenkins != null) {
             return jenkins.getPlugin(PluginImpl.class);
         } else {
-            logger.error("INITIALIZATION Error, Jenkins could not be found, so no plugin!");
+            logger.debug("Error, Jenkins could not be found, so no plugin!");
             return null;
         }
     }
@@ -176,7 +176,7 @@ public class PluginImpl extends Plugin {
     public static List<GerritServer> getServers_() {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("PluginImpl instance not found!");
+            logger.debug("PluginImpl instance not found!");
             return Collections.emptyList();
         }
         return plugin.getServers();
@@ -206,7 +206,7 @@ public class PluginImpl extends Plugin {
     public static List<String> getServerNames_() {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("PluginImpl instance not found!");
+            logger.debug("PluginImpl instance not found!");
             return Collections.emptyList();
         }
         return plugin.getServerNames();
@@ -241,7 +241,7 @@ public class PluginImpl extends Plugin {
     public static GerritServer getServer_(String name) {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            logger.debug("Error, plugin instance could not be found!");
             return null;
         }
         return plugin.getServer(name);
@@ -270,7 +270,7 @@ public class PluginImpl extends Plugin {
     public static GerritServer getFirstServer_() {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            logger.debug("Error, plugin instance could not be found!");
             return null;
         }
         return plugin.getFirstServer();
@@ -336,7 +336,7 @@ public class PluginImpl extends Plugin {
     public static boolean containsServer_(String serverName) {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            logger.debug("Error, plugin instance could not be found!");
             return false;
         }
         return plugin.containsServer(serverName);
@@ -384,7 +384,7 @@ public class PluginImpl extends Plugin {
     public static PluginConfig getPluginConfig_() {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            logger.debug("Error, plugin instance could not be found!");
             return null;
         }
         return plugin.getPluginConfig();
@@ -399,7 +399,7 @@ public class PluginImpl extends Plugin {
     public static void save_() throws IOException {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            logger.debug("Error, plugin instance could not be found!");
             return;
         }
         plugin.save();
@@ -424,7 +424,7 @@ public class PluginImpl extends Plugin {
     public static GerritHandler getHandler_() {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            logger.debug("Error, plugin instance could not be found!");
             return null;
         }
         return plugin.getHandler();
@@ -461,7 +461,7 @@ public class PluginImpl extends Plugin {
     public static List<AbstractProject> getConfiguredJobs_(String serverName) {
         PluginImpl plugin = getInstance();
         if (plugin == null) {
-            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            logger.debug("Error, plugin instance could not be found!");
             return Collections.emptyList();
         }
         return plugin.getConfiguredJobs(serverName);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
@@ -52,11 +52,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import jenkins.model.Jenkins;
+
+import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
 
 
 /**
@@ -126,11 +130,20 @@ public class PluginImpl extends Plugin {
 
     /**
      * Returns the instance of this class.
+     * If {@link jenkins.model.Jenkins#getInstance()} isn't available
+     * or the plugin class isn't registered null will be returned.
      *
      * @return the instance.
      */
+    @CheckForNull
     public static PluginImpl getInstance() {
-        return Jenkins.getInstance().getPlugin(PluginImpl.class);
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins != null) {
+            return jenkins.getPlugin(PluginImpl.class);
+        } else {
+            logger.error("INITIALIZATION Error, Jenkins could not be found, so no plugin!");
+            return null;
+        }
     }
 
     /**
@@ -152,6 +165,25 @@ public class PluginImpl extends Plugin {
     }
 
     /**
+     * Get the list of Gerrit servers.
+     * Static shorthand for {@link #getServers()}.
+     * If the plugin instance is not available, and empty list is returned.
+     *
+     * @return the list of GerritServers
+     */
+    @Nonnull
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static List<GerritServer> getServers_() {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("PluginImpl instance not found!");
+            return Collections.emptyList();
+        }
+        return plugin.getServers();
+    }
+
+
+    /**
      * Get the list of Gerrit server names.
      *
      * @return the list of server names as a list.
@@ -162,6 +194,22 @@ public class PluginImpl extends Plugin {
             names.add(s.getName());
         }
         return names;
+    }
+
+    /**
+     * Static shorthand for {@link #getServerNames()}.
+     *
+     * @return the list of server names.
+     */
+    @Nonnull
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static List<String> getServerNames_() {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("PluginImpl instance not found!");
+            return Collections.emptyList();
+        }
+        return plugin.getServerNames();
     }
 
     /**
@@ -180,15 +228,52 @@ public class PluginImpl extends Plugin {
     }
 
     /**
+     * Get a GerritServer object by its name.
+     *
+     * Static short for {@link #getServer(String)}.
+     *
+     * @param name the name of the server to get.
+     * @return the GerritServer object to get, or null if no server has this name.
+     * @see #getServer(String)
+     */
+    @CheckForNull
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static GerritServer getServer_(String name) {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            return null;
+        }
+        return plugin.getServer(name);
+    }
+
+    /**
      * Gets the first server in the server list. Or null if there are no servers.
      *
      * @return the server.
      */
+    @CheckForNull
     public GerritServer getFirstServer() {
         if (!servers.isEmpty()) {
             return servers.get(0);
         }
         return null;
+    }
+
+    /**
+     * Static shorthand for {@link #getFirstServer()}.
+     *
+     * @return the server if any.
+     */
+    @CheckForNull
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static GerritServer getFirstServer_() {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            return null;
+        }
+        return plugin.getFirstServer();
     }
 
     /**
@@ -243,6 +328,21 @@ public class PluginImpl extends Plugin {
     }
 
     /**
+     * Static shorthand for {@link #containsServer(String)}.
+     * @param serverName to check.
+     * @return whether the list contains a server with the given name.
+     */
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static boolean containsServer_(String serverName) {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            return false;
+        }
+        return plugin.containsServer(serverName);
+    }
+
+    /**
      * Finds the server config for the event's provider.
      *
      * @param event the event
@@ -252,7 +352,7 @@ public class PluginImpl extends Plugin {
     public static IGerritHudsonTriggerConfig getServerConfig(GerritTriggeredEvent event) {
         Provider provider = event.getProvider();
         if (provider != null) {
-            GerritServer gerritServer = getInstance().getServer(provider.getName());
+            GerritServer gerritServer = getServer_(provider.getName());
             if (gerritServer != null) {
                 return gerritServer.getConfig();
             } else {
@@ -274,12 +374,60 @@ public class PluginImpl extends Plugin {
     }
 
     /**
+     * Gets the global config.
+     * Static short hand for {@link #getPluginConfig()}.
+     *
+     * @return the config.
+     */
+    @CheckForNull
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static PluginConfig getPluginConfig_() {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            return null;
+        }
+        return plugin.getPluginConfig();
+    }
+
+    /**
+     * Static shorthand for {@link hudson.Plugin#save()}.
+     *
+     * @throws IOException if save does so.
+     */
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static void save_() throws IOException {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            return;
+        }
+        plugin.save();
+    }
+
+    /**
      * Returns the GerritHandler object.
      *
      * @return gerritEventManager
      */
     public GerritHandler getHandler() {
         return gerritEventManager;
+    }
+
+    /**
+     * Static shorthand for {@link #getHandler()}.
+     *
+     * @return gerritEventManager
+     */
+    @CheckForNull
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static GerritHandler getHandler_() {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            return null;
+        }
+        return plugin.getHandler();
     }
 
     /**
@@ -299,6 +447,24 @@ public class PluginImpl extends Plugin {
             }
         }
         return configuredJobs;
+    }
+
+    /**
+     * Static shorthand for {@link #getConfiguredJobs(String)}.
+     * Will return an empty list if plugin instance is null.
+     *
+     * @param serverName the name of the Gerrit server.
+     * @return the list of jobs configured with this server.
+     */
+    @Nonnull
+    //CS IGNORE MethodName FOR NEXT 1 LINES. REASON: Static equivalent marker.
+    public static List<AbstractProject> getConfiguredJobs_(String serverName) {
+        PluginImpl plugin = getInstance();
+        if (plugin == null) {
+            logger.error("INITIALIZATION Error, plugin instance could not be found!");
+            return Collections.emptyList();
+        }
+        return plugin.getConfiguredJobs(serverName);
     }
 
     @Override

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/api/GerritTriggerApi.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/api/GerritTriggerApi.java
@@ -45,7 +45,9 @@ public final class GerritTriggerApi {
      * @throws PluginStatusException if plugin is inactive.
      */
     private PluginImpl getActivePlugin() throws PluginNotFoundException, PluginStatusException {
-        PluginImpl plugin = Jenkins.getInstance().getPlugin(PluginImpl.class);
+        Jenkins jenkins = Jenkins.getInstance();
+        assert jenkins != null;
+        PluginImpl plugin = jenkins.getPlugin(PluginImpl.class);
         if (plugin == null) {
             throw new PluginNotFoundException();
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/extensions/GerritTriggeredBuildListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/extensions/GerritTriggeredBuildListener.java
@@ -107,6 +107,8 @@ public abstract class GerritTriggeredBuildListener implements ExtensionPoint {
       * @return the extension list.
       */
      public static ExtensionList<GerritTriggeredBuildListener> all() {
-         return Jenkins.getInstance().getExtensionList(GerritTriggeredBuildListener.class);
+         Jenkins jenkins = Jenkins.getInstance();
+         assert jenkins != null;
+         return jenkins.getExtensionList(GerritTriggeredBuildListener.class);
      }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/NotificationFactory.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/NotificationFactory.java
@@ -73,7 +73,7 @@ public class NotificationFactory {
      * @return the server-config.
      */
     public IGerritHudsonTriggerConfig getConfig(String serverName) {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             return server.getConfig();
         } else {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -363,7 +363,14 @@ public class ParameterExpander {
     public int getMinimumVerifiedValue(MemoryImprint memoryImprint, boolean onlyBuilt) {
         int verified = Integer.MAX_VALUE;
         for (Entry entry : memoryImprint.getEntries()) {
-            Result result = entry.getBuild().getResult();
+            if (entry == null) {
+                continue;
+            }
+            AbstractBuild build = entry.getBuild();
+            if (build == null) {
+                continue;
+            }
+            Result result = build.getResult();
             if (onlyBuilt && result == Result.NOT_BUILT) {
                 continue;
             }
@@ -390,7 +397,11 @@ public class ParameterExpander {
     public int getMinimumCodeReviewValue(MemoryImprint memoryImprint, boolean onlyBuilt) {
         int codeReview = Integer.MAX_VALUE;
         for (Entry entry : memoryImprint.getEntries()) {
-            Result result = entry.getBuild().getResult();
+            AbstractBuild build = entry.getBuild();
+            if (build == null) {
+                continue;
+            }
+            Result result = build.getResult();
             if (onlyBuilt && result == Result.NOT_BUILT) {
                 continue;
             }
@@ -417,7 +428,14 @@ public class ParameterExpander {
     public Notify getHighestNotificationLevel(MemoryImprint memoryImprint, boolean onlyBuilt) {
         Notify highestLevel = Notify.NONE;
         for (Entry entry : memoryImprint.getEntries()) {
-            Result result = entry.getBuild().getResult();
+            if (entry == null) {
+                continue;
+            }
+            AbstractBuild build = entry.getBuild();
+            if (build == null) {
+                continue;
+            }
+            Result result = build.getResult();
             if (onlyBuilt && result == Result.NOT_BUILT) {
                 continue;
             }
@@ -530,10 +548,16 @@ public class ParameterExpander {
         // the build results.
         if (entries.length > 0) {
             for (Entry entry : entries) {
+                if (entry == null) {
+                    continue;
+                }
                 AbstractBuild build = entry.getBuild();
                 if (build != null) {
                     GerritTrigger trigger = GerritTrigger.getTrigger(build.getProject());
                     Result res = build.getResult();
+                    if (res == null) {
+                        res = Result.NOT_BUILT;
+                    }
                     String customMessage = null;
 
                     /* Gerrit comments cannot contain single-newlines, as they will be joined
@@ -544,7 +568,7 @@ public class ParameterExpander {
                     str.append("\n\n");
 
                     if (trigger.getCustomUrl() == null || trigger.getCustomUrl().isEmpty()) {
-                        str.append(rootUrl).append(entry.getBuild().getUrl());
+                        str.append(rootUrl).append(build.getUrl());
                     } else {
                         str.append(expandParameters(trigger.getCustomUrl(), build, listener, parameters));
                     }
@@ -667,11 +691,25 @@ public class ParameterExpander {
 
         @Override
         public int compare(Entry e1, Entry e2) {
+            if (e1 == null) {
+                throw new NullPointerException("e1");
+            }
+            if (e2 == null) {
+                throw new NullPointerException("e2");
+            }
             AbstractBuild b1 = e1.getBuild();
             AbstractBuild b2 = e2.getBuild();
             if (b1 != null && b2 != null) {
-                int o1 = b1.getResult().ordinal;
-                int o2 = b2.getResult().ordinal;
+                Result r1 = b1.getResult();
+                Result r2 = b2.getResult();
+                int o1 = 0;
+                if (r1 != null) {
+                    o1 = r1.ordinal;
+                }
+                int o2 = 0;
+                if (r2 != null) {
+                    o2 = r2.ordinal;
+                }
                 if (descending) {
                     return o2 - o1;
                 } else {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
@@ -50,6 +50,9 @@ import java.util.List;
 
 import jenkins.model.Jenkins;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 /**
  * The Big RunListener in charge of coordinating build results and reporting back to Gerrit.
  *
@@ -71,8 +74,10 @@ public final class ToGerritRunListener extends RunListener<AbstractBuild> {
      * @return the instance.
      */
     public static ToGerritRunListener getInstance() {
+        Jenkins jenkins = Jenkins.getInstance();
+        assert jenkins != null;
         ExtensionList<ToGerritRunListener> listeners =
-                Jenkins.getInstance().getExtensionList(ToGerritRunListener.class);
+                jenkins.getExtensionList(ToGerritRunListener.class);
         if (listeners == null || listeners.isEmpty()) {
             logger.error("INITIALIZATION ERROR? Could not find the registered instance.");
             return null;
@@ -81,10 +86,10 @@ public final class ToGerritRunListener extends RunListener<AbstractBuild> {
     }
 
     @Override
-    public synchronized void onCompleted(AbstractBuild r, TaskListener listener) {
+    public synchronized void onCompleted(AbstractBuild r, @Nonnull TaskListener listener) {
         GerritCause cause = getCause(r);
         logger.debug("Completed. Build: {} Cause: {}", r, cause);
-        if (cause != null) {
+        if (r != null && cause != null) {
             cleanUpGerritCauses(cause, r);
             GerritTriggeredEvent event = cause.getEvent();
             GerritTrigger trigger = GerritTrigger.getTrigger(r.getProject());
@@ -98,7 +103,8 @@ public final class ToGerritRunListener extends RunListener<AbstractBuild> {
             if (!cause.isSilentMode()) {
                 memory.completed(event, r);
 
-                if (r.getResult().isWorseThan(Result.SUCCESS)) {
+                Result result = r.getResult();
+                if (result != null && result.isWorseThan(Result.SUCCESS)) {
                     try {
                         // Attempt to record the failure message, if applicable
                         String failureMessage = this.obtainFailureMessage(event, r, listener);
@@ -358,8 +364,12 @@ public final class ToGerritRunListener extends RunListener<AbstractBuild> {
      * @throws IOException if an error occurs while reading the workspace
      * @throws InterruptedException if an error occurs while reading the workspace
      */
-    protected FilePath[] getMatchingWorkspaceFiles(FilePath ws, String filepath)
+    @Nonnull
+    protected FilePath[] getMatchingWorkspaceFiles(@Nullable FilePath ws, @Nonnull String filepath)
             throws IOException, InterruptedException {
+        if (ws == null) {
+            return new FilePath[0];
+        }
         return ws.list(filepath);
     }
 
@@ -391,7 +401,9 @@ public final class ToGerritRunListener extends RunListener<AbstractBuild> {
      * @throws IOException In case of an error communicating with the {@link FilePath} or {@link EnvVars Environment}
      * @throws InterruptedException If interrupted while working with the {@link FilePath} or {@link EnvVars Environment}
      */
-    private String obtainFailureMessage(GerritTriggeredEvent event, AbstractBuild build, TaskListener listener)
+    private String obtainFailureMessage(@Nullable GerritTriggeredEvent event,
+                                        @Nonnull AbstractBuild build,
+                                        @Nullable TaskListener listener)
             throws IOException, InterruptedException {
         AbstractProject project = build.getProject();
         String content = null;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
@@ -86,10 +86,10 @@ public final class ToGerritRunListener extends RunListener<AbstractBuild> {
     }
 
     @Override
-    public synchronized void onCompleted(AbstractBuild r, @Nonnull TaskListener listener) {
+    public synchronized void onCompleted(@Nonnull AbstractBuild r, @Nonnull TaskListener listener) {
         GerritCause cause = getCause(r);
         logger.debug("Completed. Build: {} Cause: {}", r, cause);
-        if (r != null && cause != null) {
+        if (cause != null) {
             cleanUpGerritCauses(cause, r);
             GerritTriggeredEvent event = cause.getEvent();
             GerritTrigger trigger = GerritTrigger.getTrigger(r.getProject());

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction.java
@@ -105,7 +105,7 @@ public class BadgeAction implements BuildBadgeAction {
             provider.setName(PluginImpl.DEFAULT_SERVER_NAME);
             tEvent.setProvider(provider);
         }
-        GerritServer server = PluginImpl.getInstance().getServer(provider.getName());
+        GerritServer server = PluginImpl.getServer_(provider.getName());
         //TODO: investigate the case where server == null:
         if (server != null) {
             return server.getConfig().getGerritFrontEndUrlFor(tEvent);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
@@ -271,7 +271,11 @@ final class EventListener implements GerritEventListener {
      */
     @CheckForNull
     private GerritTrigger getTrigger() {
-        AbstractProject p = Jenkins.getInstance().getItemByFullName(job, AbstractProject.class);
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return null;
+        }
+        AbstractProject p = jenkins.getItemByFullName(job, AbstractProject.class);
         if (p == null) {
             return null;
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause.java
@@ -185,7 +185,7 @@ public class GerritCause extends SCMTriggerCause {
     private String getUrlFromEvent() {
         if (tEvent.getProvider() != null) {
             String serverName = tEvent.getProvider().getName();
-            GerritServer server = PluginImpl.getInstance().getServer(serverName);
+            GerritServer server = PluginImpl.getServer_(serverName);
             if (server != null) {
             IGerritHudsonTriggerConfig config = server.getConfig();
                 if (config != null) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritConnectionListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritConnectionListener.java
@@ -27,6 +27,7 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
 import java.util.LinkedList;
 import java.util.List;
 
+import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,8 @@ import com.sonymobile.tools.gerrit.gerritevents.ConnectionListener;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.version.GerritVersionChecker;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.version.GerritVersionNumber;
+
+import javax.annotation.CheckForNull;
 
 /**
  * Every instance of this class is a connection listener to a specific Gerrit server.
@@ -127,9 +130,16 @@ public class GerritConnectionListener implements ConnectionListener {
      *
      * @return the Gerrit version as a String, or null if server not found.
      */
+    @CheckForNull
     private String getVersionString() {
-        if (PluginImpl.getInstance().getServer(serverName) != null) {
-            return PluginImpl.getInstance().getServer(serverName).getGerritVersion();
+        PluginImpl plugin = PluginImpl.getInstance();
+        if (plugin == null) {
+            logger.error("INITIALIZATION Error, the plugin instance couldn't be found!");
+            return null;
+        }
+        GerritServer server = plugin.getServer(serverName);
+        if (server != null) {
+            return server.getGerritVersion();
         } else {
             logger.error("server does not exist");
             return null;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritItemListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritItemListener.java
@@ -75,11 +75,9 @@ public class GerritItemListener extends ItemListener {
      */
     @Override
     public void onLoaded() {
-        if (PluginImpl.getInstance() != null) {
-            for (GerritServer s : PluginImpl.getInstance().getServers()) {
-                if (!s.isNoConnectionOnStartup()) {
-                    s.startConnection();
-                }
+        for (GerritServer s : PluginImpl.getServers_()) {
+            if (!s.isNoConnectionOnStartup()) {
+                s.startConnection();
             }
         }
         super.onLoaded();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -468,11 +468,13 @@ public class GerritTrigger extends Trigger<AbstractProject> {
      */
     private Provider initializeProvider(GerritTriggeredEvent tEvent) {
         Provider provider = tEvent.getProvider();
-        if (provider == null && !isAnyServer()) {
-            provider = new Provider();
-            provider.setName(serverName);
-        } else if (provider.getName() == null && !isAnyServer()) {
-            provider.setName(serverName);
+        if (!isAnyServer()) {
+            if (provider == null) {
+                provider = new Provider();
+                provider.setName(serverName);
+            } else if (provider.getName() == null) {
+                provider.setName(serverName);
+            }
         }
         return provider;
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -482,16 +482,17 @@ public enum GerritTriggerParameters {
                 serverName = name;
             }
         }
-        if (serverName == null && PluginImpl.getInstance().getFirstServer() != null) {
+        GerritServer firstServer = PluginImpl.getFirstServer_();
+        if (serverName == null && firstServer != null) {
             logger.warn("No server could be determined from event or project config, "
                     + "defaulting to the first configured server. Event: [{}] Project: [{}]", event, project);
-            serverName = PluginImpl.getInstance().getFirstServer().getName();
+            serverName = firstServer.getName();
         } else if (serverName == null) {
             //We have exhausted all possibilities, time to fail horribly
             throw new IllegalStateException("Cannot determine a Gerrit server to link to. Have you configured one?");
         }
 
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             IGerritHudsonTriggerConfig config = server.getConfig();
             if (config != null) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimer.java
@@ -30,6 +30,7 @@ import hudson.util.TimeUnit2;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.List;
 import java.util.Timer;
 
 /**
@@ -94,7 +95,8 @@ public final class GerritTriggerTimer {
     private long calculateDynamicConfigRefreshInterval(GerritTriggerTimerTask timerTask) {
         GerritTrigger trigger = timerTask.getGerritTrigger();
         if (trigger != null && trigger.isAnyServer()) {
-            if (PluginImpl.getInstance().getServers() == null || PluginImpl.getInstance().getServers().isEmpty()) {
+            List<GerritServer> servers = PluginImpl.getServers_();
+            if (servers.isEmpty()) {
                 return GerritDefaultValues.DEFAULT_DYNAMIC_CONFIG_REFRESH_INTERVAL;
             } else {
                 //Do an average just for giggles
@@ -105,7 +107,7 @@ public final class GerritTriggerTimer {
             return calculateAverageDynamicConfigRefreshInterval();
         } else {
             //get the actual if it exists.
-            GerritServer server = PluginImpl.getInstance().getServer(trigger.getServerName());
+            GerritServer server = PluginImpl.getServer_(trigger.getServerName());
             if (server != null) {
                 return server.getConfig().getDynamicConfigRefreshInterval();
             } else {
@@ -126,10 +128,10 @@ public final class GerritTriggerTimer {
      */
     private long calculateAverageDynamicConfigRefreshInterval() {
         long total = 0;
-        for (GerritServer server : PluginImpl.getInstance().getServers()) {
+        for (GerritServer server : PluginImpl.getServers_()) {
             total += server.getConfig().getDynamicConfigRefreshInterval();
         }
-        long average = total / Math.max(1, PluginImpl.getInstance().getServers().size()); //Avoid division by 0
+        long average = total / Math.max(1, PluginImpl.getServers_().size()); //Avoid division by 0
         return Math.max(GerritDefaultValues.MINIMUM_DYNAMIC_CONFIG_REFRESH_INTERVAL, average);
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
@@ -80,7 +80,11 @@ public class GerritTriggerTimerTask extends TimerTask {
                 return gerritTrigger;
             }
         }
-        AbstractProject p = Jenkins.getInstance().getItemByFullName(job, AbstractProject.class);
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return null;
+        }
+        AbstractProject p = jenkins.getItemByFullName(job, AbstractProject.class);
         if (p == null) {
             return null;
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/UnreviewedPatchesListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/UnreviewedPatchesListener.java
@@ -80,7 +80,7 @@ public class UnreviewedPatchesListener implements ConnectionListener {
      * Add this patches listener to the GerritServer object to which it is associated.
      */
     private void addThisAsListener() {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             server.addListener(this);
         } else {
@@ -103,7 +103,7 @@ public class UnreviewedPatchesListener implements ConnectionListener {
      * Shutdown the listener.
      */
     public void shutdown() {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             server.removeListener(this);
         } else {
@@ -169,7 +169,7 @@ public class UnreviewedPatchesListener implements ConnectionListener {
      * @return the server config or null if not found.
      */
     private IGerritHudsonTriggerConfig getConfig() {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             IGerritHudsonTriggerConfig config = server.getConfig();
             if (config != null) {
@@ -233,7 +233,7 @@ public class UnreviewedPatchesListener implements ConnectionListener {
      */
     private boolean hasUserReviewedChange(JSONObject changeSet, String userName) {
         if (changeSet == null) {
-            logger.warn("Invalid changeSet: " + changeSet);
+            logger.warn("No provided changeSet!");
             return true;
         }
         List<String> names = this.changeSets.get(changeSet);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
@@ -122,7 +122,7 @@ public class ManualTriggerAction implements RootAction {
      * @see com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig#isEnableManualTrigger()
      */
     public boolean hasEnabledServers() {
-        for (GerritServer s : PluginImpl.getInstance().getServers()) {
+        for (GerritServer s : PluginImpl.getServers_()) {
             if (s.getConfig().isEnableManualTrigger()) {
                 return true;
             }
@@ -152,7 +152,7 @@ public class ManualTriggerAction implements RootAction {
      * @return the config of the server or null if config not found.
      */
     private IGerritHudsonTriggerConfig getServerConfig(String serverName) {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             IGerritHudsonTriggerConfig config = server.getConfig();
             if (config != null) {
@@ -197,7 +197,7 @@ public class ManualTriggerAction implements RootAction {
      */
     public ArrayList<String> getEnabledServers() {
         ArrayList<String> enabledServers = new ArrayList<String>();
-        for (GerritServer s : PluginImpl.getInstance().getServers()) {
+        for (GerritServer s : PluginImpl.getServers_()) {
             if (s.getConfig().isEnableManualTrigger()) {
                 enabledServers.add(s.getName());
             }
@@ -468,7 +468,7 @@ public class ManualTriggerAction implements RootAction {
      * @return the Provider with info from the GerritServer, or an empty provider if server not found
      */
     private Provider createProviderFromGerritServer(String serverName) {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             return new Provider(
                     server.getName(),
@@ -587,12 +587,12 @@ public class ManualTriggerAction implements RootAction {
      * Triggers the event by putting it into the event queue.
      *
      * @param event the event to trigger.
-     * @see PluginImpl#triggerEvent(com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent)
+     * @see GerritServer#triggerEvent(com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent)
      */
     private void triggerEvent(ManualPatchsetCreated event) {
         logger.trace("Going to trigger event: {}", event);
         String serverName = event.getProvider().getName(); //null handled by caller method doBuild
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             server.triggerEvent(event);
         } else {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
@@ -291,11 +291,14 @@ public class GerritProject implements Describable<GerritProject> {
 
             if (serverName != null && !serverName.isEmpty()) {
                 if (ANY_SERVER.equals(serverName)) {
-                    for (GerritServer server : PluginImpl.getInstance().getServers()) {
+                    for (GerritServer server : PluginImpl.getServers_()) {
                         projects.addAll(server.getGerritProjects());
                     }
                 } else {
-                    projects.addAll(PluginImpl.getInstance().getServer(serverName).getGerritProjects());
+                    GerritServer server = PluginImpl.getServer_(serverName);
+                    if (server != null) {
+                        projects.addAll(server.getGerritProjects());
+                    }
                 }
             }
             return new ComboBoxModel(projects);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedEvent.java
@@ -25,6 +25,7 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events;
 
 import static com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer.ANY_SERVER;
 
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.CommentAdded;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
@@ -124,7 +125,7 @@ public class PluginCommentAddedEvent extends PluginGerritEvent implements Serial
             Collection<VerdictCategory> list = null;
             if (ANY_SERVER.equals(serverName)) { //list all configured VCs in all servers
                 Map<String, VerdictCategory> map = new HashMap<String, VerdictCategory>();
-                for (GerritServer server : PluginImpl.getInstance().getServers()) {
+                for (GerritServer server : PluginImpl.getServers_()) {
                     for (VerdictCategory vc : server.getConfig().getCategories()) {
                         if (!map.containsKey(vc.getVerdictValue())) {
                             map.put(vc.getVerdictValue(), vc);
@@ -133,7 +134,13 @@ public class PluginCommentAddedEvent extends PluginGerritEvent implements Serial
                 }
                 list = map.values();
             } else {
-                list = PluginImpl.getInstance().getServer(serverName).getConfig().getCategories();
+                GerritServer server = PluginImpl.getServer_(serverName);
+                if (server != null) {
+                    IGerritHudsonTriggerConfig config = server.getConfig();
+                    if (config != null) {
+                        list = config.getCategories();
+                    }
+                }
             }
             if (list != null && !list.isEmpty()) {
                 for (VerdictCategory v : list) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginDraftPublishedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginDraftPublishedEvent.java
@@ -77,7 +77,7 @@ public class PluginDraftPublishedEvent extends PluginGerritEvent implements Seri
          * @return true if so.
          */
         public boolean isReplicationEnabled() {
-            for (GerritServer server : PluginImpl.getInstance().getServers()) {
+            for (GerritServer server : PluginImpl.getServers_()) {
                 ReplicationConfig replicationConfig = server.getConfig().getReplicationConfig();
                 if (replicationConfig != null) {
                     return replicationConfig.isEnableReplication();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/WaitingForReplication.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/WaitingForReplication.java
@@ -33,6 +33,8 @@ import com.google.common.collect.Collections2;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritSlave;
 
+import javax.annotation.Nullable;
+
 /**
  * Build is blocked because replication is not completed to slave(s).
  * @author Hugo Arès &lt;hugo.ares@ericsson.com&gt;
@@ -61,8 +63,12 @@ public class WaitingForReplication extends CauseOfBlockage {
     private static enum ToGerritSlaveName implements Function<GerritSlave, String> {
         INSTANCE; //enum singleton pattern
         @Override
-        public String apply(GerritSlave gerritStave) {
-            return gerritStave.getName();
+        public String apply(@Nullable GerritSlave gerritSlave) {
+            if (gerritSlave != null) {
+                return gerritSlave.getName();
+            } else {
+                return null;
+            }
         }
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
@@ -111,7 +111,7 @@ public final class GerritVersionChecker {
     public static boolean isCorrectVersion(Feature feature, String serverName) {
         if (PluginImpl.getInstance() != null) {
             if (serverName == null || serverName.isEmpty() || GerritServer.ANY_SERVER.equals(serverName)) {
-                for (GerritServer server : PluginImpl.getInstance().getServers()) {
+                for (GerritServer server : PluginImpl.getServers_()) {
                     GerritVersionNumber gerritVersion
                             = createVersionNumber(server.getGerritVersion());
                     if (isCorrectVersion(gerritVersion, feature)) {
@@ -135,13 +135,13 @@ public final class GerritVersionChecker {
      *@return the current Gerrit version as a String if connected, or null otherwise.
     */
     private static String getGerritVersion(String serverName) {
-        GerritServer server = PluginImpl.getInstance().getServer(serverName);
+        GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null) {
             String version = server.getGerritVersion();
             if (version != null) {
                 return version;
             } else {
-                logger.error("Could not find the Gerrit version {}", version);
+                logger.error("Could not find the Gerrit version for {}", serverName);
             }
         } else {
             logger.error("Could not find the server {}", serverName);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritItemListenerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritItemListenerTest.java
@@ -23,13 +23,8 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
 
-import static org.powermock.api.mockito.PowerMockito.mock;
-import static org.powermock.api.mockito.PowerMockito.mockStatic;
-import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.spy;
 import static org.powermock.api.mockito.PowerMockito.doNothing;
-
-import java.util.Arrays;
 
 import org.junit.Before;
 import org.junit.Rule;
@@ -67,12 +62,9 @@ public class GerritItemListenerTest {
      */
     @Before
     public void setup() {
-        PluginImpl plugin = mock(PluginImpl.class);
-        mockStatic(PluginImpl.class);
-        when(PluginImpl.getInstance()).thenReturn(plugin);
         gerritServer = spy(new GerritServer(gerritServerName));
         doNothing().when(gerritServer).startConnection();
-        when(plugin.getServers()).thenReturn(Arrays.asList(gerritServer));
+        PluginImpl.getInstance().addServer(gerritServer);
     }
 
     /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
@@ -116,10 +116,10 @@ import static org.mockito.Mockito.same;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
-import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.spy;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 //CS IGNORE MagicNumber FOR NEXT 2000 LINES. REASON: testdata.
 
@@ -235,10 +235,11 @@ public class GerritTriggerTest {
         config = spy(config);
         doReturn("http://mock.url").when(config).getGerritFrontEndUrlFor(any(String.class), any(String.class));
         when(plugin.getServer(any(String.class))).thenReturn(server);
+        when(PluginImpl.getServer_(any(String.class))).thenReturn(server);
         GerritHandler handler = mock(GerritHandler.class);
         when(plugin.getHandler()).thenReturn(handler);
         when(server.getConfig()).thenReturn(config);
-        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
+        when(PluginImpl.getInstance()).thenReturn(plugin);
         when(config.getBuildScheduleDelay()).thenReturn(20);
 
         GerritTrigger trigger = Setup.createDefaultTrigger(project);
@@ -331,6 +332,7 @@ public class GerritTriggerTest {
         PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
         GerritServer server = mock(GerritServer.class);
         when(plugin.getServer(any(String.class))).thenReturn(server);
+        when(PluginImpl.getServer_(any(String.class))).thenReturn(server);
         IGerritHudsonTriggerConfig config = Setup.createConfig();
         config = spy(config);
         doReturn("http://mock.url").when(config).getGerritFrontEndUrlFor(any(String.class), any(String.class));
@@ -371,6 +373,7 @@ public class GerritTriggerTest {
         PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
         GerritServer server = mock(GerritServer.class);
         when(plugin.getServer(any(String.class))).thenReturn(server);
+        when(PluginImpl.getServer_(any(String.class))).thenReturn(server);
         IGerritHudsonTriggerConfig config = Setup.createConfig();
         config = spy(config);
         doReturn("http://mock.url").when(config).getGerritFrontEndUrlFor(any(String.class), any(String.class));
@@ -410,6 +413,7 @@ public class GerritTriggerTest {
         PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
         GerritServer server = mock(GerritServer.class);
         when(plugin.getServer(any(String.class))).thenReturn(server);
+        when(PluginImpl.getServer_(any(String.class))).thenReturn(server);
         IGerritHudsonTriggerConfig config = Setup.createConfig();
         config = spy(config);
         doReturn("http://mock.url").when(config).getGerritFrontEndUrlFor(any(String.class), any(String.class));
@@ -458,6 +462,7 @@ public class GerritTriggerTest {
         PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
         GerritServer server = mock(GerritServer.class);
         when(plugin.getServer(any(String.class))).thenReturn(server);
+        when(PluginImpl.getServer_(any(String.class))).thenReturn(server);
         GerritHandler handler = mock(GerritHandler.class);
         when(plugin.getHandler()).thenReturn(handler);
 
@@ -509,6 +514,7 @@ public class GerritTriggerTest {
         PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
         GerritServer server = mock(GerritServer.class);
         when(plugin.getServer(any(String.class))).thenReturn(server);
+        when(PluginImpl.getServer_(any(String.class))).thenReturn(server);
         GerritHandler handler = mock(GerritHandler.class);
         when(plugin.getHandler()).thenReturn(handler);
 
@@ -1961,6 +1967,7 @@ public class GerritTriggerTest {
         when(PluginImpl.getInstance()).thenReturn(pluginMock);
         GerritServer serverMock = mock(GerritServer.class);
         when(pluginMock.getServer(PluginImpl.DEFAULT_SERVER_NAME)).thenReturn(serverMock);
+        when(PluginImpl.getServer_(eq(PluginImpl.DEFAULT_SERVER_NAME))).thenReturn(serverMock);
         IGerritHudsonTriggerConfig configMock = mock(IGerritHudsonTriggerConfig.class);
         when(serverMock.getConfig()).thenReturn(configMock);
         return configMock;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionTest.java
@@ -23,6 +23,7 @@
  */
 
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.actions.manual;
+
 import static org.mockito.Mockito.any;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
@@ -52,7 +53,7 @@ import static org.mockito.Mockito.when;
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
 @RunWith(PowerMockRunner.class)
-@PrepareForTest(fullyQualifiedNames = "com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl")
+@PrepareForTest(PluginImpl.class)
 public class ManualTriggerActionTest {
 
     /**
@@ -264,6 +265,7 @@ public class ManualTriggerActionTest {
         PluginImpl plugin = mock(PluginImpl.class);
         GerritServer server = mock(GerritServer.class);
         when(plugin.getServer(any(String.class))).thenReturn(server);
+        when(PluginImpl.getServer_(any(String.class))).thenReturn(server);
         when(server.getConfig()).thenReturn(Setup.createConfig());
         PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/VersionCheckTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/VersionCheckTest.java
@@ -25,40 +25,50 @@
 
 package com.sonyericsson.hudson.plugins.gerrit.trigger.version;
 
-
-
 import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static junit.framework.Assert.assertFalse;
 import static junit.framework.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Matchers.eq;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
 
 /**
- * Tests for the version checking of gerrit.
+ * Tests for the version checking of Gerrit.
  */
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ PluginImpl.class })
 public class VersionCheckTest {
 
     private final String testServer = "server";
+    private GerritServer server;
+
+    /**
+     * Pre setup for all tests.
+     */
+    @Before
+    public void setup() {
+        mockStatic(PluginImpl.class);
+        PluginImpl plugin = mock(PluginImpl.class);
+        server = mock(GerritServer.class);
+        when(PluginImpl.getInstance()).thenReturn(plugin);
+        when(plugin.getServer(testServer)).thenReturn(server);
+        when(PluginImpl.getServer_(eq(testServer))).thenReturn(server);
+    }
 
     /**
      * Tests that the gerrit version is high enough to run the file trigger feature.
      */
     @Test
     public void testHighEnoughVersion() {
-        PowerMockito.mockStatic(PluginImpl.class);
-        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
-        GerritServer server = mock(GerritServer.class);
-        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
-        PowerMockito.when(plugin.getServer(testServer)).thenReturn(server);
-        PowerMockito.when(server.getGerritVersion()).thenReturn("2.3.1-450");
+        when(server.getGerritVersion()).thenReturn("2.3.1-450");
         assertTrue(GerritVersionChecker.isCorrectVersion(GerritVersionChecker.Feature.fileTrigger, testServer));
     }
 
@@ -67,12 +77,7 @@ public class VersionCheckTest {
      */
     @Test
     public void testNotHighEnoughVersion() {
-        PowerMockito.mockStatic(PluginImpl.class);
-        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
-        GerritServer server = mock(GerritServer.class);
-        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
-        PowerMockito.when(plugin.getServer(testServer)).thenReturn(server);
-        PowerMockito.when(server.getGerritVersion()).thenReturn("2.2.2.1-150");
+        when(server.getGerritVersion()).thenReturn("2.2.2.1-150");
         assertFalse(GerritVersionChecker.isCorrectVersion(GerritVersionChecker.Feature.fileTrigger, testServer));
     }
 
@@ -81,12 +86,7 @@ public class VersionCheckTest {
      */
     @Test
     public void testUnknownVersionEmpty() {
-        PowerMockito.mockStatic(PluginImpl.class);
-        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
-        GerritServer server = mock(GerritServer.class);
-        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
-        PowerMockito.when(plugin.getServer(testServer)).thenReturn(server);
-        PowerMockito.when(server.getGerritVersion()).thenReturn("");
+        when(server.getGerritVersion()).thenReturn("");
         assertTrue(GerritVersionChecker.isCorrectVersion(GerritVersionChecker.Feature.fileTrigger, testServer));
     }
 
@@ -95,12 +95,7 @@ public class VersionCheckTest {
      */
     @Test
     public void testUnknownVersionNull() {
-        PowerMockito.mockStatic(PluginImpl.class);
-        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
-        GerritServer server = mock(GerritServer.class);
-        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
-        PowerMockito.when(plugin.getServer(testServer)).thenReturn(server);
-        PowerMockito.when(server.getGerritVersion()).thenReturn(null);
+        when(server.getGerritVersion()).thenReturn(null);
         assertTrue(GerritVersionChecker.isCorrectVersion(GerritVersionChecker.Feature.fileTrigger , testServer));
     }
 
@@ -109,13 +104,8 @@ public class VersionCheckTest {
      */
     @Test
     public void testSnapshotVersion() {
-        PowerMockito.mockStatic(PluginImpl.class);
-        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
-        GerritServer server = mock(GerritServer.class);
-        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
-        PowerMockito.when(plugin.getServer(testServer)).thenReturn(server);
         String version = "2.2.2.1-340-g47084d4";
-        PowerMockito.when(server.getGerritVersion()).thenReturn(version);
+        when(server.getGerritVersion()).thenReturn(version);
         assertTrue(GerritVersionChecker.isCorrectVersion(GerritVersionChecker.Feature.fileTrigger , testServer));
         assertTrue(GerritVersionNumber.getGerritVersionNumber(version).isSnapshot());
     }


### PR DESCRIPTION
The bump in core version introduced @CheckforNull on Jenkins.getInstance
and escalated to PluginImpl.getInstance.
Added some static helper/shortcut methods in PluginImpl so not too many
new if statements littering the rest of the code.

This commit should fix all current, including old,
"possible null pointer dereference" warnings.