### PR TITLE
Introduce Google Truth

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,12 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>com.google.truth</groupId>
+            <artifactId>truth</artifactId>
+            <version>0.25</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.9.5</version>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/ChangeIdAnnotatorTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/ChangeIdAnnotatorTest.java
@@ -1,10 +1,10 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import hudson.MarkupText;
 import hudson.model.AbstractBuild;
-import junit.framework.Assert;
 
 import org.junit.Test;
 
@@ -58,6 +58,6 @@ public class ChangeIdAnnotatorTest {
         MarkupText t = new MarkupText(plain);
         new ChangeIdAnnotator().annotate(b, null, t);
         System.out.println(t.toString(true));
-        Assert.assertEquals(expected, t.toString(true));
+        assertThat(t.toString(true)).isEqualTo(expected);
     }
 }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdaterTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdaterTest.java
@@ -29,7 +29,7 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.List;
 
-import static org.junit.Assert.assertArrayEquals;
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Test class for the GerritProjectListUpdater.
@@ -56,11 +56,9 @@ public class GerritProjectListUpdaterTest {
         stringBuilder.append("tools/gerrit\n");
 
         List<String> projects = GerritProjectListUpdater.readProjects(new StringReader(stringBuilder.toString()));
-
-        assertArrayEquals(projects.toArray(), new String[] {
+        assertThat(projects).containsExactly(
             "tools/somepath/someproject",
             "tools/hello/jenkins",
-            "tools/gerrit",
-        });
+            "tools/gerrit");
     }
 }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerHudsonTest.java
@@ -44,10 +44,8 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 
-
-
-//CS IGNORE AvoidStarImport FOR NEXT 1 LINES. REASON: UnitTest.
-import static org.junit.Assert.*;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assert_;
 
 
 /**
@@ -150,14 +148,16 @@ public class GerritServerHudsonTest {
         TestUtils.waitForBuilds(projectTwo, 1);
 
         FreeStyleBuild buildOne = projectOne.getLastCompletedBuild();
-        assertSame(Result.SUCCESS, buildOne.getResult());
-        assertEquals(1, projectOne.getLastCompletedBuild().getNumber());
-        assertSame(gerritServerOneName, buildOne.getCause(GerritCause.class).getEvent().getProvider().getName());
+        assertThat(buildOne.getResult()).isEqualTo(Result.SUCCESS);
+        assertThat(projectOne.getLastCompletedBuild().getNumber()).is(1);
+        assertThat(buildOne.getCause(GerritCause.class).getEvent()
+            .getProvider().getName()).isEqualTo(gerritServerOneName);
 
         FreeStyleBuild buildTwo = projectTwo.getLastCompletedBuild();
-        assertSame(Result.SUCCESS, buildTwo.getResult());
-        assertEquals(1, projectTwo.getLastCompletedBuild().getNumber());
-        assertSame(gerritServerTwoName, buildTwo.getCause(GerritCause.class).getEvent().getProvider().getName());
+        assertThat(buildTwo.getResult()).isEqualTo(Result.SUCCESS);
+        assertThat(projectTwo.getLastCompletedBuild().getNumber()).is(1);
+        assertThat(buildTwo.getCause(GerritCause.class).getEvent()
+            .getProvider().getName()).isEqualTo(gerritServerTwoName);
     }
 
     /**
@@ -174,8 +174,9 @@ public class GerritServerHudsonTest {
 
         removeServer(gerritServerOneName);
 
-        assertEquals(1, PluginImpl.getInstance().getServers().size());
-        assertTrue(wrongMessageWarning, textContent.contains("Remove server"));
+        assertThat(PluginImpl.getInstance().getServers()).hasSize(1);
+        assert_().withFailureMessage(wrongMessageWarning).that(
+            textContent).contains("Remove server");
     }
 
     /**
@@ -194,10 +195,10 @@ public class GerritServerHudsonTest {
 
         removeServer(gerritServerOneName);
 
-        assertEquals(1, PluginImpl.getInstance().getServers().size());
-        assertTrue(wrongMessageWarning,
-                textContent.contains("Disable Gerrit Trigger in the following jobs and remove server \""
-                                    + gerritServerOneName + "\"?"));
+        assertThat(PluginImpl.getInstance().getServers()).hasSize(1);
+        assert_().withFailureMessage(wrongMessageWarning).that(textContent).contains(
+            "Disable Gerrit Trigger in the following jobs and remove server \""
+            + gerritServerOneName + "\"?");
     }
 
     /**
@@ -214,9 +215,9 @@ public class GerritServerHudsonTest {
 
         removeServer(gerritServerOneName);
 
-        assertEquals(false, buttonFound);
-        assertEquals(1, PluginImpl.getInstance().getServers().size());
-        assertEquals(removeLastServerWarning, textContent);
+        assertThat(buttonFound).isFalse();
+        assertThat(PluginImpl.getInstance().getServers()).hasSize(1);
+        assertThat(textContent).isEqualTo(removeLastServerWarning);
     }
 
     /**
@@ -230,9 +231,9 @@ public class GerritServerHudsonTest {
 
         removeServer(gerritServerOneName);
 
-        assertEquals(false, buttonFound);
-        assertEquals(1, PluginImpl.getInstance().getServers().size());
-        assertEquals(removeLastServerWarning, textContent);
+        assertThat(buttonFound).isFalse();
+        assertThat(PluginImpl.getInstance().getServers()).hasSize(1);
+        assertThat(textContent).isEqualTo(removeLastServerWarning);
     }
 
     /**
@@ -268,19 +269,19 @@ public class GerritServerHudsonTest {
     @Test
     public void testAddServer() throws IOException {
         addNewServerWithDefaultConfigs(gerritServerOneName);
-        assertEquals(1, PluginImpl.getInstance().getServers().size());
+        assertThat(PluginImpl.getInstance().getServers()).hasSize(1);
 
         addNewServerByCopyingConfig(gerritServerTwoName, gerritServerOneName);
-        assertEquals(2, PluginImpl.getInstance().getServers().size());
+        assertThat(PluginImpl.getInstance().getServers()).hasSize(2);
 
         //try add server with same name:
         try {
             addNewServerWithDefaultConfigs(gerritServerOneName);
         } catch (FailingHttpStatusCodeException e) {
-            assertEquals(badRequestErrorCode, e.getStatusCode());
+            assertThat(e.getStatusCode()).isEqualTo(badRequestErrorCode);
         }
         //make sure the server has not been added.
-        assertEquals(2, PluginImpl.getInstance().getServers().size());
+        assertThat(PluginImpl.getInstance().getServers()).hasSize(2);
     }
 
     /**
@@ -304,7 +305,9 @@ public class GerritServerHudsonTest {
                 radioButtonDefaultConfig.setChecked(true);
             }
         }
-        assertTrue("Failed to choose 'GerritServer with Default Configurations'", radioButtonDefaultConfig.isChecked());
+        assert_().withFailureMessage(
+            "Failed to choose 'GerritServer with Default Configurations'")
+            .that(radioButtonDefaultConfig.isChecked()).isTrue();
 
         form.submit(null);
     }
@@ -331,7 +334,9 @@ public class GerritServerHudsonTest {
                 radioButtonCopy.setChecked(true);
             }
         }
-        assertTrue("Failed to choose 'Copy from Existing Server Configurations'", radioButtonCopy.isChecked());
+        assert_().withFailureMessage(
+            "Failed to choose 'Copy from Existing Server Configurations'")
+            .that(radioButtonCopy.isChecked()).isTrue();
 
         form.getInputByName(fromInputFormName).setValueAttribute(fromServerName);
 
@@ -339,7 +344,7 @@ public class GerritServerHudsonTest {
     }
 
     /**
-     * Test not conect to Gerrit on startup.
+     * Test not connect to Gerrit on startup.
      * @throws Exception Error creating job.
      */
     @Test
