### PR TITLE
manual trigger: always trigger upon manually triggered build

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -426,10 +426,11 @@ public class GerritTrigger extends Trigger<AbstractProject> {
 
         GerritProjectList.removeTriggerFromProjectList(this);
         if (allowTriggeringUnreviewedPatches) {
-            if (gerritProjects != null)
+            if (gerritProjects != null) {
                 for (GerritProject p : gerritProjects) {
                     GerritProjectList.addProject(p, this);
                 }
+            }
         }
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -27,6 +27,8 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.events.ManualPatchsetCreated;
+
 import hudson.Extension;
 import hudson.model.Descriptor;
 import hudson.model.Hudson;
@@ -111,6 +113,10 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
         }
         if (excludeDrafts && ((PatchsetCreated)event).getPatchSet().isDraft()) {
             return false;
+        }
+        if (event instanceof ManualPatchsetCreated) {
+            // always trigger build when the build is triggered manually
+            return true;
         }
         if (excludeTrivialRebase
             && GerritChangeKind.TRIVIAL_REBASE == ((PatchsetCreated)event).getPatchSet().getKind()) {


### PR DESCRIPTION
When skip on trivial rebase is enabled, it is useful to manually
retrigger build of patchsets that failed due to an unrelated failure
on the branch that the review is against.