### PR TITLE
Correct infinite loops caused by CommentAdded

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
@@ -788,7 +788,7 @@ public class BuildMemory {
             @CheckForNull
             public AbstractBuild getBuild() {
                 AbstractProject p = getProject();
-                if (p != null) {
+                if (p != null && build != null) {
                     return p.getBuild(build);
                 } else {
                     return null;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
@@ -58,7 +58,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.Gerri
  *
  * @author Robert Sandell &lt;rsandell@cloudbees.com&gt;.
  */
-final class EventListener implements GerritEventListener {
+public final class EventListener implements GerritEventListener {
 
     private static final Logger logger = LoggerFactory.getLogger(EventListener.class);
 


### PR DESCRIPTION
CommentAdded events were not be processed with the correct
gerritEvent() signature. This caused builds be triggered needlessly
and sometimes caused infinite loops between Jenkins and Gerrit.
    
This fix exposes the EventListener as a public class so that the Gerrit Events
GerritHandler can correctly invoke the appropriate methods.
    
This also corrects a NPE during a BuildStarted notification.
    
[JENKINS-23152]