@@ -347,6 +352,6 @@ public class GerritServerHudsonTest {
         GerritServer gerritServerOne = new GerritServer(gerritServerOneName, true);
         PluginImpl.getInstance().addServer(gerritServerOne);
         gerritServerOne.start();
-        assertEquals(true, gerritServerOne.isNoConnectionOnStartup());
+        assertThat(gerritServerOne.isNoConnectionOnStartup()).isTrue();
     }
 }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerTest.java
@@ -40,8 +40,8 @@ import org.powermock.reflect.Whitebox;
 import java.util.LinkedList;
 import java.util.List;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static com.google.common.truth.Truth.assertThat;
+import static com.google.common.truth.Truth.assert_;
 import static org.mockito.Matchers.eq;
 import static org.powermock.api.mockito.PowerMockito.mock;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
@@ -93,7 +93,7 @@ public class GerritServerTest {
         String version = "2.2.2.1-340-g47084d4";
         when(gerritServerOne.getGerritVersion()).thenReturn(version);
         listener.checkGerritVersionFeatures();
-        assertTrue(gerritServerOne.isGerritSnapshotVersion());
+        assertThat(gerritServerOne.isGerritSnapshotVersion()).isTrue();
     }
 
     /**
@@ -106,7 +106,7 @@ public class GerritServerTest {
         String version = "2.2.2.1";
         when(gerritServerOne.getGerritVersion()).thenReturn(version);
         listener.checkGerritVersionFeatures();
-        assertFalse(gerritServerOne.isGerritSnapshotVersion());
+        assertThat(gerritServerOne.isGerritSnapshotVersion()).isFalse();
     }
 
     /**
@@ -119,7 +119,7 @@ public class GerritServerTest {
         String version = "2.3-rc0";
         when(gerritServerOne.getGerritVersion()).thenReturn(version);
         listener.checkGerritVersionFeatures();
-        assertFalse(gerritServerOne.isGerritSnapshotVersion());
+        assertThat(gerritServerOne.isGerritSnapshotVersion()).isFalse();
     }
 
     /**
@@ -137,14 +137,15 @@ public class GerritServerTest {
         if (gerritServerOne.hasDisabledFeatures()) {
             disabledFeatures = gerritServerOne.getDisabledFeatures();
         }
-        assertFalse(disabledFeatures.isEmpty());
+        assertThat(disabledFeatures.isEmpty()).isFalse();
         boolean foundFileTrigger = false;
         for (GerritVersionChecker.Feature feature : disabledFeatures) {
             if (feature == GerritVersionChecker.Feature.fileTrigger) {
                 foundFileTrigger = true;
             }
         }
-        assertTrue("Expected to find the file trigger feature!", foundFileTrigger);
+        assert_().withFailureMessage("Expected to find the file trigger feature!")
+            .that(foundFileTrigger).isTrue();
     }
 
     /**
@@ -160,7 +161,7 @@ public class GerritServerTest {
         listener.checkGerritVersionFeatures();
 
         List<GerritVersionChecker.Feature> disabledFeatures = gerritServerOne.getDisabledFeatures();
-        assertTrue(disabledFeatures.isEmpty());
+        assertThat(disabledFeatures).isEmpty();
     }
 
     /**
@@ -174,7 +175,7 @@ public class GerritServerTest {
         when(gerritServerOne.getGerritVersion()).thenReturn(version);
         listener.checkGerritVersionFeatures();
 
-        assertTrue(gerritServerOne.hasDisabledFeatures());
+        assertThat(gerritServerOne.hasDisabledFeatures()).isTrue();
     }
 
     /**
@@ -189,6 +190,6 @@ public class GerritServerTest {
         when(gerritServerOne.getGerritVersion()).thenReturn(version);
         listener.checkGerritVersionFeatures();
 
-        assertFalse(gerritServerOne.hasDisabledFeatures());
+        assertThat(gerritServerOne.hasDisabledFeatures()).isFalse();
     }
 }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/LockedDownGerritEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/LockedDownGerritEventTest.java
@@ -24,8 +24,7 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger;
 
 import static com.sonymobile.tools.gerrit.gerritevents.mock.SshdServerMock.GERRIT_STREAM_EVENTS;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
+import static com.google.common.truth.Truth.assertThat;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Hudson;
@@ -145,13 +144,13 @@ public class LockedDownGerritEventTest {
         gerritServer.triggerEvent(Setup.createPatchsetCreated());
 
         TestUtils.waitForBuilds(project, 1);
-        assertEquals(server.getNrCommandsHistory("gerrit review.*"), 2);
+        assertThat(server.getNrCommandsHistory("gerrit review.*")).is(2);
 
         FreeStyleBuild buildOne = project.getLastCompletedBuild();
-        assertSame(Result.SUCCESS, buildOne.getResult());
-        assertEquals(1, project.getLastCompletedBuild().getNumber());
-        assertSame(PluginImpl.DEFAULT_SERVER_NAME,
-            buildOne.getCause(GerritCause.class).getEvent().getProvider().getName());
+        assertThat(buildOne.getResult()).isEqualTo(Result.SUCCESS);
+        assertThat(project.getLastCompletedBuild().getNumber()).is(1);
+        assertThat(buildOne.getCause(GerritCause.class).getEvent().getProvider().getName())
+            .isEqualTo(PluginImpl.DEFAULT_SERVER_NAME);
 
     }
 }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextParameterizedTriggeredItemEntityTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextParameterizedTriggeredItemEntityTest.java
@@ -23,7 +23,8 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data;
 
-import junit.framework.Assert;
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -56,7 +57,8 @@ public class TriggerContextParameterizedTriggeredItemEntityTest {
      */
     @Test
     public void testEquals() {
-        Assert.assertEquals(parameter.equal, parameter.wrap1.equals(parameter.wrap2));
+        assertThat(parameter.equal).isEqualTo(
+            parameter.wrap1.equals(parameter.wrap2));
     }
 
     /**
@@ -66,7 +68,8 @@ public class TriggerContextParameterizedTriggeredItemEntityTest {
     @Test
     public void testHashCode() {
         if (parameter.wrap2 != null) {
-            Assert.assertEquals(parameter.equal, parameter.wrap1.hashCode() == parameter.wrap2.hashCode());
+            assertThat(parameter.equal).isEqualTo(
+                parameter.wrap1.hashCode() == parameter.wrap2.hashCode());
         }
     }
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtilTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtilTest.java
@@ -1,6 +1,6 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.utils;
 
-import junit.framework.Assert;
+import static com.google.common.truth.Truth.assertThat;
 import org.junit.Test;
 
 /**
@@ -19,8 +19,6 @@ public class StringUtilTest {
         String valueOfParameter = "xxx\"xxx\"xxxx";
         String escapedString = StringUtil.escapeQuotes(valueOfParameter);
         String expectedString = "xxx\\\"xxx\\\"xxxx";
-        Assert.assertEquals(expectedString, escapedString);
-
-
+        assertThat(escapedString).isEqualTo(expectedString);
     }
 }


### PR DESCRIPTION
Truth [1] is a testing framework designed to make tests and their error
messages more readable and discoverable, while being extensible to new
types of objects.

Add dependency on truth in the pom file and convert some of the trigger
tests to use it.

This also gets rid of several deprecation warnings which were caused
by using junit.framework.Assert

[1] http://google.github.io/truth/

Change-Id: I6e2ed8e646fa4831a41639ad8a12b5b0a3d98f03