### PR TITLE
Fix for "Build Current Patches Only"

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -1,8 +1,7 @@
 /*
  *  The MIT License
  *
- *  Copyright 2010 Sony Ericsson Mobile Communications. All rights reserved.
- *  Copyright 2012, 2013 Sony Mobile Communications AB. All rights reserved.
+ *  Copyright 2010, 2015 Sony Mobile Communications Inc. All rights reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -136,6 +135,16 @@ public class Config implements IGerritHudsonTriggerConfig {
      */
     public static final Notify DEFAULT_NOTIFICATION_LEVEL = Notify.ALL;
 
+    /**
+     * Default value for {@link #isGerritAbortNewPatchsets()}.
+     */
+    public static final boolean DEFAULT_ABORT_NEW_PATCHSETS = true;
+
+    /**
+     * Default value for {@link #isGerritAbortManualPatchsets()}.
+     */
+    private static final boolean DEFAULT_ABORT_MANUAL_PATCHSETS = true;
+
     private String gerritHostName;
     private int gerritSshPort;
     private String gerritProxy;
@@ -149,6 +158,8 @@ public class Config implements IGerritHudsonTriggerConfig {
     private boolean restCodeReview;
     private boolean restVerified;
     private boolean gerritBuildCurrentPatchesOnly;
+    private boolean gerritAbortNewPatchsets;
+    private boolean gerritAbortManualPatchsets;
     @Deprecated
     private transient int numberOfWorkerThreads;
     private String gerritVerifiedCmdBuildSuccessful;
@@ -209,6 +220,8 @@ public class Config implements IGerritHudsonTriggerConfig {
         restCodeReview = config.isRestCodeReview();
         restVerified = config.isRestVerified();
         gerritBuildCurrentPatchesOnly = config.isGerritBuildCurrentPatchesOnly();
+        gerritAbortNewPatchsets = config.isGerritAbortNewPatchsets();
+        gerritAbortManualPatchsets = config.isGerritAbortManualPatchsets();
         numberOfWorkerThreads = config.getNumberOfReceivingWorkerThreads();
         numberOfSendingWorkerThreads = config.getNumberOfSendingWorkerThreads();
         gerritBuildStartedVerifiedValue = config.getGerritBuildStartedVerifiedValue();
@@ -266,6 +279,15 @@ public class Config implements IGerritHudsonTriggerConfig {
         gerritBuildCurrentPatchesOnly = formData.optBoolean(
                 "gerritBuildCurrentPatchesOnly",
                 DEFAULT_BUILD_CURRENT_PATCHES_ONLY);
+
+        gerritAbortNewPatchsets = formData.optBoolean(
+                "gerritAbortNewPatchsets",
+                DEFAULT_ABORT_NEW_PATCHSETS);
+
+        gerritAbortManualPatchsets = formData.optBoolean(
+                "gerritAbortManualPatchsets",
+                DEFAULT_ABORT_MANUAL_PATCHSETS);
+
 
         numberOfWorkerThreads = formData.optInt(
                 "numberOfReceivingWorkerThreads",
@@ -509,6 +531,29 @@ public class Config implements IGerritHudsonTriggerConfig {
         this.gerritBuildCurrentPatchesOnly = gerritBuildCurrentPatchesOnly;
     }
 
+    /**
+     * GerritAbortNewPatchsets.
+     *
+     * @param gerritAbortNewPatchsets whether to abort builds of patch sets when an older patch set gets retriggered.
+     *
+     * @see #isGerritAbortNewPatchsets()
+     */
+    public void setGerritAbortNewPatchsets(boolean gerritAbortNewPatchsets) {
+        this.gerritAbortNewPatchsets = gerritAbortNewPatchsets;
+    }
+
+    /**
+     * GerritAbortManualPatchsets.
+     *
+     * @param gerritAbortManualPatchsets whether to abort builds when a patch set is manually triggered.
+     *                                   Also, whether builds of manually triggered patch sets should be cancelled
+     *                                   when another patch set comes in.
+     * @see #isGerritAbortManualPatchsets()
+     */
+    public void setGerritAbortManualPatchsets(boolean gerritAbortManualPatchsets) {
+        this.gerritAbortManualPatchsets = gerritAbortManualPatchsets;
+    }
+
     @Override
     public String getGerritFrontEndUrl() {
         String url = gerritFrontEndUrl;
@@ -691,6 +736,16 @@ public class Config implements IGerritHudsonTriggerConfig {
     @Override
     public boolean isGerritBuildCurrentPatchesOnly() {
         return gerritBuildCurrentPatchesOnly;
+    }
+
+    @Override
+    public boolean isGerritAbortNewPatchsets() {
+        return gerritAbortNewPatchsets;
+    }
+
+    @Override
+    public boolean isGerritAbortManualPatchsets() {
+        return gerritAbortManualPatchsets;
     }
 
     @Override

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
@@ -1,8 +1,7 @@
 /*
  *  The MIT License
  *
- *  Copyright 2010 Sony Ericsson Mobile Communications. All rights reserved.
- *  Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+ *  Copyright 2010, 2015 Sony Mobile Communications Inc. All rights reserved.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -45,6 +44,22 @@ public interface IGerritHudsonTriggerConfig extends GerritConnectionConfig2 {
      * @return true if so.
      */
     boolean isGerritBuildCurrentPatchesOnly();
+
+    /**
+     * If enabled, then builds of newer patch sets will be aborted by
+     * older patch sets that are retriggered.
+     *
+     * @return true if so.
+     */
+    boolean isGerritAbortNewPatchsets();
+
+    /**
+     * If enabled, then builds of manually triggered patch sets will be aborted
+     * by new patch sets. Also, manual triggers will abort other running builds.
+     *
+     * @return true if so.
+     */
+    boolean isGerritAbortManualPatchsets();
 
     /**
      * Base URL for the Gerrit UI.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
@@ -23,6 +23,7 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.config;
 
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.BuildCancellationPolicy;
 import com.sonymobile.tools.gerrit.gerritevents.GerritConnectionConfig2;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Notify;
@@ -46,20 +47,13 @@ public interface IGerritHudsonTriggerConfig extends GerritConnectionConfig2 {
     boolean isGerritBuildCurrentPatchesOnly();
 
     /**
-     * If enabled, then builds of newer patch sets will be aborted by
-     * older patch sets that are retriggered.
+     * The object containing information regarding if old builds should
+     * be cancelled when new builds are triggered.
      *
-     * @return true if so.
+     * @return the BuildCancellationPolicy
      */
-    boolean isGerritAbortNewPatchsets();
 
-    /**
-     * If enabled, then builds of manually triggered patch sets will be aborted
-     * by new patch sets. Also, manual triggers will abort other running builds.
-     *
-     * @return true if so.
-     */
-    boolean isGerritAbortManualPatchsets();
+    BuildCancellationPolicy getBuildCurrentPatchesOnly();
 
     /**
      * Base URL for the Gerrit UI.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1848,9 +1848,14 @@ public class GerritTrigger extends Trigger<AbstractProject> {
          */
         public synchronized void scheduled(ChangeBasedEvent event, ParametersAction parameters, String projectName) {
             IGerritHudsonTriggerConfig serverConfig = getServerConfig(event);
+            if (serverConfig == null) {
+                runningJobs.put(event, parameters);
+                return;
+            }
             BuildCancellationPolicy buildCurrentPatchesOnly = serverConfig.getBuildCurrentPatchesOnly();
-            if (serverConfig != null && !buildCurrentPatchesOnly.isEnabled()
+            if (!buildCurrentPatchesOnly.isEnabled()
                     || (event instanceof ManualPatchsetCreated && !buildCurrentPatchesOnly.isAbortManualPatchsets())) {
+                runningJobs.put(event, parameters);
                 return;
             }
             Iterator<Entry<GerritTriggeredEvent, ParametersAction>> it = runningJobs.entrySet().iterator();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/BuildCancellationPolicy.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/BuildCancellationPolicy.java
@@ -1,0 +1,107 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright (c) 2015 Sony Mobile Communications Inc. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data;
+
+import net.sf.json.JSONObject;
+
+/**
+ * Rules regarding cancellation of builds for when patchsets of the same change comes in.
+ * @author Tomas Westling &lt;tomas.westling@sonymobile.com&gt;
+ */
+public class BuildCancellationPolicy {
+    private boolean enabled = false;
+    private boolean abortNewPatchsets = true;
+    private boolean abortManualPatchsets = true;
+
+    /**
+     * Getter for if build cancellation is turned off or on.
+     *
+     * @return whether build cancellation is turned off or on.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Turns on/off the build cancellation.
+     *
+     * @param enabled whether build cancellation should be turned off or on.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Standard getter for the abortNewPatchsets value.
+     *
+     * @return the abortNewPatchsets value.
+     */
+    public boolean isAbortNewPatchsets() {
+        return abortNewPatchsets;
+    }
+
+    /**
+     * Standard setter for the abortNewPatchsets value.
+     *
+     * @param abortNewPatchsets true if new patchsets should be cancelled by older.
+     */
+    public void setAbortNewPatchsets(boolean abortNewPatchsets) {
+        this.abortNewPatchsets = abortNewPatchsets;
+    }
+
+    /**
+     * Standard getter for the abortManualPatchsets value.
+     *
+     * @return the abortManualPatchsets value.
+     */
+    public boolean isAbortManualPatchsets() {
+        return abortManualPatchsets;
+    }
+
+    /**
+     * Standard setter for the abortManualPatchsets value.
+     *
+     * @param abortManualPatchsets true if manual patchsets should be cancelled.
+     */
+    public void setAbortManualPatchsets(boolean abortManualPatchsets) {
+        this.abortManualPatchsets = abortManualPatchsets;
+    }
+
+    /**
+     * Creates a new BuildCancellationPolicy object from JSON.
+     *
+     * @param obj the JSONObject.
+     * @return a new BuildCancellationPolicy object.
+     */
+    public static BuildCancellationPolicy createPolicyFromJSON(JSONObject obj) {
+        boolean newPatchsets = obj.getBoolean("abortNewPatchsets");
+        boolean manualPatchsets = obj.getBoolean("abortManualPatchsets");
+        BuildCancellationPolicy policy = new BuildCancellationPolicy();
+        policy.setEnabled(true);
+        policy.setAbortNewPatchsets(newPatchsets);
+        policy.setAbortManualPatchsets(manualPatchsets);
+        return policy;
+    }
+}

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -264,6 +264,18 @@
                                 </table>
                             </f:repeatable>
                         </f:entry>
+                        <f:entry title="${%Abort new patch sets}"
+                                 help="/plugin/gerrit-trigger/help-GerritAbortNewPatchSets.html">
+                            <f:checkbox name="gerritAbortNewPatchsets"
+                                        checked="${it.config.gerritAbortNewPatchsets}"
+                                        default="true"/>
+                        </f:entry>
+                        <f:entry title="${%Abort manual patch sets}"
+                                 help="/plugin/gerrit-trigger/help-GerritAbortManualPatchSets.html">
+                            <f:checkbox name="gerritAbortManualPatchsets"
+                                        checked="${it.config.gerritAbortManualPatchsets}"
+                                        default="true"/>
+                        </f:entry>
                     </f:section>
                     <f:section title="${%REST API}">
                         <f:optionalBlock name="useRestApi" title="${%Use REST API}" checked="${it.config.useRestApi}">

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -77,12 +77,23 @@
                                     value="${it.config.gerritAuthKeyFileSecretPassword}"
                                     default="${com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_AUTH_KEY_FILE_PASSWORD}"/>
                     </f:entry>
-                    <f:entry title="${%Build Current Patches Only}"
-                             help="/plugin/gerrit-trigger/help-GerritBuildCurrentPatchesOnly.html">
-                        <f:checkbox name="gerritBuildCurrentPatchesOnly"
-                                    checked="${it.config.gerritBuildCurrentPatchesOnly}"
-                                    default="true"/>
-                    </f:entry>
+                    <f:optionalBlock name="buildCurrentPatchesOnly"
+                                                             title="${%Build Current Patches Only}"
+                                                             help="/plugin/gerrit-trigger/help-GerritBuildCurrentPatchesOnly.html"
+                                                             checked="${it.config.buildCurrentPatchesOnly.enabled}">
+                                                <f:entry title="${%Abort new patch sets}"
+                                                         help="/plugin/gerrit-trigger/help-GerritAbortNewPatchSets.html">
+                                                    <f:checkbox name="abortNewPatchsets"
+                                                                checked="${it.config.buildCurrentPatchesOnly.abortNewPatchsets}"
+                                                                default="true"/>
+                                                </f:entry>
+                                                <f:entry title="${%Abort manual patch sets}"
+                                                         help="/plugin/gerrit-trigger/help-GerritAbortManualPatchSets.html">
+                                                    <f:checkbox name="abortManualPatchsets"
+                                                                checked="${it.config.buildCurrentPatchesOnly.abortManualPatchsets}"
+                                                                default="true"/>
+                                                </f:entry>
+                                            </f:optionalBlock>
                     <f:validateButton title="${%Test Connection}"
                                       progress="${%Testing...}"
                                       method="testConnection"
@@ -263,18 +274,6 @@
                                     </tr>
                                 </table>
                             </f:repeatable>
-                        </f:entry>
-                        <f:entry title="${%Abort new patch sets}"
-                                 help="/plugin/gerrit-trigger/help-GerritAbortNewPatchSets.html">
-                            <f:checkbox name="gerritAbortNewPatchsets"
-                                        checked="${it.config.gerritAbortNewPatchsets}"
-                                        default="true"/>
-                        </f:entry>
-                        <f:entry title="${%Abort manual patch sets}"
-                                 help="/plugin/gerrit-trigger/help-GerritAbortManualPatchSets.html">
-                            <f:checkbox name="gerritAbortManualPatchsets"
-                                        checked="${it.config.gerritAbortManualPatchsets}"
-                                        default="true"/>
                         </f:entry>
                     </f:section>
                     <f:section title="${%REST API}">

--- a/src/main/webapp/help-GerritAbortManualPatchSets.html
+++ b/src/main/webapp/help-GerritAbortManualPatchSets.html
@@ -1,0 +1,3 @@
+<p>This option is only relevant if the "Build Current Patches Only" is checked.</p>
+<p>If this is enabled, builds triggered manually will be aborted when a new patch set arrives.</p>
+<p>Also, manual triggers will cancel other running build for the same change.</p>

--- a/src/main/webapp/help-GerritAbortNewPatchSets.html
+++ b/src/main/webapp/help-GerritAbortNewPatchSets.html
@@ -1,0 +1,3 @@
+<p>This option is only relevant if the "Build Current Patches Only" is checked.</p>
+<p>If this is enabled, the patch set number doesn't matter when computing if running builds should be canceled.</p>
+<p>If not, only newer patch sets will cancel older ones, not vice versa.</p>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -26,6 +26,7 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.mock;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.VerdictCategory;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.ReplicationConfig;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.BuildCancellationPolicy;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Notify;
 import com.sonymobile.tools.gerrit.gerritevents.ssh.Authentication;
@@ -298,13 +299,8 @@ public class MockGerritHudsonTriggerConfig implements
     }
 
     @Override
-    public boolean isGerritAbortNewPatchsets() {
-        return true;
-    }
-
-    @Override
-    public boolean isGerritAbortManualPatchsets() {
-        return true;
+    public BuildCancellationPolicy getBuildCurrentPatchesOnly() {
+        return new BuildCancellationPolicy();
     }
 
     @Override

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -1,8 +1,7 @@
 /*
  *  The MIT License
  *
- *  Copyright 2010 Sony Ericsson Mobile Communications.
- *  Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+ *  Copyright 2010, 2015 Sony Mobile Communications Inc.
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
  *  of this software and associated documentation files (the "Software"), to deal
@@ -295,6 +294,16 @@ public class MockGerritHudsonTriggerConfig implements
 
     @Override
     public boolean isGerritBuildCurrentPatchesOnly() {
+        return true;
+    }
+
+    @Override
+    public boolean isGerritAbortNewPatchsets() {
+        return true;
+    }
+
+    @Override
+    public boolean isGerritAbortManualPatchsets() {
         return true;
     }
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
@@ -471,6 +471,8 @@ public class SpecGerritTriggerHudsonTest {
     public void testBuildLatestPatchsetOnly() throws Exception {
         GerritServer gerritServer = PluginImpl.getInstance().getServer(PluginImpl.DEFAULT_SERVER_NAME);
         ((Config)gerritServer.getConfig()).setGerritBuildCurrentPatchesOnly(true);
+        ((Config)gerritServer.getConfig()).setGerritAbortManualPatchsets(false);
+        ((Config)gerritServer.getConfig()).setGerritAbortNewPatchsets(false);
         FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJob(j, "projectX");
         project.getBuildersList().add(new SleepBuilder(2000));
         serverMock.waitForCommand(GERRIT_STREAM_EVENTS, 2000);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
@@ -23,6 +23,7 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.spec;
 
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.BuildCancellationPolicy;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.CommentAdded;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
@@ -462,54 +463,112 @@ public class SpecGerritTriggerHudsonTest {
     }
 
     /**
-     * Tests that a build for a patch set gets cancelled when a new patch set of the same change arrives.
+     * Tests the behavior of the "Build Current Patches Only" functionality when:
+     *  - Abort manual patch sets is true.
+     *  - Abort new patch sets is false.
      *
      * @throws Exception if so.
      */
     @Test
     @LocalData
-    public void testBuildLatestPatchsetOnly() throws Exception {
+    public void testBuildLatestPatchsetOnlyAbortManual() throws Exception {
+        buildLatestPatchsetOnlyAndReport(true, false, Result.ABORTED, Result.SUCCESS, Result.SUCCESS);
+    }
+
+
+    /**
+     * Tests the behavior of the "Build Current Patches Only" functionality when:
+     *  - Abort manual patch sets is true.
+     *  - Abort new patch sets is true.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    @LocalData
+    public void testBuildLatestPatchsetOnlyAbortManualAndNew() throws Exception {
+        buildLatestPatchsetOnlyAndReport(true, true, Result.ABORTED, Result.ABORTED, Result.SUCCESS);
+    }
+
+    /**
+     * Tests the behavior of the "Build Current Patches Only" functionality when:
+     *  - Abort manual patch sets is false.
+     *  - Abort new patch sets is false.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    @LocalData
+    public void testBuildLatestPatchsetOnlyAbortNeitherManualNorNew() throws Exception {
+        buildLatestPatchsetOnlyAndReport(false, false, Result.SUCCESS, Result.SUCCESS, Result.SUCCESS);
+    }
+
+    /**
+     * Tests the behavior of the "Build Current Patches Only" functionality when:
+     *  - Abort manual patch sets is false.
+     *  - Abort new patch sets is true.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    @LocalData
+    public void testBuildLatestPatchsetOnlyAbortNew() throws Exception {
+        buildLatestPatchsetOnlyAndReport(false, true, Result.SUCCESS, Result.ABORTED, Result.SUCCESS);
+    }
+
+    /**
+     * Helper method to test the behavior of the "Build Current Patches Only" functionality.
+     * Parameterized so that the different combinations can be tested.
+     * @param abortManual true if manual patchsets should be cancelled and be able to cancel builds, false if not.
+     * @param abortNew true if new patchsets should be cancelled when older patchsets are retriggered, false if not.
+     * @param firstExpected expected result for the first build.
+     * @param secondExpected expected result for the second build.
+     * @param thirdExpected expected result for the third build
+     *
+     * @throws Exception if so.
+     */
+    @LocalData
+    public void buildLatestPatchsetOnlyAndReport(boolean abortManual, boolean abortNew, Result firstExpected,
+                                                 Result secondExpected, Result thirdExpected) throws Exception {
         GerritServer gerritServer = PluginImpl.getInstance().getServer(PluginImpl.DEFAULT_SERVER_NAME);
-        ((Config)gerritServer.getConfig()).setGerritBuildCurrentPatchesOnly(true);
-        ((Config)gerritServer.getConfig()).setGerritAbortManualPatchsets(false);
-        ((Config)gerritServer.getConfig()).setGerritAbortNewPatchsets(false);
+        BuildCancellationPolicy policy = ((Config)gerritServer.getConfig()).getBuildCurrentPatchesOnly();
+        policy.setEnabled(true);
+        policy.setAbortManualPatchsets(abortManual);
+        policy.setAbortNewPatchsets(abortNew);
         FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJob(j, "projectX");
         project.getBuildersList().add(new SleepBuilder(2000));
         serverMock.waitForCommand(GERRIT_STREAM_EVENTS, 2000);
         ManualPatchsetCreated firstEvent = Setup.createManualPatchsetCreated();
+        firstEvent.getPatchSet().setNumber("1");
         AtomicReference<AbstractBuild> firstBuildRef = TestUtils.getFutureBuildToStart(firstEvent);
         gerritServer.triggerEvent(firstEvent);
-        AbstractBuild firstBuild = TestUtils.waitForBuildToStart(firstBuildRef);
+        TestUtils.waitForBuildToStart(firstBuildRef);
         PatchsetCreated secondEvent = Setup.createPatchsetCreated();
         if (null != secondEvent.getPatchSet()) {
-            secondEvent.getPatchSet().setNumber("2");
+            secondEvent.getPatchSet().setNumber("3");
         }
         gerritServer.triggerEvent(secondEvent);
-        //No good way to wait for a non-manual patchset created.
-        Thread.sleep(3000);
+        TestUtils.waitForNonManualBuildToStart(project, secondEvent, 10000);
         PatchsetCreated thirdEvent = Setup.createPatchsetCreated();
         if (null != thirdEvent.getPatchSet()) {
-            thirdEvent.getPatchSet().setNumber("3");
+            thirdEvent.getPatchSet().setNumber("2");
         }
         gerritServer.triggerEvent(thirdEvent);
         TestUtils.waitForBuilds(project, 3);
         assertEquals(3, project.getLastCompletedBuild().getNumber());
-        assertSame(Result.SUCCESS, firstBuild.getResult());
-        assertSame(Result.SUCCESS, project.getFirstBuild().getResult());
-        assertSame(Result.ABORTED, project.getBuildByNumber(2).getResult());
-        assertSame(Result.SUCCESS, project.getLastBuild().getResult());
+        assertSame(firstExpected, project.getFirstBuild().getResult());
+        assertSame(secondExpected, project.getBuildByNumber(2).getResult());
+        assertSame(thirdExpected, project.getBuildByNumber(3).getResult());
     }
 
     /**
-     * Same test logic as {@link #testBuildLatestPatchsetOnly()}
-     * except the trigger is configured to not cancel the previous build.
+     * Tests that builds are not aborted when "build current patch sets only" is set to false.
      *
      * @throws Exception if so.
      */
     @LocalData
     public void testNotBuildLatestPatchsetOnly() throws Exception {
         GerritServer gerritServer = PluginImpl.getInstance().getServer(PluginImpl.DEFAULT_SERVER_NAME);
-        ((Config)gerritServer.getConfig()).setGerritBuildCurrentPatchesOnly(false);
+        ((Config)gerritServer.getConfig()).getBuildCurrentPatchesOnly().setEnabled(false);
         FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJob(j, "projectX");
         project.getBuildersList().add(new SleepBuilder(2000));
         serverMock.waitForCommand(GERRIT_STREAM_EVENTS, 2000);


### PR DESCRIPTION
The feature "Build Current Patches Only" cancels
builds that are already running for the same
change. I've added checks for if one of the triggers
was manual trigger as well as if an older patch set
gets triggered (due to a retrigger),
where the builds won't get cancelled.