### PR TITLE
JENKINS-27438: fix NPE when gerritProjects is null

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -426,9 +426,10 @@ public class GerritTrigger extends Trigger<AbstractProject> {
 
         GerritProjectList.removeTriggerFromProjectList(this);
         if (allowTriggeringUnreviewedPatches) {
-            for (GerritProject p : gerritProjects) {
-                GerritProjectList.addProject(p, this);
-            }
+            if (gerritProjects != null)
+                for (GerritProject p : gerritProjects) {
+                    GerritProjectList.addProject(p, this);
+                }
         }
     }
 


### PR DESCRIPTION
This NPE is triggered when saving a job where user deleted all Gerrit
Project filters and checked 'Check Non-Reviewed Patchsets'. The job is
saved anyway.

On Jenkins start, it's also triggered when job is loaded, preventing
such jobs to be loaded.