### PR TITLE
checkstyle: removes RedundantThrows which is no longer available in c…

### DIFF
--- a/build-config/swe_checkstyle.xml
+++ b/build-config/swe_checkstyle.xml
@@ -85,11 +85,6 @@
         <module name="InnerAssignment"/>
         <module name="MagicNumber"/>
         <module name="MissingSwitchDefault"/>
-        <module name="RedundantThrows">
-            <property name="logLoadErrors" value="true"/>
-            <property name="suppressLoadErrors" value="true"/>
-            <property name="severity" value="info"/>
-        </module>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>
         <module name="CovariantEquals"/>


### PR DESCRIPTION
Removes usage of obsolete checkstyle feature as of 6.2:

See https://github.com/checkstyle/checkstyle/issues/473


This improves interoperability with  Eclipse as we don't get error messages from build all the time.