### PR TITLE
Honor manual trigger even if it would have been deemed uninteresting

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -27,9 +27,12 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.events.ManualPatchsetCreated;
+
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
+
 import org.kohsuke.stapler.DataBoundConstructor;
 
 import java.io.Serializable;
@@ -108,6 +111,10 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
     public boolean shouldTriggerOn(GerritTriggeredEvent event) {
         if (!super.shouldTriggerOn(event)) {
             return false;
+        }
+        // if it was a manually triggered event, always honor it
+        if (event instanceof ManualPatchsetCreated) {
+            return true;
         }
         if (excludeDrafts && ((PatchsetCreated)event).getPatchSet().isDraft()) {
             return false;


### PR DESCRIPTION
Case in point : suppose a new change isn't validated for a transient reason
(Jenkins offline for maintenance, or a problem in the workspace), then a new
patchset is created which doesn't trigger a build, such as an edit of the
commit message, with "Exclude No Code Change" checked in the job configuration,
then there is no way to get a validation : a retrigger of patchset 1 will give
a validation on an obsolete patchset, and a manual trigger of patchset 2
doesn't work either since it is filtered by "Exclude No Code Change".