### PR TITLE
Parameter provider of Base64EncodedString is implemented for Rebuilder.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <dependency>
             <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
             <artifactId>rebuild</artifactId>
-            <version>1.1</version>
+            <version>1.22</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterProvider.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterProvider.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.parameters;
+
+import hudson.Extension;
+import hudson.model.ParameterValue;
+
+import com.sonyericsson.rebuild.RebuildParameterPage;
+import com.sonyericsson.rebuild.RebuildParameterProvider;
+
+/**
+ * An extension class to inject {@link Base64EncodedStringParameterProvider} to rebuild-plugin.
+ *
+ * @author Scott.Hebert &lt;Scott.Hebert@ericsson.com&gt;.
+ * @author Bowen.Cheng &lt;Bowen.Cheng@ericsson.com&gt;.
+ */
+@Extension(optional = true)
+public class Base64EncodedStringParameterProvider extends RebuildParameterProvider {
+    /**
+     * @param value ParameterValue to have rebuild page created for it.
+     * @return rebuild page for Base64EncodedStringParameterValue
+     * @see com.sonyericsson.rebuild.RebuildParameterProvider#getRebuildPage(hudson.model.ParameterValue)
+     */
+    @Override
+    public RebuildParameterPage getRebuildPage(ParameterValue value) {
+        if (value instanceof Base64EncodedStringParameterValue) {
+            return new RebuildParameterPage(Base64EncodedStringParameterValue.class,
+                "Base64EncodedStringParameterValue.jelly");
+        }
+
+        return null;
+    }
+
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterValue.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterValue.java
@@ -39,7 +39,7 @@ public class Base64EncodedStringParameterValue extends StringParameterValue {
     private static final int ABBREVIATE_LENGTH = 10;
 
     /**
-     * Default constractor.
+     * Default constructor.
      *
      * @param name the name.
      * @param value the value.
@@ -50,7 +50,7 @@ public class Base64EncodedStringParameterValue extends StringParameterValue {
     }
 
     /**
-     * Default constractor.
+     * Default constructor.
      * @param name the name.
      * @param value the value.
      * @param description the description.

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterValue/Base64EncodedStringParameterValue.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterValue/Base64EncodedStringParameterValue.jelly
@@ -27,6 +27,9 @@ THE SOFTWARE.
         xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
         xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
         <f:entry title="${it.name}" description="${it.description}">
+            <div name="parameter" description="${it.description}">
+                <input type="hidden" name="name" value="${it.name}" />
                 <f:textbox name="value" value="${it.value}" readonly="true" />
+            </div>
         </f:entry>
 </j:jelly>

--- a/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/matrix_build.xml
+++ b/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/matrix_build.xml
@@ -86,9 +86,6 @@
         </hudson.model.Cause_-UpstreamCause>
       </causes>
     </hudson.model.CauseAction>
-    <com.sonyericsson.rebuild.RebuildAction>
-      <rebuildurl>../buildWithParameters?GERRIT_BRANCH=master&amp;GERRIT_CHANGE_ID=Icbd12345&amp;GERRIT_CHANGE_NUMBER=38506&amp;GERRIT_CHANGE_SUBJECT=Removing the obsolete graphics&amp;GERRIT_CHANGE_URL=http://gerrit/38506&amp;GERRIT_PATCHSET_NUMBER=1&amp;GERRIT_PATCHSET_REVISION=cbd12345&amp;GERRIT_PROJECT=platform/project&amp;GERRIT_REFSPEC=refs/changes/06/38506/1</rebuildurl>
-    </com.sonyericsson.rebuild.RebuildAction>
   </actions>
   <number>102</number>
   <result>FAILURE</result>


### PR DESCRIPTION
The new provider class helps rebuild plugin to correctly display
Base64EncodedString parameters. When rebuilder plugin rebuilt a Gerrit
event triggered build, the parameters page was not displayed properly
without this provider class. matrix_build.xml is modified to pass a
failed test after changing dependency of Rebuild from v1.1 to v1.22.

Please consider the following test scenario of the provider class:

Given a Jenkins instance
 And Gerrit Trigger plugin installed on that Jenkins
 And an existing Gerrit instance configured on that Jenkins
 And Parameterized Trigger plugin installed on that Jenkins
 And Rebuilder plugin installed on that Jenkins
 And an upstream job that is triggered by Gerrit events
 And 'Commit message as human readable' is NOT set in the upstream job
 And once a build is finished, upstream job triggers a parameterized
     build of downstream job with 'current parameters'
When upstream job is triggered by a Gerrit event
 And the first build of both job completes
 And GERRIT_CHANGE_COMMIT_MESSAGE parameter is displayed properly in
     first build of both jobs
 And I rebuild the first build of the downstream job
Then the second build of downstream job should complete
 And GERRIT_CHANGE_COMMIT_MESSAGE parameter is displayed properly in
     second build of the downstream job

The test scenario is beyond scope of a unit test as it requires multiple
plugins preinstalled and it tests compatibility of these plugins.
Therefore its test should be written in Jenkins ATH rather than in
Gerrit Trigger project.

Our goal is to add such a test to ATH in the near future.

[FIXED JENKINS-26756]