### PR TITLE
Improve backwards compatibilty of Project Lister

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -189,6 +189,8 @@ public class Config implements IGerritHudsonTriggerConfig {
     private int dynamicConfigRefreshInterval;
     private boolean enableProjectAutoCompletion;
     private int projectListRefreshInterval;
+    @Deprecated
+    private transient boolean loadProjectListOnStartup;
     private int projectListFetchDelay;
     private List<VerdictCategory> categories;
     private ReplicationConfig replicationConfig;


### PR DESCRIPTION
In moving from 2.13 to 2.14, older gerrit-trigger config files fail to load.
This fix enables it to be backwards compatible.

[FIXED JENKINS-28583]

Change-Id: I0abc74e7880091d148d8d4af892d66ea90e6d8c9