### PR TITLE
Restore value.jelly for Base64EncodedParameterValue

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterProvider.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterProvider.java
@@ -47,7 +47,7 @@ public class Base64EncodedStringParameterProvider extends RebuildParameterProvid
     public RebuildParameterPage getRebuildPage(ParameterValue value) {
         if (value instanceof Base64EncodedStringParameterValue) {
             return new RebuildParameterPage(Base64EncodedStringParameterValue.class,
-                "Base64EncodedStringParameterValue.jelly");
+                "rebuild.jelly");
         }
 
         return null;

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterValue/rebuild.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterValue/rebuild.jelly
@@ -2,7 +2,7 @@
 <!--
 The MIT License
 
-Copyright 2014 rinrinne a.k.a. rin_ne All rights reserved.
+Copyright (c) 2015 Ericsson
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterValue/value.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/parameters/Base64EncodedStringParameterValue/value.jelly
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<!--
+The MIT License
+
+Copyright 2014 rinrinne a.k.a. rin_ne All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define"
+        xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form"
+        xmlns:i="jelly:fmt" xmlns:p="/lib/hudson/project">
+        <f:entry title="${it.name}" description="${it.description}">
+            <input type="hidden" name="name" value="${it.name}" />
+            <f:textbox name="value" value="${it.value}" readonly="true" />
+        </f:entry>
+</j:jelly>


### PR DESCRIPTION
By previous patch, value.jelly for Base64EncodedParameterValue was lost.
It causes that this parameter is displayed using core's fallback
solution.

This patch adds value.jelly for displaying correctly.
In addition, renames jelly file and replace copyright.