### PR TITLE
Gerrit notifier threads should impersonate SYSTEM

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/ssh/BuildCompletedCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/ssh/BuildCompletedCommandJob.java
@@ -25,12 +25,17 @@
 
 package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.ssh;
 
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+
 import com.sonymobile.tools.gerrit.gerritevents.workers.cmd.AbstractSendCommandJob;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.GerritNotifier;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.NotificationFactory;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildMemory;
+
 import hudson.model.TaskListener;
+import hudson.security.ACL;
 
 /**
  * A send-command-job that calculates and sends the builds completed command.
@@ -59,8 +64,13 @@ public class BuildCompletedCommandJob extends AbstractSendCommandJob {
 
     @Override
     public void run() {
-        GerritNotifier notifier = NotificationFactory.getInstance()
+        SecurityContext old = ACL.impersonate(ACL.SYSTEM);
+        try {
+            GerritNotifier notifier = NotificationFactory.getInstance()
                 .createGerritNotifier((IGerritHudsonTriggerConfig)getConfig(), this);
-        notifier.buildCompleted(memoryImprint, listener);
+            notifier.buildCompleted(memoryImprint, listener);
+        } finally {
+            SecurityContextHolder.setContext(old);
+        }
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/ssh/BuildStartedCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/ssh/BuildStartedCommandJob.java
@@ -25,14 +25,19 @@
 
 package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.ssh;
 
+import org.acegisecurity.context.SecurityContext;
+import org.acegisecurity.context.SecurityContextHolder;
+
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.workers.cmd.AbstractSendCommandJob;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.GerritNotifier;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.NotificationFactory;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildsStartedStats;
+
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
+import hudson.security.ACL;
 
 /**
  * A send-command-job that calculates and sends the build started command.
@@ -68,8 +73,13 @@ public class BuildStartedCommandJob extends AbstractSendCommandJob {
 
     @Override
     public void run() {
-        GerritNotifier notifier = NotificationFactory.getInstance()
+        SecurityContext old = ACL.impersonate(ACL.SYSTEM);
+        try {
+            GerritNotifier notifier = NotificationFactory.getInstance()
                 .createGerritNotifier((IGerritHudsonTriggerConfig)getConfig(), this);
-        notifier.buildStarted(build, taskListener, event, stats);
+            notifier.buildStarted(build, taskListener, event, stats);
+        } finally {
+            SecurityContextHolder.setContext(old);
+        }
     }
 }


### PR DESCRIPTION
The BuildCompletedCommandJob was not impersonating SYSTEM and was
therefore throwing permission-related exceptions.

For completeness, BuildStartedCommandJob was updated too.

Related to [JENKINS-23152]

Change-Id: I3eb6036d8186478a615c15036b4b7f98035dd54c