### PR TITLE
Build with Java 7

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Each job can be configured with one Gerrit server.
 
 # Environments
 * `linux`
-    * `java-1.6`
+    * `java-1.7`
         * `maven-3.0.4`
 
 You should have no problem running the plugin on a Windows server.

--- a/pom.xml
+++ b/pom.xml
@@ -198,8 +198,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.1</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
@@ -174,7 +174,7 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
      * @throws IOException if something unfortunate happens.
      */
     public static List<String> readProjects(Reader commandReader) throws IOException {
-        List<String> projects = new ArrayList<String>();
+        List<String> projects = new ArrayList<>();
         BufferedReader br = new BufferedReader(commandReader);
         String line = br.readLine();
 
@@ -213,7 +213,7 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
      */
     public synchronized List<String> getGerritProjects() {
         if (gerritProjects == null) {
-            gerritProjects = new ArrayList<String>();
+            gerritProjects = new ArrayList<>();
         }
         return gerritProjects;
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -381,7 +381,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
         //do not try to connect to gerrit unless there is a URL or a hostname in the text fields
         List<VerdictCategory> categories = config.getCategories();
         if (categories == null) {
-            categories = new LinkedList<VerdictCategory>();
+            categories = new LinkedList<>();
         }
         if (categories.isEmpty()) {
             categories.add(new VerdictCategory("CRVW", "Code Review"));
@@ -568,7 +568,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
         if (projectListUpdater != null) {
             return projectListUpdater.getGerritProjects();
         } else {
-            return new ArrayList<String>();
+            return new ArrayList<>();
         }
     }
 
@@ -800,7 +800,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
      */
     public static Map<Notify, String> notificationLevelTextsById() {
         ResourceBundleHolder holder = ResourceBundleHolder.get(Messages.class);
-        Map<Notify, String> textsById = new LinkedHashMap<Notify, String>(Notify.values().length, 1);
+        Map<Notify, String> textsById = new LinkedHashMap<>(Notify.values().length, 1);
         for (Notify level : Notify.values()) {
             textsById.put(level, holder.format("NotificationLevel_" + level));
         }
@@ -1093,7 +1093,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
                 return features;
             }
         }
-        return new LinkedList<GerritVersionChecker.Feature>();
+        return new LinkedList<>();
     }
 
     /**
@@ -1337,7 +1337,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
      */
     public List<ExceptionDataHelper> generateHelper() {
         WatchTimeExceptionData data = config.getExceptionData();
-        List<ExceptionDataHelper> list = new LinkedList<ExceptionDataHelper>();
+        List<ExceptionDataHelper> list = new LinkedList<>();
         list.add(new ExceptionDataHelper(Messages.MondayDisplayName(), Calendar.MONDAY, data));
         list.add(new ExceptionDataHelper(Messages.TuesdayDisplayName(), Calendar.TUESDAY, data));
         list.add(new ExceptionDataHelper(Messages.WednesdayDisplayName(), Calendar.WEDNESDAY, data));

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
@@ -99,7 +99,7 @@ public class PluginImpl extends Plugin {
             AbstractProject.BUILD);
 
     private static final Logger logger = LoggerFactory.getLogger(PluginImpl.class);
-    private final List<GerritServer> servers = new CopyOnWriteArrayList<GerritServer>();
+    private final List<GerritServer> servers = new CopyOnWriteArrayList<>();
     private transient GerritHandler gerritEventManager;
     private transient volatile boolean active = false;
 
@@ -189,7 +189,7 @@ public class PluginImpl extends Plugin {
      * @return the list of server names as a list.
      */
     public List<String> getServerNames() {
-        LinkedList<String> names = new LinkedList<String>();
+        LinkedList<String> names = new LinkedList<>();
         for (GerritServer s : getServers()) {
             names.add(s.getName());
         }
@@ -437,7 +437,7 @@ public class PluginImpl extends Plugin {
      * @return the list of jobs configured with this server.
      */
     public List<AbstractProject> getConfiguredJobs(String serverName) {
-        LinkedList<AbstractProject> configuredJobs = new LinkedList<AbstractProject>();
+        LinkedList<AbstractProject> configuredJobs = new LinkedList<>();
         for (AbstractProject<?, ?> project : Hudson.getInstance().getItems(AbstractProject.class)) { //get the jobs
             GerritTrigger gerritTrigger = project.getTrigger(GerritTrigger.class);
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -232,7 +232,7 @@ public class Config implements IGerritHudsonTriggerConfig {
         buildScheduleDelay = config.getBuildScheduleDelay();
         dynamicConfigRefreshInterval = config.getDynamicConfigRefreshInterval();
         if (config.getCategories() != null) {
-            categories = new LinkedList<VerdictCategory>();
+            categories = new LinkedList<>();
             for (VerdictCategory cat : config.getCategories()) {
                 categories.add(new VerdictCategory(cat.getVerdictValue(), cat.getVerdictDescription()));
             }
@@ -349,7 +349,7 @@ public class Config implements IGerritHudsonTriggerConfig {
         dynamicConfigRefreshInterval = formData.optInt(
                 "dynamicConfigRefreshInterval",
                 DEFAULT_DYNAMIC_CONFIG_REFRESH_INTERVAL);
-        categories = new LinkedList<VerdictCategory>();
+        categories = new LinkedList<>();
         if (formData.has("verdictCategories")) {
             Object cat = formData.get("verdictCategories");
             if (cat instanceof JSONArray) {
@@ -384,8 +384,8 @@ public class Config implements IGerritHudsonTriggerConfig {
      * @return the WatchTimeExceptionData
      */
     private WatchTimeExceptionData addWatchTimeExceptionData(JSONObject formData) {
-        List<Integer> days = new LinkedList<Integer>();
-        List<TimeSpan> exceptionTimes = new LinkedList<TimeSpan>();
+        List<Integer> days = new LinkedList<>();
+        List<TimeSpan> exceptionTimes = new LinkedList<>();
         int[] daysAsInt = new int[]{};
         if (formData.has("watchdogExceptions")) {
             JSONObject jsonObject = formData.getJSONObject(("watchdogExceptions"));
@@ -434,7 +434,7 @@ public class Config implements IGerritHudsonTriggerConfig {
     private WatchTimeExceptionData addWatchTimeExceptionData(WatchTimeExceptionData data) {
         if (data != null) {
             int[] daysAsInt = data.getDaysOfWeek();
-            List<TimeSpan> exceptionTimes = new LinkedList<TimeSpan>();
+            List<TimeSpan> exceptionTimes = new LinkedList<>();
             for (TimeSpan s : data.getTimesOfDay()) {
                 Time newFromTime = new Time(s.getFrom().getHour(), s.getFrom().getMinute());
                 Time newToTime = new Time(s.getTo().getHour(), s.getTo().getMinute());

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ReplicationConfig.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ReplicationConfig.java
@@ -78,7 +78,7 @@ public class ReplicationConfig {
     public ReplicationConfig(ReplicationConfig config) {
         enableReplication = config.isEnableReplication();
         if (config.getGerritSlaves() != null) {
-            slaves = new LinkedList<GerritSlave>();
+            slaves = new LinkedList<>();
             for (GerritSlave slave : config.getGerritSlaves()) {
                 GerritSlave slaveCopy = new GerritSlave(slave.getName(), slave.getHost(), slave.getTimeoutInSeconds());
                 slaves.add(slaveCopy);
@@ -155,7 +155,7 @@ public class ReplicationConfig {
      */
     public static ReplicationConfig createReplicationConfigFromJSON(JSONObject formData) {
         ReplicationConfig replicationConfig;
-        List<GerritSlave> slaves = new LinkedList<GerritSlave>();
+        List<GerritSlave> slaves = new LinkedList<>();
 
         boolean enableReplication = formData.has(ENABLE_REPLICATION_JSON_KEY);
         if (enableReplication) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcher.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcher.java
@@ -200,7 +200,7 @@ public final class DependencyQueueTaskDispatcher extends QueueTaskDispatcher
      */
     protected List<AbstractProject> getBlockingDependencyProjects(List<AbstractProject> dependencies,
             GerritTriggeredEvent event) {
-        List<AbstractProject> blockingProjects = new ArrayList<AbstractProject>();
+        List<AbstractProject> blockingProjects = new ArrayList<>();
         ToGerritRunListener toGerritRunListener = ToGerritRunListener.getInstance();
         if (toGerritRunListener != null) {
             for (AbstractProject dependency : dependencies) {
@@ -233,7 +233,7 @@ public final class DependencyQueueTaskDispatcher extends QueueTaskDispatcher
      * @return the list of projects
      */
     public static List<AbstractProject> getProjectsFromString(String projects, Item context) {
-        List<AbstractProject> dependencyJobs = new ArrayList<AbstractProject>();
+        List<AbstractProject> dependencyJobs = new ArrayList<>();
         if ((projects == null) || projects.equals("")) {
             return null;
         } else {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/events/ManualPatchsetCreated.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/events/ManualPatchsetCreated.java
@@ -110,7 +110,7 @@ public class ManualPatchsetCreated extends PatchsetCreated implements GerritEven
     @Override
     public synchronized void addListener(GerritEventLifecycleListener listener) {
         if (listeners == null) {
-            listeners = new LinkedList<GerritEventLifecycleListener>();
+            listeners = new LinkedList<>();
         }
         if (!listeners.contains(listener)) {
             listeners.add(listener);
@@ -206,7 +206,7 @@ public class ManualPatchsetCreated extends PatchsetCreated implements GerritEven
      */
     protected synchronized List<GerritEventLifecycleListener> getListeners() {
         if (listeners != null) {
-            return new LinkedList<GerritEventLifecycleListener>(listeners);
+            return new LinkedList<>(listeners);
         } else {
             return null;
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -221,7 +221,7 @@ public class ParameterExpander {
     private Map<String, String> createStandardParameters(AbstractBuild r, GerritTriggeredEvent gerritEvent,
             int codeReview, int verified, String notifyLevel) {
         //<GERRIT_NAME> <BRANCH> <CHANGE> <PATCHSET> <PATCHSET_REVISION> <REFSPEC> <BUILDURL> VERIFIED CODE_REVIEW
-        Map<String, String> map = new HashMap<String, String>(DEFAULT_PARAMETERS_COUNT);
+        Map<String, String> map = new HashMap<>(DEFAULT_PARAMETERS_COUNT);
         if (gerritEvent instanceof ChangeBasedEvent) {
             ChangeBasedEvent event = (ChangeBasedEvent)gerritEvent;
             map.put("GERRIT_NAME", event.getChange().getProject());

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJob.java
@@ -75,7 +75,7 @@ public class BuildCompletedRestCommandJob extends AbstractRestCommandJob {
     @Override
     protected ReviewInput createReview() {
         String message = parameterExpander.getBuildCompletedMessage(memoryImprint, listener);
-        Collection<ReviewLabel> scoredLabels = new ArrayList<ReviewLabel>();
+        Collection<ReviewLabel> scoredLabels = new ArrayList<>();
         if (memoryImprint.getEvent().isScorable()) {
             if (config.isRestCodeReview()) {
                 scoredLabels.add(new ReviewLabel(
@@ -90,7 +90,7 @@ public class BuildCompletedRestCommandJob extends AbstractRestCommandJob {
         }
         Notify notificationLevel = parameterExpander.getHighestNotificationLevel(memoryImprint, true);
         List<GerritMessageProvider> gerritMessageProviders = GerritMessageProvider.all();
-        Collection<CommentedFile> commentedFiles = new ArrayList<CommentedFile>();
+        Collection<CommentedFile> commentedFiles = new ArrayList<>();
         if (gerritMessageProviders != null) {
             for (GerritMessageProvider gerritMessageProvider : gerritMessageProviders) {
                 for (BuildMemory.MemoryImprint.Entry e : memoryImprint.getEntries()) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
@@ -69,8 +69,7 @@ public class BuildMemory {
     }
 
     private TreeMap<GerritTriggeredEvent, MemoryImprint> memory =
-            new TreeMap<GerritTriggeredEvent, MemoryImprint>(
-                    new GerritTriggeredEventComparator());
+            new TreeMap<>(new GerritTriggeredEventComparator());
     private static final Logger logger = LoggerFactory.getLogger(BuildMemory.class);
 
     /**
@@ -362,7 +361,7 @@ public class BuildMemory {
     public synchronized List<AbstractBuild> getBuilds(GerritTriggeredEvent event) {
         MemoryImprint pb = memory.get(event);
         if (pb != null) {
-            List<AbstractBuild> list = new LinkedList<AbstractBuild>();
+            List<AbstractBuild> list = new LinkedList<>();
             for (Entry entry : pb.getEntries()) {
                 if (entry.getBuild() != null) {
                     list.add(entry.getBuild());
@@ -400,7 +399,7 @@ public class BuildMemory {
     public static class MemoryImprint {
 
         private GerritTriggeredEvent event;
-        private List<Entry> list = new ArrayList<Entry>();
+        private List<Entry> list = new ArrayList<>();
 
         /**
          * Constructor.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
@@ -224,7 +224,7 @@ public final class EventListener implements GerritEventListener {
     private List<ParameterValue> getDefaultParametersValues(AbstractProject project) {
         ParametersDefinitionProperty paramDefProp =
                 (ParametersDefinitionProperty)project.getProperty(ParametersDefinitionProperty.class);
-        List<ParameterValue> defValues = new ArrayList<ParameterValue>();
+        List<ParameterValue> defValues = new ArrayList<>();
 
         /*
          * This check is made ONLY if someone calls this method even if isParametrized() is false.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritConnectionListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritConnectionListener.java
@@ -155,7 +155,7 @@ public class GerritConnectionListener implements ConnectionListener {
         if (connected) {
             GerritVersionNumber version =
                     GerritVersionChecker.createVersionNumber(getVersionString());
-            List<GerritVersionChecker.Feature> list = new LinkedList<GerritVersionChecker.Feature>();
+            List<GerritVersionChecker.Feature> list = new LinkedList<>();
             for (GerritVersionChecker.Feature f : GerritVersionChecker.Feature.values()) {
                 if (!GerritVersionChecker.isCorrectVersion(version, f)) {
                     list.add(f);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
@@ -119,7 +119,7 @@ public final class GerritDynamicUrlProcessor {
             throws IOException, ParseException {
       Pattern linePattern = buildLinePattern();
 
-      List<GerritProject> dynamicGerritProjects = new ArrayList<GerritProject>();
+      List<GerritProject> dynamicGerritProjects = new ArrayList<>();
       List<Branch> branches = null;
       List<Topic> topics = null;
       List<FilePath> filePaths = null;
@@ -171,10 +171,10 @@ public final class GerritDynamicUrlProcessor {
             dynamicGerritProjects.add(dynamicGerritProject);
           }
 
-          branches = new ArrayList<Branch>();
-          topics = new ArrayList<Topic>();
-          filePaths = new ArrayList<FilePath>();
-          forbiddenFilePaths = new ArrayList<FilePath>();
+          branches = new ArrayList<>();
+          topics = new ArrayList<>();
+          filePaths = new ArrayList<>();
+          forbiddenFilePaths = new ArrayList<>();
           dynamicGerritProject = new GerritProject(type, text, branches, topics, filePaths, forbiddenFilePaths);
         } else if (SHORTNAME_BRANCH.equals(item)) { // Branch
           if (branches == null) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectList.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectList.java
@@ -50,7 +50,7 @@ public final class GerritProjectList {
      * projectList data structure has Gerrit project's pattern as key value
      * and as content a ArrayList of Jenkins jobs related to that Gerrit project.
      */
-    private Map<String, ArrayList<GerritTrigger>> projectList = new HashMap<String, ArrayList<GerritTrigger>>();
+    private Map<String, ArrayList<GerritTrigger>> projectList = new HashMap<>();
 
     /**
      * A private Constructor prevents any other class from instantiating.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -559,7 +559,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
             return server.getConfig().getCategories();
          } else {
             logger.error("Could not find server {}", serverName);
-            return new LinkedList<VerdictCategory>();
+            return new LinkedList<>();
          }
     }
 
@@ -767,7 +767,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
         if (!shouldTriggerOnEventType(event)) {
             return false;
         }
-        List<GerritProject> allGerritProjects = new LinkedList<GerritProject>();
+        List<GerritProject> allGerritProjects = new LinkedList<>();
         if (gerritProjects != null) {
             allGerritProjects.addAll(gerritProjects);
         }
@@ -1113,7 +1113,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
      */
     private void initializeTriggerOnEvents() {
         if (triggerOnEvents == null) {
-            triggerOnEvents = new LinkedList<PluginGerritEvent>();
+            triggerOnEvents = new LinkedList<>();
         }
         if (triggerOnEvents.isEmpty()) {
             triggerOnEvents.add(new PluginPatchsetCreatedEvent());
@@ -1480,7 +1480,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
      * @return list of GerritSlave (can be empty but never null)
      */
     public List<GerritSlave> gerritSlavesToWaitFor(String gerritServerName) {
-        List<GerritSlave> gerritSlaves = new ArrayList<GerritSlave>();
+        List<GerritSlave> gerritSlaves = new ArrayList<>();
 
         GerritServer gerritServer = PluginImpl.getServer_(gerritServerName);
         if (gerritServer == null) {
@@ -1507,7 +1507,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
 
     @Override
     public List<Action> getProjectActions() {
-        List<Action> list = new LinkedList<Action>();
+        List<Action> list = new LinkedList<>();
         list.add(triggerInformationAction);
         return list;
     }
@@ -1597,7 +1597,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
             }
             //Check there are no cycles in the dependencies, by exploring all dependencies recursively
             //Only way of creating a cycle is if this project is in the dependencies somewhere.
-            Set<AbstractProject> explored = new HashSet<AbstractProject>();
+            Set<AbstractProject> explored = new HashSet<>();
             List<AbstractProject> directDependencies = DependencyQueueTaskDispatcher.getProjectsFromString(value,
                     project);
             if (directDependencies == null) {
@@ -1608,7 +1608,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
                 if (directDependency.getFullName().equals(project.getFullName())) {
                     return FormValidation.error(Messages.CannotAddSelfAsDependency());
                 }
-                java.util.Queue<AbstractProject> toExplore = new LinkedList<AbstractProject>();
+                java.util.Queue<AbstractProject> toExplore = new LinkedList<>();
                 toExplore.add(directDependency);
                 while (toExplore.size() > 0) {
                     AbstractProject currentlyExploring = toExplore.remove();
@@ -1834,7 +1834,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
      */
     public class RunningJobs {
         private final HashMap<GerritTriggeredEvent, ParametersAction> runningJobs =
-                new HashMap<GerritTriggeredEvent, ParametersAction>();
+                new HashMap<>();
 
         /**
          * Does the needful after a build has been scheduled.
@@ -1898,7 +1898,7 @@ public class GerritTrigger extends Trigger<AbstractProject> {
             Jenkins jenkins = Jenkins.getInstance();
             assert jenkins != null;
             for (Computer c : jenkins.getComputers()) {
-                List<Executor> executors = new ArrayList<Executor>();
+                List<Executor> executors = new ArrayList<>();
                 executors.addAll(c.getOneOffExecutors());
                 executors.addAll(c.getExecutors());
                 for (Executor e : executors) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/UnreviewedPatchesListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/UnreviewedPatchesListener.java
@@ -62,8 +62,8 @@ public class UnreviewedPatchesListener implements ConnectionListener {
      *
      * changeSet : [list of reviewers]
      */
-    private Map<JSONObject, List<String>> changeSets = new HashMap<JSONObject, List<String>>();
-    private List<PatchsetCreated> events = new ArrayList<PatchsetCreated>();
+    private Map<JSONObject, List<String>> changeSets = new HashMap<>();
+    private List<PatchsetCreated> events = new ArrayList<>();
     private String serverName;
 
     /**
@@ -124,7 +124,7 @@ public class UnreviewedPatchesListener implements ConnectionListener {
             }
 
             JSONObject currentPatchSet = (JSONObject)patchSetObj;
-            List<String> usernames = new ArrayList<String>();
+            List<String> usernames = new ArrayList<>();
             if (currentPatchSet.has("approvals")) {
                 JSONArray approvals = currentPatchSet.getJSONArray("approvals");
                 if (approvals == null) {
@@ -151,7 +151,7 @@ public class UnreviewedPatchesListener implements ConnectionListener {
      */
     private List<JSONObject> getCurrentPatchesFromGerrit(String project) throws IOException {
         final String queryString = "project:" + project + " is:open";
-        List<JSONObject> changeList = new ArrayList<JSONObject>();
+        List<JSONObject> changeList = new ArrayList<>();
         try {
             IGerritHudsonTriggerConfig config = getConfig();
             GerritQueryHandler handler = new GerritQueryHandler(config);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
@@ -196,7 +196,7 @@ public class ManualTriggerAction implements RootAction {
      *
      */
     public ArrayList<String> getEnabledServers() {
-        ArrayList<String> enabledServers = new ArrayList<String>();
+        ArrayList<String> enabledServers = new ArrayList<>();
         for (GerritServer s : PluginImpl.getServers_()) {
             if (s.getConfig().isEnableManualTrigger()) {
                 enabledServers.add(s.getName());
@@ -443,7 +443,7 @@ public class ManualTriggerAction implements RootAction {
      * @see #generateTheId(net.sf.json.JSONObject, net.sf.json.JSONObject)
      */
     private HashMap<String, JSONObject> indexResult(List<JSONObject> result) {
-        HashMap<String, JSONObject> map = new HashMap<String, JSONObject>();
+        HashMap<String, JSONObject> map = new HashMap<>();
         for (JSONObject res : result) {
             if (!res.has("type")) {
                 String changeId = generateTheId(res, null);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/TriggerMonitor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/TriggerMonitor.java
@@ -44,7 +44,7 @@ import java.util.List;
  */
 public class TriggerMonitor implements GerritEventLifecycleListener {
 
-    private List<EventState> events = new LinkedList<EventState>();
+    private List<EventState> events = new LinkedList<>();
 
     /**
      * Adds the event and a holder for its state to the list of triggered events.
@@ -172,7 +172,7 @@ public class TriggerMonitor implements GerritEventLifecycleListener {
          */
         EventState(GerritEventLifecycle gerritEventLifecycle) {
             this.gerritEventLifecycle = gerritEventLifecycle;
-            builds = new LinkedList<TriggeredItemEntity>();
+            builds = new LinkedList<>();
         }
 
         /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/CompareType.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/CompareType.java
@@ -53,7 +53,7 @@ public enum CompareType {
      * @return a list of available displaynames.
      */
     public static List<String> getDisplayNames() {
-        List<String> list = new LinkedList<String>();
+        List<String> list = new LinkedList<>();
         for (CompareType t : values()) {
             list.add(t.getDisplayName());
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
@@ -287,7 +287,7 @@ public class GerritProject implements Describable<GerritProject> {
          */
         public ComboBoxModel doFillPatternItems(@QueryParameter("serverName")
                 @RelativePath("..") final String serverName) {
-            Collection<String> projects = new HashSet<String>();
+            Collection<String> projects = new HashSet<>();
 
             if (serverName != null && !serverName.isEmpty()) {
                 if (ANY_SERVER.equals(serverName)) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContext.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContext.java
@@ -156,7 +156,7 @@ public class TriggerContext {
      */
     public synchronized void addOtherBuild(AbstractBuild build) {
         if (others == null) {
-            others = new LinkedList<TriggeredItemEntity>();
+            others = new LinkedList<>();
         }
         TriggeredItemEntity other = findOtherBuild(build);
         if (other == null) {
@@ -177,7 +177,7 @@ public class TriggerContext {
      */
     public synchronized void addOtherProject(AbstractProject project) {
         if (others == null) {
-            others = new LinkedList<TriggeredItemEntity>();
+            others = new LinkedList<>();
         }
         if (findOtherProject(project) == null) {
             others.add(new TriggeredItemEntity(project));
@@ -232,7 +232,7 @@ public class TriggerContext {
      * @return a list of builds from this context.
      */
     public synchronized List<AbstractBuild> getOtherBuilds() {
-        List<AbstractBuild> list = new LinkedList<AbstractBuild>();
+        List<AbstractBuild> list = new LinkedList<>();
         if (others != null) {
             for (TriggeredItemEntity entity : others) {
                 if (entity.getBuild() != null) {
@@ -249,7 +249,7 @@ public class TriggerContext {
      * @return a list of projects from this context.
      */
     public synchronized List<AbstractProject> getOtherProjects() {
-        List<AbstractProject> list = new LinkedList<AbstractProject>();
+        List<AbstractProject> list = new LinkedList<>();
         if (others != null) {
             for (TriggeredItemEntity entity : others) {
                 if (entity.getProject() != null) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextConverter.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextConverter.java
@@ -142,7 +142,7 @@ public class TriggerContextConverter implements Converter {
                 TriggeredItemEntity entity = unmarshalItemEntity(reader, context);
                 tc.setThisBuild(entity);
             } else if ("others".equalsIgnoreCase(reader.getNodeName())) {
-                List<TriggeredItemEntity> list = new LinkedList<TriggeredItemEntity>();
+                List<TriggeredItemEntity> list = new LinkedList<>();
                 while (reader.hasMoreChildren()) {
                     reader.moveDown();
                     TriggeredItemEntity entity = unmarshalItemEntity(reader, context);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedEvent.java
@@ -124,7 +124,7 @@ public class PluginCommentAddedEvent extends PluginGerritEvent implements Serial
 
             Collection<VerdictCategory> list = null;
             if (ANY_SERVER.equals(serverName)) { //list all configured VCs in all servers
-                Map<String, VerdictCategory> map = new HashMap<String, VerdictCategory>();
+                Map<String, VerdictCategory> map = new HashMap<>();
                 for (GerritServer server : PluginImpl.getServers_()) {
                     for (VerdictCategory vc : server.getConfig().getCategories()) {
                         if (!map.containsKey(vc.getVerdictValue())) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImpl.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImpl.java
@@ -59,7 +59,7 @@ public class RabbitMQMessageListenerImpl extends MessageQueueListener {
     private static final String GERRIT_VERSION   = "gerrit-version";
 
     private GerritTriggerApi api = null;
-    private Set<String> queueNames = new CopyOnWriteArraySet<String>();
+    private Set<String> queueNames = new CopyOnWriteArraySet<>();
 
     @Override
     public String getName() {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcher.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcher.java
@@ -106,7 +106,7 @@ public class ReplicationQueueTaskDispatcher extends QueueTaskDispatcher implemen
      */
     ReplicationQueueTaskDispatcher(@CheckForNull GerritHandler gerritHandler,
                                    @Nonnull ReplicationCache replicationCache) {
-        blockedItems = new ConcurrentHashMap<Integer, BlockedItem>();
+        blockedItems = new ConcurrentHashMap<>();
         this.replicationCache = replicationCache;
         if (gerritHandler != null) {
             logger.warn("No GerritHandler was specified, won't register as event listener, so no function.");
@@ -344,7 +344,7 @@ public class ReplicationQueueTaskDispatcher extends QueueTaskDispatcher implemen
             this.gerritProject = gerritProject;
             this.ref = ref;
             this.gerritServer = gerritServer;
-            this.slavesWaitingFor = new ConcurrentHashMap<String, GerritSlave>(gerritSlaves.size());
+            this.slavesWaitingFor = new ConcurrentHashMap<>(gerritSlaves.size());
             for (GerritSlave gerritSlave : gerritSlaves) {
                 slavesWaitingFor.put(gerritSlave.getHost(), gerritSlave);
             }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerTest.java
@@ -133,7 +133,7 @@ public class GerritServerTest {
         when(gerritServerOne.getGerritVersion()).thenReturn(version);
         listener.checkGerritVersionFeatures();
 
-        List<GerritVersionChecker.Feature> disabledFeatures = new LinkedList<GerritVersionChecker.Feature>();
+        List<GerritVersionChecker.Feature> disabledFeatures = new LinkedList<>();
         if (gerritServerOne.hasDisabledFeatures()) {
             disabledFeatures = gerritServerOne.getDisabledFeatures();
         }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcherTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcherTest.java
@@ -124,7 +124,7 @@ public class DependencyQueueTaskDispatcherTest {
      */
     @Test
     public void shouldNotBlockNonAbstractProjects() {
-        List<Action> actions = new ArrayList<Action>();
+        List<Action> actions = new ArrayList<>();
         Queue.Item item = new WaitingItem(Calendar.getInstance(), null, actions);
         CauseOfBlockage cause = dispatcher.canRun(new Queue.BuildableItem((WaitingItem)item));
         assertNull("Build should not be blocked", cause);
@@ -290,7 +290,7 @@ public class DependencyQueueTaskDispatcherTest {
      * @return the queue item
      */
     private Queue.Item createItem(GerritCause gerritCause, String dependency) {
-        List<Action> actions = new ArrayList<Action>();
+        List<Action> actions = new ArrayList<>();
         actions.add(new CauseAction(gerritCause));
 
         abstractProjectMock = mock(AbstractProject.class);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderParameterizedTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderParameterizedTest.java
@@ -86,7 +86,7 @@ public class ParameterExpanderParameterizedTest {
      */
     @Parameters
     public static Collection getParameters() {
-        List<TestParameters[]> list = new LinkedList<TestParameters[]>();
+        List<TestParameters[]> list = new LinkedList<>();
 
         IGerritHudsonTriggerConfig config = Setup.createConfig();
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderSkipVoteParameterTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderSkipVoteParameterTest.java
@@ -92,7 +92,7 @@ public class ParameterExpanderSkipVoteParameterTest {
      */
     @Parameterized.Parameters
     public static Collection getParameters() {
-        List<TestParameter[]> parameters = new LinkedList<TestParameter[]>();
+        List<TestParameter[]> parameters = new LinkedList<>();
 
         parameters.add(createParameter(+1, +2,
                 Setup.createAndSetupMemoryImprintEntry(Result.SUCCESS, +1, +2, false),

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
@@ -99,7 +99,7 @@ public class ParameterExpanderTest {
         when(hudson.getRootUrl()).thenReturn("http://localhost/");
 
         PowerMockito.mockStatic(GerritMessageProvider.class);
-        List<GerritMessageProvider> messageProviderExtensionList = new LinkedList<GerritMessageProvider>();
+        List<GerritMessageProvider> messageProviderExtensionList = new LinkedList<>();
         messageProviderExtensionList.add(new GerritMessageProviderExtension());
         messageProviderExtensionList.add(new GerritMessageProviderExtensionReturnNull());
         when(GerritMessageProvider.all()).thenReturn(messageProviderExtensionList);
@@ -476,7 +476,7 @@ public class ParameterExpanderTest {
         final String expectedRefSpec = StringUtil.makeRefSpec((ChangeBasedEvent)event);
 
         PowerMockito.mockStatic(GerritMessageProvider.class);
-        List<GerritMessageProvider> messageProviderExtensionList = new LinkedList<GerritMessageProvider>();
+        List<GerritMessageProvider> messageProviderExtensionList = new LinkedList<>();
         messageProviderExtensionList.add(new GerritMessageProviderExtension());
         messageProviderExtensionList.add(new GerritMessageProviderExtensionReturnNull());
         when(GerritMessageProvider.all()).thenReturn(messageProviderExtensionList);
@@ -561,7 +561,7 @@ public class ParameterExpanderTest {
         when(memoryImprint.getEntries()).thenReturn(entries);
 
         PowerMockito.mockStatic(GerritMessageProvider.class);
-        List<GerritMessageProvider> messageProviderExtensionList = new LinkedList<GerritMessageProvider>();
+        List<GerritMessageProvider> messageProviderExtensionList = new LinkedList<>();
         messageProviderExtensionList.add(new GerritMessageProviderExtension());
         messageProviderExtensionList.add(new GerritMessageProviderExtensionReturnNull());
         when(GerritMessageProvider.all()).thenReturn(messageProviderExtensionList);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListenerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListenerTest.java
@@ -160,7 +160,7 @@ public class ToGerritRunListenerTest {
         doReturn(envVars).when(build).getEnvironment();
         doReturn(envVars).when(build).getEnvironment(any(TaskListener.class));
 
-        Map<String, String> buildVarsMap = new HashMap<String, String>();
+        Map<String, String> buildVarsMap = new HashMap<>();
         buildVarsMap.put("BUILD_NUM", Integer.toString(buildNumber));
         when(build.getBuildVariables()).thenReturn(buildVarsMap);
 
@@ -403,7 +403,7 @@ public class ToGerritRunListenerTest {
         GerritCause cause = new GerritCause(event, true);
         when(build.getCause(GerritCause.class)).thenReturn(cause);
         CauseAction causeAction = mock(CauseAction.class);
-        List<Cause> causes = new LinkedList<Cause>();
+        List<Cause> causes = new LinkedList<>();
         causes.add(cause);
         when(causeAction.getCauses()).thenReturn(causes);
         when(build.getAction(CauseAction.class)).thenReturn(causeAction);
@@ -428,7 +428,7 @@ public class ToGerritRunListenerTest {
         GerritCause cause = new GerritCause(event, true);
         when(build.getCause(GerritCause.class)).thenReturn(cause);
         CauseAction causeAction = mock(CauseAction.class);
-        List<Cause> causes = new LinkedList<Cause>();
+        List<Cause> causes = new LinkedList<>();
         causes.add(cause);
         causes.add(cause);
         causes.add(cause);
@@ -455,7 +455,7 @@ public class ToGerritRunListenerTest {
         GerritCause cause = new GerritCause(event, true);
         when(build.getCause(GerritCause.class)).thenReturn(cause);
         CauseAction causeAction = mock(CauseAction.class);
-        List<Cause> causes = new LinkedList<Cause>();
+        List<Cause> causes = new LinkedList<>();
         causes.add(cause);
         causes.add(new GerritCause(event, true));
         causes.add(new GerritCause(event, true));
@@ -485,7 +485,7 @@ public class ToGerritRunListenerTest {
         manualCause.setEvent(event);
         manualCause.setSilentMode(true);
         CauseAction causeAction = mock(CauseAction.class);
-        List<Cause> causes = new LinkedList<Cause>();
+        List<Cause> causes = new LinkedList<>();
         causes.add(cause);
         causes.add(manualCause);
         causes.add(cause);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectListTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectListTest.java
@@ -61,7 +61,7 @@ public class GerritProjectListTest {
      * @return GerritProject the created project.
      */
     private GerritProject createGerritProject(String pattern, CompareType compareType) {
-        List<Branch> branches = new LinkedList<Branch>();
+        List<Branch> branches = new LinkedList<>();
         Branch branch = new Branch(compareType, "master");
         branches.add(branch);
         GerritProject config = new GerritProject(CompareType.PLAIN, pattern, branches, null, null, null);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParametersTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParametersTest.java
@@ -82,7 +82,7 @@ public class GerritTriggerParametersTest {
     public void setOrCreateParametersProviderUrl() throws Exception {
         PatchsetCreated created = Setup.createPatchsetCreated();
         AbstractProject project = j.createFreeStyleProject();
-        LinkedList<ParameterValue> parameters = new LinkedList<ParameterValue>();
+        LinkedList<ParameterValue> parameters = new LinkedList<>();
         GerritTriggerParameters.setOrCreateParameters(created, project, parameters);
         StringParameterValue param = findParameter(GerritTriggerParameters.GERRIT_CHANGE_URL, parameters);
         assertNotNull(param);
@@ -101,7 +101,7 @@ public class GerritTriggerParametersTest {
         created.setProvider(null);
         AbstractProject project = j.createFreeStyleProject();
         GerritTrigger trigger = Setup.createDefaultTrigger(project);
-        LinkedList<ParameterValue> parameters = new LinkedList<ParameterValue>();
+        LinkedList<ParameterValue> parameters = new LinkedList<>();
         GerritTriggerParameters.setOrCreateParameters(created, project, parameters);
         StringParameterValue param = findParameter(GerritTriggerParameters.GERRIT_CHANGE_URL, parameters);
         assertNotNull(param);
@@ -121,7 +121,7 @@ public class GerritTriggerParametersTest {
         AbstractProject project = j.createFreeStyleProject();
         GerritTrigger trigger = Setup.createDefaultTrigger(project);
         trigger.setServerName(GerritServer.ANY_SERVER);
-        LinkedList<ParameterValue> parameters = new LinkedList<ParameterValue>();
+        LinkedList<ParameterValue> parameters = new LinkedList<>();
         GerritTriggerParameters.setOrCreateParameters(created, project, parameters);
         StringParameterValue param = findParameter(GerritTriggerParameters.GERRIT_CHANGE_URL, parameters);
         assertNotNull(param);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
@@ -452,7 +452,7 @@ public class GerritTriggerTest {
         when(project.getFullDisplayName()).thenReturn("MockedProject");
         when(project.getFullName()).thenReturn("MockedProject");
         ParametersDefinitionProperty parameters = mock(ParametersDefinitionProperty.class);
-        List<ParameterDefinition> list = new LinkedList<ParameterDefinition>();
+        List<ParameterDefinition> list = new LinkedList<>();
         list.add(new StringParameterDefinition("MOCK_PARAM", "mock_value"));
         when(parameters.getParameterDefinitions()).thenReturn(list);
         when(project.getProperty(ParametersDefinitionProperty.class)).thenReturn(parameters);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionTest.java
@@ -225,7 +225,7 @@ public class ManualTriggerActionTest {
 
         change.put("patchSets", patchSets);
 
-        List<JSONObject> result = new LinkedList<JSONObject>();
+        List<JSONObject> result = new LinkedList<>();
         result.add(change);
 
         JSONObject type = new JSONObject();

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
@@ -69,29 +69,29 @@ public class GerritProjectInterestingTest {
     @Parameters
     public static Collection getParameters() {
 
-        List<InterestingScenario[]> parameters = new LinkedList<InterestingScenario[]>();
+        List<InterestingScenario[]> parameters = new LinkedList<>();
 
-        List<Branch> branches = new LinkedList<Branch>();
-        List<Topic> topics = new LinkedList<Topic>();
+        List<Branch> branches = new LinkedList<>();
+        List<Topic> topics = new LinkedList<>();
         Branch branch = new Branch(CompareType.PLAIN, "master");
         branches.add(branch);
         GerritProject config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "origin/master", null, true), });
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
@@ -99,7 +99,7 @@ public class GerritProjectInterestingTest {
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.PLAIN, "olstorp");
         branches.add(branch);
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
@@ -108,30 +108,30 @@ public class GerritProjectInterestingTest {
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "feature/mymaster", null, true), });
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
         config = new GerritProject(CompareType.ANT, "vendor/**/project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "vendor/semc/master/project", "origin/master", null, true), });
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.PLAIN, "master");
         branches.add(branch);
-        topics = new LinkedList<Topic>();
+        topics = new LinkedList<>();
         Topic topic = new Topic(CompareType.PLAIN, "topic");
         topics.add(topic);
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", "topic", true)});
 
-        topics = new LinkedList<Topic>();
+        topics = new LinkedList<>();
         topic = new Topic(CompareType.ANT, "**/topic");
         topics.add(topic);
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "master", "team/topic", true), });
 
-        topics = new LinkedList<Topic>();
+        topics = new LinkedList<>();
         topic = new Topic(CompareType.REG_EXP, ".*_topic");
         topics.add(topic);
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
@@ -67,57 +67,57 @@ public class GerritProjectWithFilesInterestingTest {
     @Parameters
     public static Collection getParameters() {
 
-        List<InterestingScenarioWithFiles[]> parameters = new LinkedList<InterestingScenarioWithFiles[]>();
+        List<InterestingScenarioWithFiles[]> parameters = new LinkedList<>();
 
-        List<Branch> branches = new LinkedList<Branch>();
+        List<Branch> branches = new LinkedList<>();
         Branch branch = new Branch(CompareType.PLAIN, "master");
         branches.add(branch);
-        List<Topic> topics = new LinkedList<Topic>();
-        List<FilePath> filePaths = new LinkedList<FilePath>();
+        List<Topic> topics = new LinkedList<>();
+        List<FilePath> filePaths = new LinkedList<>();
         FilePath filePath = new FilePath(CompareType.PLAIN, "test.txt");
         filePaths.add(filePath);
         List<FilePath> forbiddenFilePaths = null;
         GerritProject config = new GerritProject(
                 CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths);
-        List<String> files = new LinkedList<String>();
+        List<String> files = new LinkedList<>();
         files.add("test.txt");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "project", "master", null, files, true), });
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
         branches.add(branch);
-        filePaths = new LinkedList<FilePath>();
+        filePaths = new LinkedList<>();
         filePath = new FilePath(CompareType.REG_EXP, "tests/.*");
         filePaths.add(filePath);
-        files = new LinkedList<String>();
+        files = new LinkedList<>();
         files.add("tests/test.txt");
         forbiddenFilePaths = null;
         config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "projectNumber5", "feature/mymaster", null, files, true), });
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
-        filePaths = new LinkedList<FilePath>();
+        filePaths = new LinkedList<>();
         filePath = new FilePath(CompareType.ANT, "**/*test*");
         filePaths.add(filePath);
         forbiddenFilePaths = null;
         config = new GerritProject(
                 CompareType.ANT, "vendor/**/project", branches, topics, filePaths, forbiddenFilePaths);
-        files = new LinkedList<String>();
+        files = new LinkedList<>();
         files.add("resources/test.xml");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "vendor/semc/master/project", "origin/master", null, files, true), });
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
         branches.add(branch);
-        filePaths = new LinkedList<FilePath>();
+        filePaths = new LinkedList<>();
         filePath = new FilePath(CompareType.REG_EXP, "tests/.*");
         filePaths.add(filePath);
-        files = new LinkedList<String>();
+        files = new LinkedList<>();
         files.add("notintests/test.txt");
         forbiddenFilePaths = null;
         config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
@@ -125,51 +125,51 @@ public class GerritProjectWithFilesInterestingTest {
                 config, "projectNumber5", "feature/mymaster", null, files, false), });
 
         //Testing with Forbidden File Paths now
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.PLAIN, "master");
         branches.add(branch);
-        topics = new LinkedList<Topic>();
-        filePaths = new LinkedList<FilePath>();
+        topics = new LinkedList<>();
+        filePaths = new LinkedList<>();
         filePath = new FilePath(CompareType.PLAIN, "test.txt");
         filePaths.add(filePath);
-        forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePaths = new LinkedList<>();
         FilePath forbiddenFilePath = new FilePath(CompareType.PLAIN, "test2.txt");
         forbiddenFilePaths.add(forbiddenFilePath);
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths);
-        files = new LinkedList<String>();
+        files = new LinkedList<>();
         files.add("test.txt");
         files.add("test2.txt");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "project", "master", null, files, false), });
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
         branches.add(branch);
-        filePaths = new LinkedList<FilePath>();
+        filePaths = new LinkedList<>();
         filePath = new FilePath(CompareType.REG_EXP, "tests/.*");
         filePaths.add(filePath);
-        forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePaths = new LinkedList<>();
         forbiddenFilePath = new FilePath(CompareType.REG_EXP, "tests/.*2.*");
         forbiddenFilePaths.add(forbiddenFilePath);
-        files = new LinkedList<String>();
+        files = new LinkedList<>();
         files.add("tests/test.txt");
         files.add("tests/test2.txt");
         config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "projectNumber5", "feature/mymaster", null, files, false), });
 
-        branches = new LinkedList<Branch>();
+        branches = new LinkedList<>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
-        filePaths = new LinkedList<FilePath>();
+        filePaths = new LinkedList<>();
         filePath = new FilePath(CompareType.ANT, "**/*test*");
         filePaths.add(filePath);
-        forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePaths = new LinkedList<>();
         forbiddenFilePath = new FilePath(CompareType.ANT, "**/*skip*");
         forbiddenFilePaths.add(forbiddenFilePath);
         config = new GerritProject(
                 CompareType.ANT, "vendor/**/project", branches, topics, filePaths, forbiddenFilePaths);
-        files = new LinkedList<String>();
+        files = new LinkedList<>();
         files.add("resources/test.xml");
         files.add("files/skip.txt");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextConverterTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextConverterTest.java
@@ -188,7 +188,7 @@ public class TriggerContextConverterTest {
         PatchsetCreated event = Setup.createPatchsetCreated();
         TriggerContext context = new TriggerContext(event);
         context.setThisBuild(entity);
-        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<TriggeredItemEntity>();
+        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<>();
         otherBuilds.add(new TriggeredItemEntity(1, "projectY"));
         otherBuilds.add(new TriggeredItemEntity(12, "projectZ"));
         context.setOthers(otherBuilds);
@@ -232,7 +232,7 @@ public class TriggerContextConverterTest {
         PatchsetCreated event = Setup.createPatchsetCreated();
         TriggerContext context = new TriggerContext(event);
         context.setThisBuild(entity);
-        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<TriggeredItemEntity>();
+        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<>();
         otherBuilds.add(new TriggeredItemEntity(1, "projectY"));
         otherBuilds.add(null);
         otherBuilds.add(new TriggeredItemEntity(12, "projectZ"));
@@ -286,7 +286,7 @@ public class TriggerContextConverterTest {
 
         TriggerContext context = new TriggerContext(event);
         context.setThisBuild(entity);
-        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<TriggeredItemEntity>();
+        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<>();
         otherBuilds.add(new TriggeredItemEntity(1, "projectY"));
         otherBuilds.add(new TriggeredItemEntity(12, "projectZ"));
         context.setOthers(otherBuilds);
@@ -332,7 +332,7 @@ public class TriggerContextConverterTest {
 
         TriggerContext context = new TriggerContext(event);
         context.setThisBuild(entity);
-        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<TriggeredItemEntity>();
+        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<>();
         otherBuilds.add(new TriggeredItemEntity(1, "projectY"));
         otherBuilds.add(new TriggeredItemEntity(12, "projectZ"));
         context.setOthers(otherBuilds);
@@ -378,7 +378,7 @@ public class TriggerContextConverterTest {
 
         TriggerContext context = new TriggerContext(event);
         context.setThisBuild(entity);
-        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<TriggeredItemEntity>();
+        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<>();
         otherBuilds.add(new TriggeredItemEntity(1, "projectY"));
         otherBuilds.add(new TriggeredItemEntity(12, "projectZ"));
         context.setOthers(otherBuilds);
@@ -458,7 +458,7 @@ public class TriggerContextConverterTest {
 
         TriggerContext context = new TriggerContext(event);
         context.setThisBuild(entity);
-        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<TriggeredItemEntity>();
+        LinkedList<TriggeredItemEntity> otherBuilds = new LinkedList<>();
         otherBuilds.add(new TriggeredItemEntity(1, "projectY"));
         otherBuilds.add(new TriggeredItemEntity(12, "projectZ"));
         context.setOthers(otherBuilds);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextParameterizedTriggeredItemEntityTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextParameterizedTriggeredItemEntityTest.java
@@ -76,7 +76,7 @@ public class TriggerContextParameterizedTriggeredItemEntityTest {
      */
     @Parameters
     public static final Collection getParameters() {
-        List<TestParameter[]> parameters = new LinkedList<TestParameter[]>();
+        List<TestParameter[]> parameters = new LinkedList<>();
 
         parameters.add(new TestParameter[]{new TestParameter(
                     new TriggeredItemEntity(0, "project"),

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextTest.java
@@ -311,7 +311,7 @@ public class TriggerContextTest {
      */
     @Test
     public void testGetOtherBuildsOne() {
-        List<TriggeredItemEntity> bah = new LinkedList<TriggeredItemEntity>();
+        List<TriggeredItemEntity> bah = new LinkedList<>();
         bah.add(new TriggeredItemEntity(mockBuild("p2", 3)));
         TriggerContext context = new TriggerContext(mockBuild("p", 2), null, bah);
         List<AbstractBuild> others = context.getOtherBuilds();

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImplTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/impls/RabbitMQMessageListenerImplTest.java
@@ -95,7 +95,7 @@ public class RabbitMQMessageListenerImplTest {
         RabbitMQMessageListenerImpl listener = new RabbitMQMessageListenerImpl();
         Whitebox.setInternalState(listener, GerritTriggerApi.class, apiMock);
 
-        Map<String, Object> header = new HashMap<String, Object>();
+        Map<String, Object> header = new HashMap<>();
         header.put("gerrit-name", LongStringHelper.asLongString("gerrit1"));
         header.put("gerrit-host", LongStringHelper.asLongString("gerrit1.localhost"));
         header.put("gerrit-port", LongStringHelper.asLongString("29418"));

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
@@ -80,7 +80,7 @@ public abstract class DuplicatesUtil {
     public static FreeStyleProject createGerritTriggeredJob(JenkinsRule rule,
             String projectName, String serverName) throws Exception {
         FreeStyleProject p = rule.createFreeStyleProject(projectName);
-        List<GerritProject> projects = new LinkedList<GerritProject>();
+        List<GerritProject> projects = new LinkedList<>();
         projects.add(new GerritProject(CompareType.ANT, "**",
                 Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null));
         p.addTrigger(new GerritTrigger(projects, null,
@@ -102,14 +102,14 @@ public abstract class DuplicatesUtil {
      */
     public static FreeStyleProject createGerritDynamicTriggeredJob(JenkinsRule rule, String name) throws Exception {
         FreeStyleProject p = rule.createFreeStyleProject(name);
-        List<GerritProject> projects = new LinkedList<GerritProject>();
+        List<GerritProject> projects = new LinkedList<>();
 
         File file = File.createTempFile("dynamic", "txt");
         FileWriter fw = new FileWriter(file);
         fw.write("p=project\n");
         fw.write("b=branch");
         fw.close();
-        List<PluginGerritEvent> list = new LinkedList<PluginGerritEvent>();
+        List<PluginGerritEvent> list = new LinkedList<>();
         URI uri = file.toURI();
         String filepath = uri.toURL().toString();
         GerritTrigger trigger = new GerritTrigger(projects, null,
@@ -149,11 +149,11 @@ public abstract class DuplicatesUtil {
             String name, String serverName)
             throws Exception {
         FreeStyleProject p = rule.createFreeStyleProject(name);
-        List<GerritProject> projects = new LinkedList<GerritProject>();
+        List<GerritProject> projects = new LinkedList<>();
         projects.add(new GerritProject(CompareType.ANT, "**",
                 Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null));
         PluginCommentAddedEvent event = new PluginCommentAddedEvent("CRVW", "1");
-        List<PluginGerritEvent> list = new LinkedList<PluginGerritEvent>();
+        List<PluginGerritEvent> list = new LinkedList<>();
         list.add(event);
         p.addTrigger(new GerritTrigger(projects, null,
                 null, null, null, null, null, null, null, null, null, null,

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -260,7 +260,7 @@ public class MockGerritHudsonTriggerConfig implements
 
     @Override
     public List<VerdictCategory> getCategories() {
-        return new LinkedList<VerdictCategory>();
+        return new LinkedList<>();
     }
 
     @Override

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
@@ -408,7 +408,7 @@ public final class Setup {
         patch.setNumber("1");
         patch.setRevision("9999");
         event.setPatchset(patch);
-        List<Approval> approvals = new LinkedList<Approval>();
+        List<Approval> approvals = new LinkedList<>();
         Approval approval = new Approval();
         approval.setType("CRVW");
         approval.setValue("1");
@@ -521,7 +521,7 @@ public final class Setup {
      */
     public static GerritTrigger createDefaultTrigger(AbstractProject project) {
         PluginPatchsetCreatedEvent pluginEvent = new PluginPatchsetCreatedEvent();
-        List<PluginGerritEvent> triggerOnEvents = new LinkedList<PluginGerritEvent>();
+        List<PluginGerritEvent> triggerOnEvents = new LinkedList<>();
         triggerOnEvents.add(pluginEvent);
         boolean silentMode = true;
         boolean silentStart = false;
@@ -573,7 +573,7 @@ public final class Setup {
      */
     public static List<VerdictCategory> createCodeReviewVerdictCategoryList() {
         VerdictCategory cat = new VerdictCategory("CRVW", "Code review");
-        List<VerdictCategory> list = new LinkedList<VerdictCategory>();
+        List<VerdictCategory> list = new LinkedList<>();
         list.add(cat);
         return list;
     }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/TestUtils.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/TestUtils.java
@@ -79,7 +79,7 @@ public final class TestUtils {
      * @return the reference of future build to start.
      */
     public static AtomicReference<AbstractBuild> getFutureBuildToStart(GerritEventLifecycle event) {
-        final AtomicReference<AbstractBuild> reference = new AtomicReference<AbstractBuild>();
+        final AtomicReference<AbstractBuild> reference = new AtomicReference<>();
         event.addListener(new GerritEventLifeCycleAdaptor() {
             @Override
             public void buildStarted(GerritEvent event, AbstractBuild build) {

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcherTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcherTest.java
@@ -505,7 +505,7 @@ public class ReplicationQueueTaskDispatcherTest {
                 "refs/changes/1/1/1");
         Item item = createItem(patchsetCreated, null);
         //setup slaves to have one with timeout
-        List<GerritSlave> gerritSlaves = new ArrayList<GerritSlave>();
+        List<GerritSlave> gerritSlaves = new ArrayList<>();
         gerritSlaves.add(new GerritSlave("slave1", "host1", 0));
         gerritSlaves.add(new GerritSlave("slave2", "host2", 1)); // slave timeout is 1 second
         when(gerritTriggerMock.gerritSlavesToWaitFor("someGerritServer")).thenReturn(gerritSlaves);
@@ -749,13 +749,13 @@ public class ReplicationQueueTaskDispatcherTest {
      * @return the queue item
      */
     private Item createItem(GerritCause gerritCause, String[] slaves) {
-        List<Action> actions = new ArrayList<Action>();
+        List<Action> actions = new ArrayList<>();
         actions.add(new CauseAction(gerritCause));
 
         abstractProjectMock = mock(AbstractProject.class);
         when(abstractProjectMock.getTrigger(GerritTrigger.class)).thenReturn(gerritTriggerMock);
         if (slaves != null && slaves.length > 0) {
-            List<GerritSlave> gerritSlaves = new ArrayList<GerritSlave>();
+            List<GerritSlave> gerritSlaves = new ArrayList<>();
             for (String slave : slaves) {
                 gerritSlaves.add(new GerritSlave(slave + " display name", slave , 0));
             }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/WaitingForReplicationTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/WaitingForReplicationTest.java
@@ -47,7 +47,7 @@ public class WaitingForReplicationTest {
      */
     @Test
     public void shouldReturnADescriptionWithAllSlaves() {
-        List<GerritSlave> slaves = new ArrayList<GerritSlave>();
+        List<GerritSlave> slaves = new ArrayList<>();
         slaves.add(new GerritSlave("slaveA", null, 1234));
 
         WaitingForReplication waitingForReplication = new WaitingForReplication(slaves);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersPreloadedProjectHudsonTestCase.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersPreloadedProjectHudsonTestCase.java
@@ -329,7 +329,7 @@ public class DuplicateGerritListenersPreloadedProjectHudsonTestCase {
      * @throws URISyntaxException if so
      */
     List<String> javaCliJarCmd(String... cmd) throws IOException, URISyntaxException {
-        List<String> commands = new ArrayList<String>(cmd.length + 5);
+        List<String> commands = new ArrayList<>(cmd.length + 5);
         commands.add(String.format("%s/bin/java", System.getProperty("java.home")));
         commands.add("-jar");
         commands.add(new File(j.jenkins.getJnlpJars("jenkins-cli.jar").getURL().toURI()).getAbsolutePath());

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
@@ -221,7 +221,7 @@ public class SpecGerritTriggerHudsonTest {
         FreeStyleBuild build = project.getLastCompletedBuild();
         assertSame(Result.SUCCESS, build.getResult());
         // JENKINS-23152
-        WeakReference<FreeStyleProject> old = new WeakReference<FreeStyleProject>(project);
+        WeakReference<FreeStyleProject> old = new WeakReference<>(project);
         project = null;
         //builds = null;
         build = null;

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
@@ -131,7 +131,7 @@ public class SshdServerMock implements CommandFactory {
     protected synchronized CommandMock setCurrentCommand(CommandMock command) {
         currentCommand = command;
         if (commandHistory == null) {
-            commandHistory = new LinkedList<CommandMock>();
+            commandHistory = new LinkedList<>();
         }
         commandHistory.add(0, command);
         return currentCommand;
@@ -242,7 +242,7 @@ public class SshdServerMock implements CommandFactory {
         Constructor<? extends CommandMock> constructor = cmd.getConstructor(argumentTypes);
         if (constructor != null) {
             if (commandLookups == null) {
-                commandLookups = new LinkedList<CommandLookup>();
+                commandLookups = new LinkedList<>();
             }
             commandLookups.add(new CommandLookup(cmd, commandPattern, oneShot, constructor, arguments));
         }
@@ -315,7 +315,7 @@ public class SshdServerMock implements CommandFactory {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(port);
         sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("hostkey.ser"));
-        List<NamedFactory<UserAuth>>userAuthFactories = new ArrayList<NamedFactory<UserAuth>>();
+        List<NamedFactory<UserAuth>>userAuthFactories = new ArrayList<>();
         userAuthFactories.add(new UserAuthNone.Factory());
         sshd.setUserAuthFactories(userAuthFactories);
         sshd.setCommandFactory(server);


### PR DESCRIPTION
Public updates for Java 6 ended in Feb 2013 [1].

Update the project to build with Java 7.

Java 7 has support for type inference, so we no longer need to give
explicit specification of type arguments.  For example code like:

   List<String> list = new List<String>();

will now cause a warning "Redundant specification of type arguments".

Code using this syntax can be changed to:

   List<String> list = new List<>();

which silences the warning and makes the code a bit more compact.

[1] http://www.oracle.com/technetwork/java/eol-135779.html
[2] http://docs.oracle.com/javase/tutorial/java/generics/genTypeInference.html

Change-Id: Ifd72081ae7d6090594cd3d5cb219a639da64424a