### PR TITLE
Correct Typo in Messages for Playback Warning

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/message.properties
@@ -10,5 +10,5 @@ SpecificVersionRequiredWarning=\
   {0} requires {1}
 MissedEventsPlaybackNotSupportedWarning=\
   Gerrit Missed Events Playback is not supported. Verify if the connection \
-  has the REST API enabled and that the Gerrit Audit plugin is installed and \
+  has the REST API enabled and that the Gerrit Events-log plugin is installed and \
   configured on the Gerrit Server.


### PR DESCRIPTION
Corrected the name of the Events-log plugin in the Message properties.

Change-Id: I66f4bedd2d4fcc38873b355a15107d9799a79fbf