### PR TITLE
checkstyle: fixes checkstyle error that snuck into master branch

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -426,10 +426,11 @@ public class GerritTrigger extends Trigger<AbstractProject> {
 
         GerritProjectList.removeTriggerFromProjectList(this);
         if (allowTriggeringUnreviewedPatches) {
-            if (gerritProjects != null)
+            if (gerritProjects != null) {
                 for (GerritProject p : gerritProjects) {
                     GerritProjectList.addProject(p, this);
                 }
+            }
         }
     }
 


### PR DESCRIPTION
A tiny checkstyle error made it into master so now all pull requests will fail builds before this is fixed.

BTW, I can't see the artifacts published anywhere on 'details' of a failed build. This makes it hard to figure out what the checkstyle error was.