### PR TITLE
Change should be checked for BuildCurrentPatchsets

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1895,22 +1895,34 @@ public class GerritTrigger extends Trigger<AbstractProject> {
                 // a retrigger of an older build.
                 if (pairs.getKey() instanceof ChangeBasedEvent) {
                     ChangeBasedEvent runningChangeBasedEvent = ((ChangeBasedEvent)pairs.getKey());
-                    boolean shouldCancelManual = (runningChangeBasedEvent instanceof ManualPatchsetCreated
-                            && buildCurrentPatchesOnly.isAbortManualPatchsets()
-                            || !(runningChangeBasedEvent instanceof ManualPatchsetCreated));
-                    boolean shouldCancelPatchsetNumber = buildCurrentPatchesOnly.isAbortNewPatchsets()
-                            || Integer.parseInt(runningChangeBasedEvent.getPatchSet().getNumber())
-                            < Integer.parseInt(event.getPatchSet().getNumber());
-                    if (shouldCancelManual && shouldCancelPatchsetNumber) {
-                        logger.debug("Cancelling build for " + pairs.getKey());
-                        try {
-                            cancelJob(pairs.getKey());
-                        } catch (Exception e) {
-                            // Ignore any problems with canceling the job.
-                            logger.error("Error canceling job", e);
-                        }
-                        it.remove();
+                    if (!runningChangeBasedEvent.getChange().equals(event.getChange())) {
+                        continue;
                     }
+
+                    boolean shouldCancelManual = (runningChangeBasedEvent instanceof ManualPatchsetCreated
+                                && buildCurrentPatchesOnly.isAbortManualPatchsets()
+                                || !(runningChangeBasedEvent instanceof ManualPatchsetCreated));
+
+                    if (!shouldCancelManual) {
+                        continue;
+                    }
+
+                    boolean shouldCancelPatchsetNumber = buildCurrentPatchesOnly.isAbortNewPatchsets()
+                                || Integer.parseInt(runningChangeBasedEvent.getPatchSet().getNumber())
+                                < Integer.parseInt(event.getPatchSet().getNumber());
+
+                    if (!shouldCancelPatchsetNumber) {
+                        continue;
+                    }
+
+                    logger.debug("Cancelling build for " + pairs.getKey());
+                    try {
+                        cancelJob(pairs.getKey());
+                    } catch (Exception e) {
+                        // Ignore any problems with canceling the job.
+                        logger.error("Error canceling job", e);
+                    }
+                    it.remove();
                 }
             }
             // add our new job

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/BuildCancellationPolicy.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/BuildCancellationPolicy.java
@@ -32,8 +32,8 @@ import net.sf.json.JSONObject;
  */
 public class BuildCancellationPolicy {
     private boolean enabled = false;
-    private boolean abortNewPatchsets = true;
-    private boolean abortManualPatchsets = true;
+    private boolean abortNewPatchsets = false;
+    private boolean abortManualPatchsets = false;
 
     /**
      * Getter for if build cancellation is turned off or on.


### PR DESCRIPTION
If Build Current Patchsets only is enabled, then the Change in question must first be
checked to see if a build should be aborted.

Without this fix, it is possible for a build to be aborted because of a NON-related patchset
from ANOTHER change.

This change also makes the two new options disabled by default to be compatible
with the previous behaviour.

Change-Id: I958a4974756f398d87c7d60fb23cdd1b978a0ea1