### PR TITLE
Support configuration of when and how the project list is fetched

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
@@ -33,6 +33,8 @@ import java.io.IOException;
 import java.io.Reader;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,10 +51,6 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
      */
     public static final String GERRIT_LS_PROJECTS = "gerrit ls-projects";
 
-    /**
-     * Time to wait between refresh attempts
-     */
-    private static final int UPDATE_DELAY = 3600 * 1000;
     private boolean connected = false;
     private boolean shutdown = false;
     private static final Logger logger = LoggerFactory.getLogger(GerritProjectListUpdater.class);
@@ -109,18 +107,28 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
 
     @Override
     public void run() {
+        // Zero or negative value, never query this Gerrit-server for project list
+        if (getConfig().getProjectListRefreshInterval() <= 0) {
+            return;
+        }
+
+        boolean loadProjectList = getConfig().isLoadProjectListOnStartup();
         while (!shutdown) {
             try {
-                if (isConnected()) {
-                    IGerritHudsonTriggerConfig activeConfig = getConfig();
-                    SshConnection sshConnection = SshConnectionFactory.getConnection(
-                            activeConfig.getGerritHostName(),
-                            activeConfig.getGerritSshPort(),
-                            activeConfig.getGerritProxy(),
-                            activeConfig.getGerritAuthentication()
-                    );
-                    setGerritProjects(readProjects(sshConnection.executeCommandReader(GERRIT_LS_PROJECTS)));
-                    sshConnection.disconnect();
+                if (loadProjectList) {
+                    if (isConnected()) {
+                        IGerritHudsonTriggerConfig activeConfig = getConfig();
+                        SshConnection sshConnection = SshConnectionFactory.getConnection(
+                                activeConfig.getGerritHostName(),
+                                activeConfig.getGerritSshPort(),
+                                activeConfig.getGerritProxy(),
+                                activeConfig.getGerritAuthentication()
+                        );
+                        setGerritProjects(readProjects(sshConnection.executeCommandReader(GERRIT_LS_PROJECTS)));
+                        sshConnection.disconnect();
+                    }
+                } else {
+                    loadProjectList = true;
                 }
             } catch (SshException ex) {
                  logger.warn("Could not connect to Gerrit server when updating Gerrit project list: ", ex);
@@ -130,7 +138,7 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
 
             try {
                 synchronized (this) {
-                    wait(UPDATE_DELAY);
+                    wait(TimeUnit.SECONDS.toMillis(getConfig().getProjectListRefreshInterval()));
                 }
             } catch (InterruptedException ex) {
                 logger.warn("InterruptedException: ", ex);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -1188,6 +1188,23 @@ public class GerritServer implements Describable<GerritServer>, Action {
     }
 
     /**
+     * Checks that the provided parameter is an integer, not negative.
+     *
+     * @param value the value.
+     * @return {@link FormValidation#validatePositiveInteger(String)}
+     */
+    public FormValidation doProjectListRefreshIntervalCheck(
+            @QueryParameter("value")
+            final String value) {
+
+        FormValidation validatePositive = FormValidation.validateNonNegativeInteger(value);
+        if (!validatePositive.kind.equals(FormValidation.Kind.OK)) {
+            return validatePositive;
+        }
+        return FormValidation.ok();
+    }
+
+    /**
      * Checks that the provided parameter is an integer.
      * @param value the value.
      * @return {@link FormValidation#validatePositiveInteger(String)}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -115,6 +115,14 @@ public class Config implements IGerritHudsonTriggerConfig {
     public static final int DEFAULT_GERRIT_BUILD_NOT_BUILT_CODE_REVIEW_VALUE = 0;
 
     /**
+     * Default value indicating if the project list should be fetched on startup.
+     */
+    public static final boolean DEFAULT_LOAD_PROJECT_LIST_ON_STARTUP = true;
+    /**
+     * Default value showing how often the project list should be updated.
+     */
+    public static final int DEFAULT_PROJECT_LIST_REFRESH_INTERVAL = 3600;
+    /**
      * Default timeout value in minutes for the connection watchdog.
      */
     public static final int DEFAULT_GERRIT_WATCHDOG_TIMEOUT_MINUTES = 0;
@@ -173,6 +181,8 @@ public class Config implements IGerritHudsonTriggerConfig {
     private transient int numberOfSendingWorkerThreads;
     private int buildScheduleDelay;
     private int dynamicConfigRefreshInterval;
+    private boolean loadProjectListOnStartup;
+    private int projectListRefreshInterval;
     private List<VerdictCategory> categories;
     private ReplicationConfig replicationConfig;
     private int watchdogTimeoutMinutes;
@@ -231,6 +241,8 @@ public class Config implements IGerritHudsonTriggerConfig {
         enablePluginMessages = config.isEnablePluginMessages();
         buildScheduleDelay = config.getBuildScheduleDelay();
         dynamicConfigRefreshInterval = config.getDynamicConfigRefreshInterval();
+        loadProjectListOnStartup = config.isLoadProjectListOnStartup();
+        projectListRefreshInterval = config.getProjectListRefreshInterval();
         if (config.getCategories() != null) {
             categories = new LinkedList<VerdictCategory>();
             for (VerdictCategory cat : config.getCategories()) {
@@ -349,6 +361,15 @@ public class Config implements IGerritHudsonTriggerConfig {
         dynamicConfigRefreshInterval = formData.optInt(
                 "dynamicConfigRefreshInterval",
                 DEFAULT_DYNAMIC_CONFIG_REFRESH_INTERVAL);
+
+        projectListRefreshInterval = formData.optInt(
+                "projectListRefreshInterval",
+                DEFAULT_PROJECT_LIST_REFRESH_INTERVAL);
+
+        loadProjectListOnStartup = formData.optBoolean(
+                "isLoadProjectListOnStartup",
+                DEFAULT_LOAD_PROJECT_LIST_ON_STARTUP);
+
         categories = new LinkedList<VerdictCategory>();
         if (formData.has("verdictCategories")) {
             Object cat = formData.get("verdictCategories");
@@ -598,6 +619,12 @@ public class Config implements IGerritHudsonTriggerConfig {
         }
         return dynamicConfigRefreshInterval;
     }
+
+    @Override
+    public int getProjectListRefreshInterval() { return projectListRefreshInterval; }
+
+    @Override
+    public boolean isLoadProjectListOnStartup() { return loadProjectListOnStartup; }
 
     /**
      * Setting dynamicConfigRefreshInterval.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
@@ -196,6 +196,18 @@ public interface IGerritHudsonTriggerConfig extends GerritConnectionConfig2 {
     int getDynamicConfigRefreshInterval();
 
     /**
+     * Returns the projectListRefreshInterval.
+     * @return the value.
+     */
+    int getProjectListRefreshInterval();
+
+    /**
+     * If the Project List should be fetched from Gerrit on startup.
+     * @return true if so.
+     */
+    boolean isLoadProjectListOnStartup();
+
+    /**
      * If the plugin still has default values for hostname and frontendurl.
      * @return true if so.
      */

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -230,6 +230,31 @@
                                         checked="${it.config.enableManualTrigger}"
                                         default="${true}"/>
                         </f:entry>
+                        <f:entry title="${%Fetch Project List Settings}"
+                                 help="/plugin/gerrit-trigger/help-GerritFetchProjectList.html">
+                            <div>
+                                <div style="width: 200px; display: inline-block;">
+                                    ${%Load Project List on Startup}
+                                </div>
+                                <div style="display: inline">
+                                    <f:checkbox name="loadProjectListOnStartup"
+                                         checked="${it.config.loadProjectListOnStartup}"
+                                         default="${com.sonyericsson.gerrithudsontrigger.config.Config.DEFAULT_LOAD_PROJECT_LIST_ON_STARTUP}"/>
+                                </div>
+                            </div>
+                            <div>
+                                <div style="width: 200px; display: inline-block;">
+                                    ${%Refresh Project List Interval} (seconds)
+                                </div>
+                                <div style="display: inline;">
+                                     <f:textbox name="projectListRefreshInterval"
+                                        value="${it.config.projectListRefreshInterval}"
+                                        default="${com.sonyericsson.gerrithudsontrigger.config.Config.DEFAULT_PROJECT_LIST_REFRESH_INTERVAL}"
+                                        checkUrl="'${rootURL}/${serverURL}/projectListRefreshIntervalCheck?value='+escape(this.value)"
+                                        style="max-width: 100px;"/>
+                                </div>
+                            </div>
+                        </f:entry>
                         <f:entry title="${%Notification Level}"
                                  field="notificationLevel"
                                  help="/plugin/gerrit-trigger/help-GerritNotificationLevel.html">

--- a/src/main/webapp/help-GerritFetchProjectList.html
+++ b/src/main/webapp/help-GerritFetchProjectList.html
@@ -1,0 +1,16 @@
+Defines when and how the project list is fetched from Gerrit.
+<p/>
+This list is used for project auto completion in the project configuration.
+<p/>
+<b>Load Project List on Startup</b>
+<p/>
+If checked, Gerrit will be queried for the project list as early as possible.
+<p/>
+If unchecked, the project list will not be fetched until the first duration period has passed.
+Note: Auto-completion in the project configuration will not be availible during this period.
+<p/>
+<b>Refresh project list interval</b>
+<p/>
+The interval between fetches of the project list. A value of 0 disables the fetching altogether,
+which also means no project name auto-completion will be available for users configuring Jenkins
+projects.

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -25,6 +25,7 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.mock;
 
 import com.sonyericsson.hudson.plugins.gerrit.trigger.VerdictCategory;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.ReplicationConfig;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
@@ -286,6 +287,16 @@ public class MockGerritHudsonTriggerConfig implements
     @Override
     public int getDynamicConfigRefreshInterval() {
         return 30;
+    }
+
+    @Override
+    public int getProjectListRefreshInterval() {
+        return Config.DEFAULT_PROJECT_LIST_REFRESH_INTERVAL;
+    }
+
+    @Override
+    public boolean isLoadProjectListOnStartup() {
+        return Config.DEFAULT_LOAD_PROJECT_LIST_ON_STARTUP;
     }
 
     @Override


### PR DESCRIPTION
Introduces a new configuration section where the admin can configure
how often the project list is queried from Gerrit (used for project
auto completion) and if it should be fetched during startup.

Change-Id: Id4493dc4381d59b9db789e1469c0783bcb2a31f1