### PR TITLE
Missed Events Playback on re-connect

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ generated-sources
 .idea
 hostkey.ser
 *.xml~
+/eclipse-classes

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,12 @@
             <artifactId>guava</artifactId>
             <version>11.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.tomakehurst</groupId>
+            <artifactId>wiremock</artifactId>
+            <version>1.51</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <repositories>
         <repository>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/EventTimeSlice.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/EventTimeSlice.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.playback;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * This class holds events that were processed by the MissedEventPlaybackManager
+ * for the most recent timestamp.
+ *
+ * For example, if 3 events were received at t1, they would be present in the Event Slice.
+ * However, if another event is processed at t2, then the Event Slice would evict the previous
+ * events and only keep the new event at t2.
+ *
+ * Created by scott.hebert@ericsson.com on 12/12/14.
+ */
+public class EventTimeSlice {
+
+    private long timeSlice;
+    /**
+     * events to persist.
+     */
+    protected List<GerritTriggeredEvent> events = Collections.synchronizedList(new ArrayList<GerritTriggeredEvent>());
+
+    /**
+     *
+     * @param ts Time slice in ms to hold events for.
+     */
+    public EventTimeSlice(long ts) {
+        this.timeSlice = ts;
+    }
+
+    /**
+     * Get the time slice in ms.
+     * @return this time slice
+     */
+    public long getTimeSlice() {
+        return timeSlice;
+    }
+    /**
+     * Add an event to the list.
+     * @param evt Event to be persisted.
+     */
+    public void addEvent(GerritTriggeredEvent evt) {
+        events.add(evt);
+    }
+
+    /**
+     * get the events for this time slice.
+     * @return events that pertain to the time slice.
+     */
+    public List<GerritTriggeredEvent> getEvents() {
+        return events;
+    }
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -1,0 +1,497 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.playback;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.utils.GerritPluginChecker;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.utils.HttpUtils;
+import com.sonymobile.tools.gerrit.gerritevents.ConnectionListener;
+import com.sonymobile.tools.gerrit.gerritevents.GerritEventListener;
+import com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+
+import hudson.Util;
+import hudson.XmlFile;
+import net.sf.json.JSONObject;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.ContentType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Scanner;
+
+import javax.annotation.CheckForNull;
+
+import jenkins.model.Jenkins;
+
+
+/**
+ * The GerritMissedEventsPlaybackManager is responsible for recording a last-alive timestamp
+ * for each server connection. The motivation is that we want to be able to know when we last
+ * received an event. This will help us determine upon connection startup, if we have missed
+ * some events while the connection was down.
+ *
+ * Once the server is re-connected, the missed event will be played back as if they had been
+ * received orginally.
+ *
+ * @author scott.hebert@ericsson.com
+ */
+public class GerritMissedEventsPlaybackManager implements ConnectionListener, GerritEventListener {
+
+    private static final String GERRIT_SERVER_EVENT_DATA_FOLDER = "/gerrit-server-event-data/";
+    private static final Logger logger = LoggerFactory.getLogger(GerritMissedEventsPlaybackManager.class);
+    static final String EVENTS_LOG_PLUGIN_NAME = "events-log";
+    private static final String EVENTS_LOG_PLUGIN_URL = "a/plugins/" + EVENTS_LOG_PLUGIN_NAME + "/events/";
+    private static final String GERRIT_TRIGGER_SERVER_TIMESTAMPS_XML = "gerrit-trigger-server-timestamps.xml";
+
+    private String serverName;
+    /**
+     * Server Timestamp.
+     */
+    protected EventTimeSlice serverTimestamp = null;
+    /**
+     * List that contains received Gerrit Events.
+     */
+    protected List<GerritTriggeredEvent> receivedEventCache
+        = Collections.synchronizedList(new ArrayList<GerritTriggeredEvent>());
+
+    private boolean isSupported = false;
+    private boolean playBackComplete = false;
+
+    /**
+     * @param name Gerrit Server Name
+     */
+    public GerritMissedEventsPlaybackManager(String name) {
+        this.serverName = name;
+        checkIfEventsLogPluginSupported();
+    }
+
+    /**
+     * method to verify if plugin is supported
+     */
+    private void checkIfEventsLogPluginSupported() {
+        GerritServer server = PluginImpl.getServer_(serverName);
+        if (server != null && server.getConfig() != null) {
+            isSupported = GerritPluginChecker.isPluginEnabled(
+                    server.getConfig(), EVENTS_LOG_PLUGIN_NAME);
+        }
+    }
+
+    /**
+     * Load in the last-alive Timestamp file.
+     * @throws IOException is we cannot unmarshal.
+     */
+    protected void load() throws IOException {
+        XmlFile xml = getConfigXml(serverName);
+        if (xml.exists()) {
+            serverTimestamp  = (EventTimeSlice)xml.unmarshal(serverTimestamp);
+        }
+    }
+
+    /**
+     * get DateRange from current and last known time.
+     * @return last known timestamp or current date if not found.
+     */
+    protected synchronized Date getDateFromTimestamp() {
+        //get timestamp for server
+        if (serverTimestamp != null) {
+            Date myDate = new Date(serverTimestamp.getTimeSlice());
+            logger.debug("Previous alive timestamp was: {}", myDate);
+            return myDate;
+        }
+        return new Date();
+    }
+
+    /**
+     * When the connection is established, we load in the last-alive
+     * timestamp for this server and try to determine if a time range
+     * exist whereby we missed some events. If so, request the events
+     * from the Gerrit events-log plugin and pump them in to play them back.
+     */
+    @Override
+    public void connectionEstablished() {
+
+        playBackComplete = false;
+        checkIfEventsLogPluginSupported();
+        if (!isSupported) {
+            logger.warn("Playback of missed events not supported for server {}!", serverName);
+            playBackComplete = true;
+            return;
+        }
+        logger.debug("Connection Established!");
+
+        try {
+            load();
+        } catch (IOException e) {
+            logger.error("Failed to load in timestamps for server {}", serverName);
+            logger.error("Exception: {}", e.getMessage(), e);
+            playBackComplete = true;
+            return;
+        }
+        Date timeStampDate = getDateFromTimestamp();
+        long diff = System.currentTimeMillis() - timeStampDate.getTime();
+        if (diff > 0) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("Non-zero date range from last-alive timestamp exists for server {} : {}"
+                        , serverName, Util.getPastTimeString(diff));
+            }
+        } else {
+            logger.debug("Zero date range from last-alive timestamp for server {}", serverName);
+            playBackComplete = true;
+            return;
+        }
+        try {
+            List<GerritTriggeredEvent> events = getEventsFromDateRange(timeStampDate);
+            logger.info("({}) missed events to process for server: {} ...", events.size(), serverName);
+            for (GerritTriggeredEvent evt: events) {
+                logger.debug("({}) Processing missed event {}", serverName, evt);
+                boolean receivedEvtFound = false;
+                synchronized (receivedEventCache) {
+                  Iterator<GerritTriggeredEvent> i = receivedEventCache.iterator(); // Must be in synchronized block
+                  while (i.hasNext()) {
+                      GerritTriggeredEvent rEvt = i.next();
+                      if (rEvt.equals(evt)) {
+                        receivedEvtFound = true;
+                        break;
+                      }
+                  }
+                }
+                if (receivedEvtFound) {
+                    logger.debug("({}) Event already triggered...skipping trigger.", serverName);
+                } else {
+
+                    //do we have this event in the time slice?
+                    long currentEventCreatedTime = ((GerritTriggeredEvent)evt).getEventCreatedOn().getTime();
+                    if (serverTimestamp.getTimeSlice() == currentEventCreatedTime) {
+                        if (serverTimestamp.getEvents().contains(evt)) {
+                            logger.debug("({}) Event already triggered from time slice...skipping trigger.", serverName);
+                            continue;
+                        }
+                    }
+                    logger.info("({}) Triggering: {}", serverName, evt);
+                    GerritServer server = PluginImpl.getServer_(serverName);
+                    if (server == null) {
+                        logger.error("Server for {} could not be found. Skipping this event", serverName);
+                        continue;
+                    }
+                    server.triggerEvent(evt);
+                    receivedEventCache.add(evt);
+                    logger.debug("Added event {} to received cache for server: {}", evt, serverName);
+                }
+            }
+        } catch (UnsupportedEncodingException e) {
+            logger.error("Error building URL for playback query: " + e.getMessage(), e);
+        } catch (IOException e) {
+            logger.error("Error accessing URL for playback query: " + e.getMessage(), e);
+        }
+        playBackComplete = true;
+        logger.info("Processing completed for server: {}", serverName);
+    }
+
+    /**
+     * Log when the connection goes down.
+     */
+    @Override
+    public void connectionDown() {
+        logger.info("connectionDown for server: {}", serverName);
+    }
+
+    /**
+     * This allows us to persist a last known alive time
+     * for the server.
+     * @param event Gerrit Event
+     */
+    @Override
+    public void gerritEvent(GerritEvent event) {
+        if (!isSupported()) {
+            return;
+        }
+
+        if (event instanceof GerritTriggeredEvent) {
+            logger.debug("Recording timestamp due to an event {} for server: {}", event, serverName);
+            GerritTriggeredEvent triggeredEvent = (GerritTriggeredEvent)event;
+            persist(triggeredEvent);
+            //add to cache
+            if (!playBackComplete) {
+                boolean receivedEvtFound = false;
+                synchronized (receivedEventCache) {
+                  Iterator<GerritTriggeredEvent> i = receivedEventCache.iterator(); // Must be in synchronized block
+                  while (i.hasNext()) {
+                      GerritTriggeredEvent rEvt = i.next();
+                      if (rEvt.equals(triggeredEvent)) {
+                        receivedEvtFound = true;
+                        break;
+                      }
+                  }
+                }
+                if (!receivedEvtFound) {
+                    receivedEventCache.add(triggeredEvent);
+                    logger.debug("Added event {} to received cache for server: {}", event, serverName);
+                } else {
+                    logger.debug("Event {} ALREADY in received cache for server: {}", event, serverName);
+                }
+            } else {
+                receivedEventCache = Collections.synchronizedList(new ArrayList<GerritTriggeredEvent>());
+                logger.debug("Playback complete...will NOT add event {} to received cache for server: {}"
+                        , event, serverName);
+            }
+        }
+    }
+
+    /**
+     * Get events for a given lower bound date.
+     * @param lowerDate lower bound for which to request missed events.
+     * @return collection of gerrit events.
+     * @throws IOException if HTTP errors occur
+     */
+    protected List<GerritTriggeredEvent> getEventsFromDateRange(Date lowerDate) throws IOException {
+
+        GerritServer server = PluginImpl.getServer_(serverName);
+        if (server == null) {
+            logger.error("Server for {} could not be found.", serverName);
+            return Collections.synchronizedList(new ArrayList<GerritTriggeredEvent>());
+        }
+        IGerritHudsonTriggerConfig config = server.getConfig();
+
+        String events = getEventsFromEventsLogPlugin(config, buildEventsLogURL(config, lowerDate));
+
+        return createEventsFromString(events);
+    }
+
+    /**
+     * Takes a string of json events and creates a collection.
+     * @param eventsString Events in json in a string.
+     * @return collection of events.
+     */
+    private List<GerritTriggeredEvent> createEventsFromString(String eventsString) {
+        List<GerritTriggeredEvent> events = Collections.synchronizedList(new ArrayList<GerritTriggeredEvent>());
+        Scanner scanner = new Scanner(eventsString);
+        while (scanner.hasNextLine()) {
+            String line = scanner.nextLine();
+            logger.debug("found line: {}", line);
+            JSONObject jsonObject = JSONObject.fromObject(line);
+            GerritEvent evt = GerritJsonEventFactory.getEvent(jsonObject);
+            if (evt instanceof ChangeBasedEvent) {
+                Provider provider = new Provider();
+                provider.setName(serverName);
+                ((GerritTriggeredEvent)evt).setProvider(provider);
+                events.add((ChangeBasedEvent)evt);
+            }
+        }
+        scanner.close();
+        return events;
+    }
+
+    /**
+     *
+     * @param config Gerrit config for server.
+     * @param url URL to use.
+     * @return String of gerrit events.
+     */
+    protected String getEventsFromEventsLogPlugin(IGerritHudsonTriggerConfig config, String url) {
+        logger.debug("({}) Going to GET: {}", serverName, url);
+
+        HttpResponse execute = null;
+        try {
+            execute = HttpUtils.performHTTPGet(config, url);
+        } catch (IOException e) {
+            logger.warn(e.getMessage(), e);
+            return "";
+        }
+
+        int statusCode = execute.getStatusLine().getStatusCode();
+        logger.debug("Received status code: {} for server: {}", statusCode, serverName);
+
+        if (statusCode == HttpURLConnection.HTTP_OK) {
+            try {
+                HttpEntity entity = execute.getEntity();
+                ContentType contentType;
+                if (entity == null) {
+                    logger.warn("Not successful at requesting missed events from {} plugin. Null entity returned)",
+                            statusCode);
+                }
+                contentType = ContentType.get(entity);
+                if (contentType == null) {
+                    contentType = ContentType.DEFAULT_TEXT;
+                }
+                Charset charset = contentType.getCharset();
+                if (charset == null) {
+                    charset = Charset.defaultCharset();
+                }
+                InputStream bodyStream = entity.getContent();
+                String body = IOUtils.toString(bodyStream, charset.name());
+                logger.debug(body);
+                return body;
+            } catch (IOException ioe) {
+                logger.warn(ioe.getMessage(), ioe);
+                logger.warn("Not successful at requesting missed events from {} plugin. (errorcode: {})",
+                    EVENTS_LOG_PLUGIN_NAME, statusCode);
+            }
+        } else {
+            logger.warn("Not successful at requesting missed events from {} plugin. (errorcode: {})",
+                EVENTS_LOG_PLUGIN_NAME, statusCode);
+        }
+        return "";
+    }
+
+    /**
+     *
+     * @param config Gerrit Config for server.
+     * @param date1 lower bound for date range,
+     * @return url to use to request missed events.
+     * @throws UnsupportedEncodingException if URL encoding not supported.
+     */
+    protected String buildEventsLogURL(IGerritHudsonTriggerConfig config, Date date1)
+            throws UnsupportedEncodingException {
+        SimpleDateFormat df = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+
+        String url = EVENTS_LOG_PLUGIN_URL + "?t1=" + URLEncoder.encode(df.format(date1), "UTF-8");
+
+        String gerritFrontEndUrl = config.getGerritFrontEndUrl();
+        String restUrl = gerritFrontEndUrl;
+        if (gerritFrontEndUrl != null && !gerritFrontEndUrl.endsWith("/")) {
+            restUrl = gerritFrontEndUrl + "/";
+        }
+        return restUrl + url;
+    }
+
+    /**
+     * Takes a timestamp and persists to xml file.
+     * @param evt Gerrit Event to persist.
+     * @return true if was able to persist event.
+     */
+    private synchronized boolean persist(GerritTriggeredEvent evt) {
+
+        long ts = evt.getEventCreatedOn().getTime();
+
+        if (ts == 0) {
+            logger.warn("Event CreatedOn is 0...Gerrit Server does not support attribute eventCreateOn. "
+                    + "Will NOT persist this event and Missed Events will be disabled!");
+            isSupported = false;
+            return false;
+        }
+
+        if (serverTimestamp != null && ts < serverTimestamp.getTimeSlice()) {
+            logger.debug("Event has same time slice {} or is earlier...NOT Updating time slice.", ts);
+            return false;
+        } else {
+            if (serverTimestamp == null) {
+                serverTimestamp = new EventTimeSlice(ts);
+                serverTimestamp.addEvent(evt);
+            } else {
+                if (ts > serverTimestamp.getTimeSlice()) {
+                    logger.debug("Current timestamp {} is GREATER than slice time {}.",
+                            ts, serverTimestamp.getTimeSlice());
+                    serverTimestamp = new EventTimeSlice(ts);
+                    serverTimestamp.addEvent(evt);
+                } else {
+                    if (ts == serverTimestamp.getTimeSlice()) {
+                        logger.debug("Current timestamp {} is EQUAL to slice time {}.",
+                                ts, serverTimestamp.getTimeSlice());
+                        serverTimestamp.addEvent(evt);
+                    }
+                }
+            }
+        }
+
+        try {
+            XmlFile config = getConfigXml(serverName);
+            config.write(serverTimestamp);
+        } catch (IOException e) {
+            logger.error(e.getMessage(), e);
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Shutdown the listener.
+     */
+    public void shutdown() {
+        GerritServer server = PluginImpl.getServer_(serverName);
+        if (server != null) {
+            server.removeListener((GerritEventListener)this);
+        } else {
+            logger.error("Could not find server {}", serverName);
+        }
+    }
+
+    /**
+     * @return whether playback is supported.
+     */
+    public boolean isSupported() {
+        return isSupported;
+    }
+
+    /**
+     * Return server timestamp.
+     * @return timestamp.
+     */
+    public EventTimeSlice getServerTimestamp() {
+        return serverTimestamp;
+    }
+
+    /**
+     * @param serverName The Name of the Gerrit Server to load config for.
+     * @return XmlFile corresponding to gerrit-trigger-server-timestamps.xml.
+     * @throws IOException if it occurs.
+     */
+    @CheckForNull
+    public static XmlFile getConfigXml(String serverName) throws IOException {
+        Jenkins jenkins = Jenkins.getInstance();
+        if (jenkins == null) {
+            return null;
+        }
+
+        File dataDir = new File(jenkins.getRootDir(), GERRIT_SERVER_EVENT_DATA_FOLDER);
+        File serverDataDir = new File(dataDir, serverName);
+        serverDataDir.mkdirs();
+        File xmlFile = new File(serverDataDir, GERRIT_TRIGGER_SERVER_TIMESTAMPS_XML);
+
+        return new XmlFile(Jenkins.XSTREAM, xmlFile);
+    }
+
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/GerritPluginChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/GerritPluginChecker.java
@@ -1,0 +1,132 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.utils;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
+
+import org.apache.http.HttpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+
+/**
+ * Helper to determine if a Gerrit Plugin is installed
+ * on the Gerrit server.
+ * @author scott.hebert@ericsson.com
+ */
+public final class GerritPluginChecker {
+
+    /**
+     * Gerrit Plugin Checker.
+     */
+    private GerritPluginChecker() {
+    }
+
+    private static final Logger logger = LoggerFactory.getLogger(GerritPluginChecker.class);
+
+    /**
+     * Build URL using Gerrit Server config.
+     * @param config Gerrit Server config.
+     * @return URL
+     */
+    private static String buildURL(IGerritHudsonTriggerConfig config) {
+        if (config == null) {
+            throw new IllegalArgumentException("Gerrit Server Configuration cannot be null");
+        }
+
+        if (!config.isUseRestApi()) {
+            logger.warn("REST API is not enabled.");
+            return null;
+        }
+
+        String gerritFrontEndUrl = config.getGerritFrontEndUrl();
+        String restUrl = gerritFrontEndUrl;
+        if (gerritFrontEndUrl != null && !gerritFrontEndUrl.endsWith("/")) {
+            restUrl = gerritFrontEndUrl + "/";
+        }
+        return restUrl;
+    }
+
+    /**
+     * Given a status code, decode its status.
+     * @param statusCode HTTP code
+     * @param pluginName plugin that was checked.
+     * @return true/false if installed or not.
+     */
+    private static boolean decodeStatus(int statusCode, String pluginName) {
+        switch (statusCode) {
+            case HttpURLConnection.HTTP_OK:
+                logger.info(Messages.PluginInstalled(pluginName));
+                return true;
+            case HttpURLConnection.HTTP_NOT_FOUND:
+                logger.info(Messages.PluginNotInstalled(pluginName));
+                return false;
+            case HttpURLConnection.HTTP_UNAUTHORIZED:
+                logger.warn(Messages.PluginHttpConnectionUnauthorized(pluginName,
+                        Messages.HttpConnectionUnauthorized()));
+                return false;
+            case HttpURLConnection.HTTP_FORBIDDEN:
+                logger.warn(Messages.PluginHttpConnectionForbidden(pluginName,
+                        Messages.HttpConnectionUnauthorized()));
+                return false;
+            default:
+                logger.warn(Messages.PluginHttpConnectionGeneralError(pluginName,
+                        Messages.HttpConnectionError(statusCode)));
+                return false;
+        }
+    }
+    /**
+     * Query Gerrit to determine if plugin is enabled.
+     * @param config Gerrit Server Config
+     * @param pluginName The Gerrit Plugin name.
+     * @return true if enabled.
+     */
+    public static boolean isPluginEnabled(IGerritHudsonTriggerConfig config, String pluginName) {
+
+        String restUrl = buildURL(config);
+        if (restUrl == null) {
+            logger.warn(Messages.PluginInstalledRESTApiNull(pluginName));
+            return false;
+        }
+        logger.trace("{}plugins/{}/", restUrl, pluginName);
+
+        HttpResponse execute = null;
+        try {
+            execute = HttpUtils.performHTTPGet(config, restUrl + "plugins/" + pluginName + "/");
+        } catch (IOException e) {
+            logger.warn(Messages.PluginHttpConnectionGeneralError(pluginName,
+                    e.getMessage()), e);
+            return false;
+        }
+
+        int statusCode = execute.getStatusLine().getStatusCode();
+        logger.debug("status code: {}", statusCode);
+        return decodeStatus(statusCode, pluginName);
+    }
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/HttpUtils.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/HttpUtils.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.utils;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import org.apache.http.HttpHost;
+import org.apache.http.HttpResponse;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.conn.params.ConnRoutePNames;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
+
+/**
+ * Helper class for HTTP operations.
+ */
+public final class HttpUtils {
+
+    private static final Logger logger = LoggerFactory.getLogger(HttpUtils.class);
+
+    /**
+     * Helper methods for Http operations.
+     */
+    private HttpUtils() {
+    }
+
+    /**
+     * @param config Gerrit Server Configuration.
+     * @param url URL to get.
+     * @return httpresponse.
+     * @throws IOException if found.
+     */
+    public static HttpResponse performHTTPGet(IGerritHudsonTriggerConfig config, String url) throws IOException {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        HttpGet httpGet = new HttpGet(url);
+        if (config.getGerritProxy() != null && !config.getGerritProxy().isEmpty()) {
+            try {
+                URL proxyUrl = new URL(config.getGerritProxy());
+                HttpHost proxy = new HttpHost(proxyUrl.getHost(), proxyUrl.getPort(), proxyUrl.getProtocol());
+                httpclient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
+            } catch (MalformedURLException e) {
+                logger.error("Could not parse proxy URL, attempting without proxy.", e);
+            }
+        }
+
+        httpclient.getCredentialsProvider().setCredentials(new AuthScope(null, -1),
+                config.getHttpCredentials());
+        HttpResponse execute;
+        return httpclient.execute(httpGet);
+    }
+}

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.jelly
@@ -10,6 +10,11 @@
             ${%SnapshotVersionWarning}
         </div>
     </j:if>
+    <j:if test="${!it.isGerritMissedEventsSupported()}">
+        <div class="warning">
+            ${%MissedEventsPlaybackNotSupportedWarning}
+        </div>
+    </j:if>
     <j:if test="${it.hasDisabledFeatures()}">
         <div class="warning">
             ${%DisabledFeaturesWarning}

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.properties
@@ -8,3 +8,7 @@ DisabledFeaturesWarning=\
   The following features have been disabled:
 SpecificVersionRequiredWarning=\
   {0} requires {1}
+MissedEventsPlaybackNotSupportedWarning=\
+  Gerrit Missed Events Playback is not supported. Verify if the connection \
+  has the REST API enabled and that the Gerrit Audit plugin is installed and \
+  configured on the Gerrit Server.

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -167,3 +167,15 @@ NotificationLevel_OWNER_REVIEWERS=\
  Owner and reviewers
 NotificationLevel_ALL=\
  All
+PluginInstalled=\
+ Gerrit Plugin {0} is installed
+PluginNotInstalled=\
+ Gerrit Plugin {0} is NOT installed
+PluginHttpConnectionUnauthorized=\
+ Not able to verify if Gerrit plugin {0} is installed. User is not NOT AUTHORIZED! Error: {1}
+PluginHttpConnectionForbidden=\
+ Not able to verify if Gerrit plugin {0} is installed. User is Forbidden! Error: {1}
+PluginHttpConnectionGeneralError=\
+ Not able to verify if Gerrit plugin {0} is installed. Error: {1}
+PluginInstalledRESTApiNull=\
+ Not able to verify if Gerrit plugin {0} is installed. REST URL cannot be null. Is the REST API Enabled?

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/LockedDownGerritEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/LockedDownGerritEventTest.java
@@ -26,6 +26,9 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger;
 import static com.sonymobile.tools.gerrit.gerritevents.mock.SshdServerMock.GERRIT_STREAM_EVENTS;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertSame;
+
+import java.util.concurrent.TimeUnit;
+
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Hudson;
@@ -145,7 +148,10 @@ public class LockedDownGerritEventTest {
         gerritServer.triggerEvent(Setup.createPatchsetCreated());
 
         TestUtils.waitForBuilds(project, 1);
-        assertEquals(server.getNrCommandsHistory("gerrit review.*"), 2);
+        //wait until command is registered
+        // CS IGNORE MagicNumber FOR NEXT 2 LINES. REASON: ConstantsNotNeeded
+        Thread.sleep(TimeUnit.SECONDS.toMillis(10));
+        assertEquals(2, server.getNrCommandsHistory("gerrit review.*"));
 
         FreeStyleBuild buildOne = project.getLastCompletedBuild();
         assertSame(Result.SUCCESS, buildOne.getResult());

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
@@ -144,6 +144,7 @@ public final class Setup {
         refUpdate.setProject(project);
         refUpdate.setRefName(ref);
         event.setRefUpdate(refUpdate);
+        event.setEventCreatedOn("1418133772");
 
         return event;
     }
@@ -174,6 +175,7 @@ public final class Setup {
         patch.setRef(ref);
         event.setPatchset(patch);
         event.setProvider(new Provider(serverName, "gerrit", "29418", "ssh", "http://gerrit/", "1"));
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 
@@ -191,6 +193,7 @@ public final class Setup {
         event.getChange().setOwner(owner);
         event.getPatchSet().setUploader(uploader);
         event.setAccount(account);
+        event.setEventCreatedOn("1418133772");
 
         return event;
     }
@@ -219,6 +222,7 @@ public final class Setup {
         event.setPatchset(patch);
         patch.setRef("ref");
         event.setProvider(new Provider(PluginImpl.DEFAULT_SERVER_NAME, "gerrit", "29418", "ssh", "http://gerrit/", "1"));
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 
@@ -244,6 +248,7 @@ public final class Setup {
         event.setPatchset(patch);
         Account abandoner = new Account("Name1", "email@domain1.com");
         event.setAbandoner(abandoner);
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 
@@ -291,6 +296,7 @@ public final class Setup {
         patch.setNumber("1");
         patch.setRevision("9999");
         event.setPatchset(patch);
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 
@@ -324,6 +330,7 @@ public final class Setup {
         patch.setRef(ref);
         patch.setCreatedOn(date);
         event.setProvider(new Provider(serverName, "gerrit", "29418", "ssh", "http://gerrit/", "1"));
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 
@@ -357,6 +364,7 @@ public final class Setup {
         patch.setRef(ref);
         patch.setCreatedOn(date);
         event.setProvider(new Provider(serverName, "gerrit", "29418", "ssh", "http://gerrit/", "1"));
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 
@@ -382,6 +390,7 @@ public final class Setup {
         event.setPatchset(patch);
         Account restorer = new Account("Name1", "email@domain1.com");
         event.setRestorer(restorer);
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 
@@ -414,6 +423,7 @@ public final class Setup {
         approval.setValue("1");
         approvals.add(approval);
         event.setApprovals(approvals);
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 
@@ -447,6 +457,7 @@ public final class Setup {
 
         event.put(PATCH_SET, patchSet);
         event.put(UPLOADER, account);
+
         return event;
     }
 
@@ -474,6 +485,7 @@ public final class Setup {
         event.setPatchset(patch);
         event.setUserName("Bobby");
         event.setProvider(new Provider(PluginImpl.DEFAULT_SERVER_NAME, "gerrit", "29418", "ssh", "http://gerrit/", "1"));
+        event.setEventCreatedOn("1418133772");
         return event;
     }
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsFunctionalTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsFunctionalTest.java
@@ -1,0 +1,208 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2014 rinrinne All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.playback;
+
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.api.GerritTriggerApi;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.api.exception.GerritTriggerException;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritCause;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.DuplicatesUtil;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.Setup;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.TestUtils;
+import com.sonymobile.tools.gerrit.gerritevents.Handler;
+import com.sonymobile.tools.gerrit.gerritevents.mock.SshdServerMock;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+
+import org.apache.sshd.SshServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.sonymobile.tools.gerrit.gerritevents.mock.SshdServerMock.GERRIT_STREAM_EVENTS;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.assertSame;
+import static junit.framework.TestCase.fail;
+import static net.sf.ezmorph.test.ArrayAssertions.assertEquals;
+
+//CS IGNORE AvoidStarImport FOR NEXT 1 LINES. REASON: UnitTest.
+
+/**
+ * Functional Test for Missed Events Playback.
+ *
+ * @author scott.heber@ericsson.com;
+ */
+public class GerritMissedEventsFunctionalTest {
+
+    /**
+     * An instance of Jenkins Rule.
+     */
+    // CS IGNORE VisibilityModifier FOR NEXT 2 LINES. REASON: JenkinsRule.
+    @Rule
+    public final JenkinsRule j = new JenkinsRule();
+    /**
+     * An instance of WireMock Rule.
+     */
+    // CS IGNORE VisibilityModifier FOR NEXT 2 LINES. REASON: WireMockRule.
+    @Rule
+    public final WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructor defaults to port 8089
+
+    private static final int HTTPOK = 200;
+    private static final int SLEEPTIME = 1000;
+
+    private final String gerritServerName = "testServer";
+    private final String projectName = "testProject";
+    private final int port = 29418;
+
+    private SshdServerMock server;
+    private SshServer sshd;
+    private SshdServerMock.KeyPairFiles sshKey;
+
+    /**
+     * Runs before test method.
+     *
+     * @throws Exception throw if so.
+     */
+    @Before
+    public void setUp() throws Exception {
+        sshKey = SshdServerMock.generateKeyPair();
+        System.setProperty(PluginImpl.TEST_SSH_KEYFILE_LOCATION_PROPERTY, sshKey.getPrivateKey().getAbsolutePath());
+        server = new SshdServerMock();
+        sshd = SshdServerMock.startServer(port, server);
+        server.returnCommandFor("gerrit ls-projects", SshdServerMock.EofCommandMock.class);
+        server.returnCommandFor(GERRIT_STREAM_EVENTS, SshdServerMock.CommandMock.class);
+        server.returnCommandFor("gerrit review.*", SshdServerMock.EofCommandMock.class);
+        server.returnCommandFor("gerrit version", SshdServerMock.EofCommandMock.class);
+        stubFor(get(urlEqualTo("/plugins/" + GerritMissedEventsPlaybackManager.EVENTS_LOG_PLUGIN_NAME + "/"))
+                .willReturn(aResponse()
+                        .withStatus(HTTPOK)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody("ok")));
+
+    }
+
+    /**
+     * Runs after test method.
+     *
+     * @throws Exception throw if so.
+     */
+    @After
+    public void tearDown() throws Exception {
+        sshd.stop(true);
+        sshd = null;
+    }
+
+    /**
+     * Test the scenario whereby connection is restarted and events are missed
+     * but replayed.
+     * @throws Exception Error creating job.
+     */
+    @Test
+    public void testRestartWithMissedEvents() throws Exception {
+        GerritServer gerritServer = new GerritServer(gerritServerName);
+        Config config = (Config)gerritServer.getConfig();
+        config.setUseRestApi(true);
+        config.setGerritHttpUserName("scott");
+        config.setGerritHttpPassword("scott");
+        config.setGerritFrontEndURL("http://localhost:8089");
+        config.setGerritHostName("localhost");
+        config.setGerritProxy("");
+        config.setGerritAuthKeyFile(sshKey.getPrivateKey());
+        gerritServer.setConfig(config);
+
+        PluginImpl.getInstance().addServer(gerritServer);
+        gerritServer.start();
+        gerritServer.startConnection();
+        FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJob(j, projectName, gerritServerName);
+
+        GerritTriggerApi api = new GerritTriggerApi();
+        Handler handler = null;
+        try {
+            handler = api.getHandler();
+        } catch (GerritTriggerException ex) {
+            fail(ex.getMessage());
+        }
+        assertNotNull(handler);
+        handler.post(Setup.createPatchsetCreated(gerritServerName));
+        TestUtils.waitForBuilds(project, 1);
+
+        assertNotNull(gerritServer.getMissedEventsPlaybackManager().getServerTimestamp());
+        FreeStyleBuild buildOne = project.getLastCompletedBuild();
+        assertSame(Result.SUCCESS, buildOne.getResult());
+        assertEquals(1, project.getLastCompletedBuild().getNumber());
+        assertSame(gerritServerName, buildOne.getCause(GerritCause.class).getEvent().getProvider().getName());
+
+        gerritServer.stopConnection();
+        Thread.currentThread().sleep(SLEEPTIME);
+
+        String json = "{\"type\":\"patchset-created\",\"change\":{\"project\":\""
+                + projectName
+                + "\",\"branch\":\"develop\","
+                + "\"id\":\"Icae2322236e0e521950a0232effda08d6ffcdab7\",\"number\":\"392335\",\"subject\":\""
+                + "IPSEC: Small test code fixes due to Sonar warnings\",\"owner\":{\"name\":\"Szymon L\","
+                + "\"email\":\"szymon.l@abc.com\",\"username\":\"eszyabc\"},\"url\":"
+                + "\"https://abc.aaa.se/392335\","
+                + "\"commitMessage\":\"IPSEC: Small test code fixes due to Sonar warnings\\n\\nChange-Id: "
+                + "Icae2322236e0e521950a0232effda08d6ffcdab7\\nSigned-off-by:Szymon L \\u003cszymo"
+                + "n.l@abc.com\\u003e\\n\",\"status\":\"NEW\"},\"patchSet\":{\"number\":\"2\",\"revision"
+                + "\":\"607eea8f472235b3ee47483b630003250764dab2\",\"parents\":"
+                + "[\"87c0e57d2497ab334584ec9d1a7953ebcf016e10\"],"
+                + "\"ref\":\"refs/changes/35/392335/2\",\"uploader\":{\"name\":\"Szymon L\",\"email\":"
+                + "\"szymon"
+                + "@abc.com\",\"username\":\"eszyabc\"},\"createdOn\":1413448337,\"author\":{\"name\":\"Szy"
+                + "mon L\",\"email\":\"szymon.l@abc.com\",\"username\":\"eszyabc\"},\"isDraft\""
+                + ":false,\""
+                + "sizeInsertions\":6,\"sizeDeletions\":-7},\"author\":{\"name\":\"Build user for \","
+                + "\"email\":\"tnbuilder@"
+                + "abc.se\",\"username\":\"tnabc\"},\"approvals\":[{\"type\":\"Verified\""
+                + ",\"description\":"
+                + "\"Verified\",\"value\":\"-1\"}],\"comment\":\"Patch Set 2: Verified-1\\n\\nBuild Failed \\n\\nhttp:"
+                + "//jenkins/tn/job/tn-review/22579/ : FAILURE\",\"eventCreatedOn\":1418133772}\n";
+
+        stubFor(get(urlMatching(GerritMissedEventsPlaybackManagerTest.EVENTS_LOG_CHANGE_EVENTS_URL_REGEXP))
+                .willReturn(aResponse()
+                        .withStatus(HTTPOK)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody(json)));
+
+        gerritServer.restartConnection();
+
+        TestUtils.waitForBuilds(project, 2);
+
+    }
+
+
+}

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsLoadPersistTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsLoadPersistTest.java
@@ -1,0 +1,264 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.playback;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.Setup;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.utils.GerritPluginChecker;
+import com.sonymobile.tools.gerrit.gerritevents.GerritHandler;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+
+import hudson.XmlFile;
+import jenkins.model.Jenkins;
+import junit.framework.TestCase;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.Date;
+import java.util.Random;
+
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.spy;
+
+/**
+ *
+ * Missed events load and persist tests.
+ *
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Jenkins.class, PluginImpl.class, GerritMissedEventsPlaybackManager.class, GerritPluginChecker.class })
+@PowerMockIgnore("javax.net.ssl.*")
+public class GerritMissedEventsLoadPersistTest {
+
+    private static final int MAXRANDOMNUMBER = 100;
+    private static final int SLEEPTIME = 500;
+
+    /**
+     * Default constructor.
+     */
+    public GerritMissedEventsLoadPersistTest() {
+    }
+
+    /**
+     * Create mocks.
+     * @throws IOException if it occurs.
+     */
+    @Before
+    public void setUp() throws IOException {
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+
+        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
+        GerritServer server = mock(GerritServer.class);
+        IGerritHudsonTriggerConfig config = Setup.createConfig();
+        config = spy(config);
+        when(plugin.getServer(any(String.class))).thenReturn(server);
+        GerritHandler handler = mock(GerritHandler.class);
+        when(plugin.getHandler()).thenReturn(handler);
+        when(server.getConfig()).thenReturn(config);
+        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
+
+        PowerMockito.mockStatic(GerritMissedEventsPlaybackManager.class);
+
+        File tmpFile = null;
+        try {
+            tmpFile = File.createTempFile("gerrit-server-timestamps", ".xml");
+        } catch (IOException e) {
+            fail("Failed to create Temp File");
+        }
+        tmpFile.deleteOnExit();
+        PrintWriter out = null;
+        try {
+            out = new PrintWriter(tmpFile);
+        } catch (FileNotFoundException e) {
+            fail("Failed to write to Temp File");
+        }
+        String text = "<?xml version='1.0' encoding='UTF-8'?>\n"
+                + "<com.sonyericsson.hudson.plugins.gerrit.trigger.playback.EventTimeSlice "
+                + "plugin='gerrit-trigger@2.14.0-SNAPSHOT'>"
+                + "<timeSlice>1430244884000</timeSlice>"
+                + "<events>"
+                + "</events>"
+                + "</com.sonyericsson.hudson.plugins.gerrit.trigger.playback.EventTimeSlice>";
+        out.println(text);
+        out.close();
+        XmlFile xmlFile = new XmlFile(tmpFile);
+        PowerMockito.when(GerritMissedEventsPlaybackManager.getConfigXml(anyString())).thenReturn(xmlFile);
+
+        PowerMockito.mockStatic(GerritPluginChecker.class);
+        PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
+                , anyString())).thenReturn(true);
+    }
+
+    /**
+     * Given a non-existing timestamp file
+     * When we attempt to load it
+     * Then we retrieve a null map.
+     * @throws IOException if it occurs.
+     */
+    @Test
+    public void testLoadTimeStampFromNonExistentFile() throws IOException {
+
+        GerritMissedEventsPlaybackManager.getConfigXml("defaultServer").delete();
+
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        try {
+            missingEventsPlaybackManager.load();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        assertNull(missingEventsPlaybackManager.serverTimestamp);
+
+    }
+
+    /**
+     * Given an existing timestamp file
+     * And it contains at least one entry with a valid timestamp
+     * When we attempt to load it
+     * Then we retrieve a non-null map.
+     */
+    @Test
+    public void testLoadTimeStampFromFile() {
+
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        try {
+            missingEventsPlaybackManager.load();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        assertNotNull(missingEventsPlaybackManager.serverTimestamp);
+    }
+
+    /**
+     * Given an existing timestamp file
+     * And it contains at least one entry with a valid timestamp
+     * When a new event is received for the server connection
+     * Then the timestamp is persisted.
+     */
+    @Test
+    public void testPersistTimeStampToFile() {
+
+        Random randomGenerator = new Random();
+        int randomInt = randomGenerator.nextInt(MAXRANDOMNUMBER);
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager(new Integer(randomInt).toString() + "-server");
+        try {
+            missingEventsPlaybackManager.load();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        PatchsetCreated patchsetCreated = Setup.createPatchsetCreated("someGerritServer", "someProject",
+                "refs/heads/master");
+        patchsetCreated.setReceivedOn(System.currentTimeMillis());
+
+        missingEventsPlaybackManager.gerritEvent(patchsetCreated);
+        assertNotNull(missingEventsPlaybackManager.serverTimestamp);
+    }
+
+    /**
+     * Return a missingEventsPlaybackManager.
+     * @return missingEventsPlaybackManager.
+     */
+    private GerritMissedEventsPlaybackManager setupManager() {
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        try {
+            missingEventsPlaybackManager.load();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        assertNotNull(missingEventsPlaybackManager.serverTimestamp);
+
+        assertTrue("should be true", missingEventsPlaybackManager.isSupported());
+
+        PatchsetCreated patchsetCreated = Setup.createPatchsetCreated("someGerritServer", "someProject",
+                "refs/heads/master");
+        patchsetCreated.setReceivedOn(System.currentTimeMillis());
+
+        missingEventsPlaybackManager.gerritEvent(patchsetCreated);
+        patchsetCreated.setReceivedOn(System.currentTimeMillis());
+        missingEventsPlaybackManager.gerritEvent(patchsetCreated);
+        try {
+            Thread.currentThread().sleep(SLEEPTIME);
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+        }
+
+        missingEventsPlaybackManager.connectionDown();
+        missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        try {
+            missingEventsPlaybackManager.load();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+        return missingEventsPlaybackManager;
+    }
+    /**
+     * Given an existing timestamp file
+     * When a connection is restarted
+     * Then the diff between last timestamp and current time
+     * should be greater than 0.
+     */
+    @Test
+    public void testGetTimeStampDiff() {
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager =
+                setupManager();
+
+        assertNotNull(missingEventsPlaybackManager.serverTimestamp);
+        TestCase.assertTrue("Diff should be greater than 0",
+                new Date().getTime() - missingEventsPlaybackManager.getDateFromTimestamp().getTime() > 0);
+
+        missingEventsPlaybackManager.shutdown();
+    }
+
+}

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManagerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManagerTest.java
@@ -1,0 +1,337 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2014 Ericsson
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.playback;
+
+import com.github.tomakehurst.wiremock.http.Fault;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.Setup;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.utils.GerritPluginChecker;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.utils.MockPluginCheckerConfig;
+import com.sonymobile.tools.gerrit.gerritevents.GerritHandler;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+
+import hudson.XmlFile;
+import jenkins.model.Jenkins;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static junit.framework.Assert.assertTrue;
+import static junit.framework.TestCase.assertNotNull;
+import static junit.framework.TestCase.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.mock;
+
+/**
+ *
+ * missed events tests for events-log plugin interaction.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ Jenkins.class, PluginImpl.class, GerritMissedEventsPlaybackManager.class, GerritPluginChecker.class })
+@PowerMockIgnore("javax.net.ssl.*")
+public class GerritMissedEventsPlaybackManagerTest {
+
+    /**
+     * regexp for change events plugin.
+     */
+    public static final String EVENTS_LOG_CHANGE_EVENTS_URL_REGEXP = ".+plugins/events-log/events/.+";
+    /**
+     * instance of WireMockRule.
+     */
+    // CS IGNORE VisibilityModifier FOR NEXT 2 LINES. REASON: WireMockRule.
+    @Rule
+    public final WireMockRule wireMockRule = new WireMockRule(8089); // No-args constructor defaults to port 8089
+    private XmlFile xmlFile;
+    private static final int SLEEPTIME = 500;
+    private static final int HTTPOK = 200;
+
+    /**
+     * Default constructor.
+     */
+    public GerritMissedEventsPlaybackManagerTest() {
+    }
+
+    /**
+     * Create ReplicationQueueTaskDispatcher with a mocked GerritHandler.
+     * @throws IOException if it occurs.
+     */
+    @Before
+    public void setUp() throws IOException {
+        Jenkins jenkinsMock = mock(Jenkins.class);
+        PowerMockito.mockStatic(Jenkins.class);
+        when(Jenkins.getInstance()).thenReturn(jenkinsMock);
+
+        PluginImpl plugin = PowerMockito.mock(PluginImpl.class);
+        GerritServer server = mock(GerritServer.class);
+
+        MockPluginCheckerConfig config = new MockPluginCheckerConfig();
+        config.setGerritFrontEndURL("http://localhost:8089");
+        config.setUseRestApi(true);
+        config.setGerritHttpUserName("user");
+        config.setGerritHttpPassword("passwd");
+
+        when(plugin.getServer(any(String.class))).thenReturn(server);
+        GerritHandler handler = mock(GerritHandler.class);
+        when(plugin.getHandler()).thenReturn(handler);
+        when(server.getConfig()).thenReturn(config);
+        PowerMockito.when(PluginImpl.getInstance()).thenReturn(plugin);
+
+        PowerMockito.mockStatic(GerritMissedEventsPlaybackManager.class);
+
+        File tmpFile = null;
+        try {
+            tmpFile = File.createTempFile("gerrit-server-timestamps", ".xml");
+        } catch (IOException e) {
+            fail("Failed to create Temp File");
+        }
+        tmpFile.deleteOnExit();
+        PrintWriter out = null;
+        try {
+            out = new PrintWriter(tmpFile);
+        } catch (FileNotFoundException e) {
+            fail("Failed to write to Temp File");
+        }
+        String text = "<?xml version='1.0' encoding='UTF-8'?>\n"
+                + "<com.sonyericsson.hudson.plugins.gerrit.trigger.playback.EventTimeSlice "
+                + "plugin='gerrit-trigger@2.14.0-SNAPSHOT'>"
+                + "<timeSlice>1430244884000</timeSlice>"
+                + "<events>"
+                + "</events>"
+                + "</com.sonyericsson.hudson.plugins.gerrit.trigger.playback.EventTimeSlice>";
+        out.println(text);
+        out.close();
+
+        xmlFile = new XmlFile(tmpFile);
+        PowerMockito.when(GerritMissedEventsPlaybackManager.getConfigXml("defaultServer")).thenReturn(xmlFile);
+
+        PowerMockito.mockStatic(GerritPluginChecker.class);
+        PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
+                , anyString())).thenReturn(true);
+
+    }
+
+    /**
+     * returns a GerritMissedEventsPlaybackManager.
+     * @return GerritMissedEventsPlaybackManager.
+     */
+    private GerritMissedEventsPlaybackManager setupManager() {
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        try {
+            missingEventsPlaybackManager.load();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        assertNotNull(missingEventsPlaybackManager.serverTimestamp);
+
+        assertTrue("should be true", missingEventsPlaybackManager.isSupported());
+
+        PatchsetCreated patchsetCreated = Setup.createPatchsetCreated("someGerritServer", "someProject",
+                "refs/heads/master");
+        patchsetCreated.setReceivedOn(System.currentTimeMillis());
+
+        missingEventsPlaybackManager.gerritEvent(patchsetCreated);
+        patchsetCreated.setReceivedOn(System.currentTimeMillis());
+        missingEventsPlaybackManager.gerritEvent(patchsetCreated);
+        try {
+            Thread.currentThread().sleep(SLEEPTIME);
+        } catch (InterruptedException e) {
+            fail(e.getMessage());
+        }
+
+        missingEventsPlaybackManager.connectionDown();
+        missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        try {
+            missingEventsPlaybackManager.load();
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+        return missingEventsPlaybackManager;
+    }
+
+    /**
+     * Given a Gerrit Server with Events-Log plugin installed
+     * When we request the events from a time range
+     * Then we receive the response in JSON
+     * And we can convert to events.
+     */
+    @Test
+    public void testConvertJSONToEvents() {
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager =
+                setupManager();
+
+        String json = "{\"type\":\"patchset-created\",\"change\":{\"project\":\""
+                + "testProject"
+                + "\",\"branch\":\"develop\","
+                + "\"id\":\"Icae2322236e0e521950a0232effda08d6ffcdab7\",\"number\":\"392335\",\"subject\":\""
+                + "IPSEC: Small test code fixes due to Sonar warnings\",\"owner\":{\"name\":\"Szymon L\","
+                + "\"email\":\"szymon.l@abc.com\",\"username\":\"eszyabc\"},\"url\":"
+                + "\"https://abc.aaa.se/392335\","
+                + "\"commitMessage\":\"IPSEC: Small test code fixes due to Sonar warnings\\n\\nChange-Id: "
+                + "Icae2322236e0e521950a0232effda08d6ffcdab7\\nSigned-off-by:Szymon L \\u003cszymo"
+                + "n.l@abc.com\\u003e\\n\",\"status\":\"NEW\"},\"patchSet\":{\"number\":\"2\",\"revision"
+                + "\":\"607eea8f472235b3ee47483b630003250764dab2\",\"parents\":"
+                + "[\"87c0e57d2497ab334584ec9d1a7953ebcf016e10\"],"
+                + "\"ref\":\"refs/changes/35/392335/2\",\"uploader\":{\"name\":\"Szymon L\",\"email\":"
+                + "\"szymon"
+                + "@abc.com\",\"username\":\"eszyabc\"},\"createdOn\":1413448337,\"author\":{\"name\":\"Szy"
+                + "mon L\",\"email\":\"szymon.l@abc.com\",\"username\":\"eszyabc\"},\"isDraft\""
+                + ":false,\""
+                + "sizeInsertions\":6,\"sizeDeletions\":-7},\"author\":{\"name\":\"Build user for \","
+                + "\"email\":\"tnbuilder@"
+                + "abc.se\",\"username\":\"tnabc\"},\"approvals\":[{\"type\":\"Verified\""
+                + ",\"description\":"
+                + "\"Verified\",\"value\":\"-1\"}],\"comment\":\"Patch Set 2: Verified-1\\n\\nBuild Failed \\n\\nhttp:"
+                + "//jenkins/tn/job/tn-review/22579/ : FAILURE\"}\n";
+
+
+        stubFor(get(urlMatching(EVENTS_LOG_CHANGE_EVENTS_URL_REGEXP))
+                .willReturn(aResponse()
+                        .withStatus(HTTPOK)
+                        .withHeader("Content-Type", "text/html")
+                        .withBody(json)));
+
+
+        List<GerritTriggeredEvent> events = new ArrayList<GerritTriggeredEvent>();
+        try {
+            events = missingEventsPlaybackManager.getEventsFromDateRange(
+                    missingEventsPlaybackManager.getDateFromTimestamp());
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        Assert.assertTrue("Should have 1 event", events.size() == 1);
+
+    }
+
+    /**
+     * Given a Gerrit Server with Events-log plugin installed
+     * When we request the events from a time range
+     * And we receive a malformed response
+     * Then we log an error
+     * And we return an empty set of events.
+     */
+    @Test
+    public void testHandleMalformedConnection() {
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager =
+                setupManager();
+
+        stubFor(get(urlMatching(EVENTS_LOG_CHANGE_EVENTS_URL_REGEXP))
+                .willReturn(aResponse().withFault(Fault.MALFORMED_RESPONSE_CHUNK)));
+
+        List<GerritTriggeredEvent> events = new ArrayList<GerritTriggeredEvent>();
+        try {
+            events = missingEventsPlaybackManager.getEventsFromDateRange(
+                    missingEventsPlaybackManager.getDateFromTimestamp());
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        Assert.assertTrue("Should have 0 event", events.size() == 0);
+
+    }
+
+    /**
+     * Given a Gerrit Server with Events-log plugin installed
+     * When we request the events from a time range
+     * And we receive a malformed response
+     * Then we log an error
+     * And we return an empty set of events.
+     */
+    @Test
+    public void testHandleEmptyResponse() {
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager =
+                setupManager();
+
+        stubFor(get(urlMatching(EVENTS_LOG_CHANGE_EVENTS_URL_REGEXP))
+                .willReturn(aResponse().withFault(Fault.EMPTY_RESPONSE)));
+
+        List<GerritTriggeredEvent> events = new ArrayList<GerritTriggeredEvent>();
+        try {
+            events = missingEventsPlaybackManager.getEventsFromDateRange(
+                    missingEventsPlaybackManager.getDateFromTimestamp());
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        Assert.assertTrue("Should have 0 event", events.size() == 0);
+
+    }
+
+    /**
+     * Given a Gerrit Server with Events-log plugin installed
+     * When we request the events from a time range
+     * And we receive garbage as a response
+     * Then we log an error
+     * And we return an empty set of events.
+     */
+    @Test
+    public void testHandleGarbageResponse() {
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager =
+                setupManager();
+
+        stubFor(get(urlMatching(EVENTS_LOG_CHANGE_EVENTS_URL_REGEXP))
+                .willReturn(aResponse().withFault(Fault.RANDOM_DATA_THEN_CLOSE)));
+
+        List<GerritTriggeredEvent> events = new ArrayList<GerritTriggeredEvent>();
+        try {
+            events = missingEventsPlaybackManager.getEventsFromDateRange(
+                    missingEventsPlaybackManager.getDateFromTimestamp());
+        } catch (IOException e) {
+            fail(e.getMessage());
+        }
+
+        Assert.assertTrue("Should have 0 event", events.size() == 0);
+
+    }
+
+}

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/MockPluginCheckerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/MockPluginCheckerConfig.java
@@ -1,0 +1,338 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.utils;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.VerdictCategory;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.ReplicationConfig;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.BuildCancellationPolicy;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Notify;
+import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
+import com.sonymobile.tools.gerrit.gerritevents.watchdog.WatchTimeExceptionData;
+
+import hudson.util.Secret;
+import net.sf.json.JSONObject;
+
+import org.apache.http.auth.Credentials;
+import org.apache.http.auth.UsernamePasswordCredentials;
+
+import java.io.File;
+import java.util.List;
+
+/**
+ * Created by escoheb on 11/14/14.
+ */
+public class MockPluginCheckerConfig implements IGerritHudsonTriggerConfig {
+
+    private String frontEndUrl;
+    private String gerritHttpUser;
+    private String gerritHttpPassword;
+    private boolean isUseRestApi;
+
+    /**
+     * Sets gerritHttpPassword.
+     *
+     * @param gerritHttpPassword the password
+     * @see #getGerritHttpPassword()
+     */
+    public void setGerritHttpPassword(String gerritHttpPassword) {
+        this.gerritHttpPassword = gerritHttpPassword;
+    }
+
+    /**
+     * Sets gerritHttpUserName.
+     *
+     * @param gerritHttpUserName the username
+     * @see #getGerritHttpUserName()
+     */
+    public void setGerritHttpUserName(String gerritHttpUserName) {
+        this.gerritHttpUser = gerritHttpUserName;
+    }
+
+    /**
+     * GerritFrontEndURL.
+     *
+     * @param gerritFrontEndURL the URL
+     * @see #getGerritFrontEndUrl()
+     */
+    public void setGerritFrontEndURL(String gerritFrontEndURL) {
+        this.frontEndUrl = gerritFrontEndURL;
+    }
+
+    @Override
+    public boolean isGerritBuildCurrentPatchesOnly() {
+        return false;
+    }
+
+    @Override
+    public String getGerritEMail() {
+        return null;
+    }
+
+    @Override
+    public String getGerritFrontEndUrl() {
+        return frontEndUrl;
+    }
+
+    @Override
+    public Credentials getHttpCredentials() {
+        return new UsernamePasswordCredentials(gerritHttpUser, gerritHttpPassword);
+    }
+
+    @Override
+    public String getGerritCmdBuildStarted() {
+        return null;
+    }
+
+    @Override
+    public String getGerritCmdBuildSuccessful() {
+        return null;
+    }
+
+    @Override
+    public String getGerritCmdBuildFailed() {
+        return null;
+    }
+
+    @Override
+    public String getGerritCmdBuildUnstable() {
+        return null;
+    }
+
+    @Override
+    public String getGerritCmdBuildNotBuilt() {
+        return null;
+    }
+
+    @Override
+    public int getGerritBuildStartedVerifiedValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildStartedCodeReviewValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildSuccessfulVerifiedValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildSuccessfulCodeReviewValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildFailedVerifiedValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildFailedCodeReviewValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildUnstableVerifiedValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildUnstableCodeReviewValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildNotBuiltVerifiedValue() {
+        return 0;
+    }
+
+    @Override
+    public int getGerritBuildNotBuiltCodeReviewValue() {
+        return 0;
+    }
+
+    @Override
+    public void setValues(JSONObject form) {
+
+    }
+
+    @Override
+    public String getGerritFrontEndUrlFor(String number, String revision) {
+        return null;
+    }
+
+    @Override
+    public String getGerritFrontEndUrlFor(GerritTriggeredEvent event) {
+        return null;
+    }
+
+    @Override
+    public List<VerdictCategory> getCategories() {
+        return null;
+    }
+
+    @Override
+    public void setCategories(List<VerdictCategory> categories) {
+
+    }
+
+    @Override
+    public boolean isEnableManualTrigger() {
+        return false;
+    }
+
+    @Override
+    public int getBuildScheduleDelay() {
+        return 0;
+    }
+
+    @Override
+    public int getDynamicConfigRefreshInterval() {
+        return 0;
+    }
+
+    @Override
+    public boolean hasDefaultValues() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnablePluginMessages() {
+        return false;
+    }
+
+    @Override
+    public boolean isUseRestApi() {
+        return isUseRestApi;
+    }
+
+    @Override
+    public Secret getGerritHttpSecretPassword() {
+        return null;
+    }
+
+    @Override
+    public String getGerritHttpPassword() {
+        return gerritHttpPassword;
+    }
+
+    @Override
+    public boolean isRestCodeReview() {
+        return false;
+    }
+
+    @Override
+    public boolean isRestVerified() {
+        return false;
+    }
+
+    @Override
+    public String getGerritHttpUserName() {
+        return gerritHttpUser;
+    }
+
+    @Override
+    public ReplicationConfig getReplicationConfig() {
+        return null;
+    }
+
+    @Override
+    public void setNumberOfSendingWorkerThreads(int numberOfSendingWorkerThreads) {
+
+    }
+
+    @Override
+    public int getNumberOfReceivingWorkerThreads() {
+        return 0;
+    }
+
+    @Override
+    public int getNumberOfSendingWorkerThreads() {
+        return 0;
+    }
+
+    @Override
+    public Notify getNotificationLevel() {
+        return null;
+    }
+
+    @Override
+    public Secret getGerritAuthKeyFileSecretPassword() {
+        return null;
+    }
+
+    @Override
+    public int getWatchdogTimeoutMinutes() {
+        return 0;
+    }
+
+    @Override
+    public int getWatchdogTimeoutSeconds() {
+        return 0;
+    }
+
+    @Override
+    public WatchTimeExceptionData getExceptionData() {
+        return null;
+    }
+
+    @Override
+    public File getGerritAuthKeyFile() {
+        return null;
+    }
+
+    @Override
+    public String getGerritAuthKeyFilePassword() {
+        return null;
+    }
+
+    @Override
+    public String getGerritHostName() {
+        return null;
+    }
+
+    @Override
+    public int getGerritSshPort() {
+        return 0;
+    }
+
+    @Override
+    public String getGerritUserName() {
+        return null;
+    }
+
+    @Override
+    public Authentication getGerritAuthentication() {
+        return null;
+    }
+
+    @Override
+    public String getGerritProxy() {
+        return null;
+    }
+
+    /**
+     * Set the REST API flag.
+     * @param b use rest API.
+     */
+    public void setUseRestApi(boolean b) {
+        this.isUseRestApi = b;
+    }
+
+    @Override
+    public BuildCancellationPolicy getBuildCurrentPatchesOnly() {
+        return null;
+    }
+
+    @Override
+    public int getProjectListRefreshInterval() {
+        return 0;
+    }
+
+    @Override
+    public boolean isLoadProjectListOnStartup() {
+        return false;
+    }
+}


### PR DESCRIPTION
The missed events playback manager is now able to:

- maintain a last known alive timestamp of events that were received by the
Gerrit Server connection.
- Upon re-connect, a request is made to the Gerrrit Events-log plugin installed on the Gerrit
 Server to determine which events may have been missed while the connection was down.
- The events are then added to the Gerrit Trigger event queue to be processed.

This feature is only enabled if:

- The REST api is configured.
- The Gerrit Events-log plugin is installed on the Gerrit Server (See https://gerrit.googlesource.com/plugins/events-log/)

[JENKINS-23871]
