### PR TITLE
[WiP] Upgrade gerrit-events to 2.9.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.7.1</version>
+            <version>2.9.0</version>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
         </dependency>
         <dependency>


### PR DESCRIPTION
- Add support for the merge-failed event
- Add support for the reviewer-added event
- Add support for the topic-changed event
- Fix up comments in GerritEventType enum
- Don't use deprecated DefaultHttpClient
- Don't use deprecated junit.framework.Assert.*

Change-Id: I1f44719e6e597a59dd57a815c0357baf37197d91