### PR TITLE
Correct default values for Build Current Patchsets

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -1054,8 +1054,8 @@ public class Config implements IGerritHudsonTriggerConfig {
         if (this.buildCurrentPatchesOnly == null) {
             this.buildCurrentPatchesOnly = new BuildCancellationPolicy();
             this.buildCurrentPatchesOnly.setEnabled(gerritBuildCurrentPatchesOnly);
-            this.buildCurrentPatchesOnly.setAbortManualPatchsets(true);
-            this.buildCurrentPatchesOnly.setAbortNewPatchsets(true);
+            this.buildCurrentPatchesOnly.setAbortManualPatchsets(false);
+            this.buildCurrentPatchesOnly.setAbortNewPatchsets(false);
         }
         return this;
     }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -85,13 +85,13 @@
                                                          help="/plugin/gerrit-trigger/help-GerritAbortNewPatchSets.html">
                                                     <f:checkbox name="abortNewPatchsets"
                                                                 checked="${it.config.buildCurrentPatchesOnly.abortNewPatchsets}"
-                                                                default="true"/>
+                                                                default="false"/>
                                                 </f:entry>
                                                 <f:entry title="${%Abort manual patch sets}"
                                                          help="/plugin/gerrit-trigger/help-GerritAbortManualPatchSets.html">
                                                     <f:checkbox name="abortManualPatchsets"
                                                                 checked="${it.config.buildCurrentPatchesOnly.abortManualPatchsets}"
-                                                                default="true"/>
+                                                                default="false"/>
                                                 </f:entry>
                                             </f:optionalBlock>
                     <f:validateButton title="${%Test Connection}"


### PR DESCRIPTION
Ensure that when migrating to the new Build Cancellation policy, the new defaults mimic the previous implementation's defaults.
