### PR TITLE
Fix "serializable class does not declare a static final serialVersionUID...

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
@@ -29,6 +29,7 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
+
 import hudson.Extension;
 import hudson.model.AbstractBuild;
 import hudson.model.TaskListener;
@@ -42,6 +43,7 @@ import hudson.plugins.git.util.BuildChooserContext;
 import hudson.plugins.git.util.BuildChooserDescriptor;
 import hudson.plugins.git.util.BuildData;
 import hudson.remoting.VirtualChannel;
+
 import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 import org.eclipse.jgit.revwalk.RevWalk;
@@ -158,6 +160,7 @@ public class GerritTriggerBuildChooser extends BuildChooser {
      * @throws InterruptedException if the repository handling gets interrupted
      * @throws IOException in case of communication errors.
      */
+    @SuppressWarnings("serial")
     private ObjectId getFirstParent(final ObjectId id, GitClient git)
             throws GitException, IOException, InterruptedException {
         return git.withRepository(new RepositoryCallback<ObjectId>() {
@@ -208,6 +211,7 @@ public class GerritTriggerBuildChooser extends BuildChooser {
      */
     private static class GetGerritEventRevision
             implements BuildChooserContext.ContextCallable<AbstractBuild<?, ?>, String> {
+        static final long serialVersionUID = 0L;
         @Override
         public String invoke(AbstractBuild<?, ?> build, VirtualChannel channel) {
             GerritCause cause = (GerritCause)build.getCause(GerritCause.class);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectListTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectListTest.java
@@ -132,6 +132,7 @@ public class GerritProjectListTest {
     public void testAddProject() throws Exception {
 
         //CS IGNORE MagicNumberCheck FOR NEXT 15 LINES. REASON: test input
+        @SuppressWarnings("serial")
         Map<String, Integer> projectNumbers = new HashMap<String, Integer>() {
             {
                put("test/project1", 4);
@@ -167,6 +168,7 @@ public class GerritProjectListTest {
         projects = GerritProjectList.getGerritProjects();
         assertEquals(projects.size(), 2);
 
+        @SuppressWarnings("serial")
         Map<String, Integer> projectNumbers = new HashMap<String, Integer>() {
             {
                put("test/project1", 2);
@@ -202,6 +204,7 @@ public class GerritProjectListTest {
         GerritProjectList.removeTriggerFromProjectList(gerritTriggers.get(2));
         projects = GerritProjectList.getGerritProjects();
         assertEquals(3, projects.size());
+        @SuppressWarnings("serial")
         Map<String, Integer> projectNumbers = new HashMap<String, Integer>() {
             {
                 put("test/project1", 3);


### PR DESCRIPTION
..." warnings

Add a dummy variable in GerritTriggerBuildChooser.GetGerritEventRevision

Suppress the warning in anonymous classes.

Change-Id: I224276e73e9a0c0ac448ed14dde0da7fcfa2cd69