### PR TITLE
Fix eclipse build errors

### DIFF
--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcherTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcherTest.java
@@ -34,7 +34,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import hudson.ExtensionList;
 import hudson.model.Action;
 import hudson.model.AbstractProject;
@@ -52,8 +51,8 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import jenkins.model.Jenkins;
-
 import jenkins.model.TransientActionFactory;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -101,7 +100,8 @@ public class DependencyQueueTaskDispatcherTest {
         jenkinsMock = mock(Jenkins.class);
         when(jenkinsMock.getQueue()).thenReturn(queueMock);
         ExtensionList<TransientActionFactory> list = mock(ExtensionList.class);
-        Iterator<TransientActionFactory> iterator = Collections.emptyIterator();
+        List<TransientActionFactory> emptyList = Collections.emptyList();
+        Iterator<TransientActionFactory> iterator = emptyList.iterator();
         when(list.iterator()).thenReturn(iterator);
         when(jenkinsMock.getExtensionList(same(TransientActionFactory.class))).thenReturn(list);
         PowerMockito.mockStatic(Jenkins.class);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcherTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcherTest.java
@@ -108,7 +108,8 @@ public class ReplicationQueueTaskDispatcherTest {
         Jenkins jenkinsMock = mock(Jenkins.class);
         when(jenkinsMock.getQueue()).thenReturn(queueMock);
         ExtensionList<TransientActionFactory> list = mock(ExtensionList.class);
-        Iterator<TransientActionFactory> iterator = Collections.emptyIterator();
+        List<TransientActionFactory> emptyList = Collections.emptyList();
+        Iterator<TransientActionFactory> iterator = emptyList.iterator();
         when(list.iterator()).thenReturn(iterator);
         when(jenkinsMock.getExtensionList(same(TransientActionFactory.class))).thenReturn(list);
         PowerMockito.mockStatic(Jenkins.class);


### PR DESCRIPTION
Improve interoperability with Eclipse.

For casual patch-work, one might be using Java 8 and it's nice that the gerrit-trigger-plugin builds in Eclipse out of the box, even if testing is done with Java 7 and mvn install on the command line.