### PR TITLE
Add a .mailmap file

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,14 @@
+Hugo Arès <hugo.ares@ericsson.com>             Hugo Ares <hugo.ares@ericsson.com>
+Robert Sandell <rsandell@cloudbees.com>        Robert Sandell <robert.sandell@sonyericsson.com>
+Robert Sandell <rsandell@cloudbees.com>        Robert Sandell <robert.sandell@sonymobile.com>
+Robert Sandell <rsandell@cloudbees.com>        Robert Sandell <sandell.robert@gmail.com>
+Robert Sandell <rsandell@cloudbees.com>        rsandell <sandell.robert@gmail.com>
+Robert Sandell <rsandell@cloudbees.com>        RSandell <sandell.robert@gmail.com>
+Robert Sandell <rsandell@cloudbees.com>        Sandell, Robert <robert.sandell@sonyericsson.com>
+Robert Sandell <rsandell@cloudbees.com>        Sandell, Robert <robert.sandell@sonymobile.com>
+Tomas Westling <tomas.westling@sonymobile.com> thomas.westling <thomas.westling@sonyericsson.com>
+Tomas Westling <tomas.westling@sonymobile.com> Thomas Westling <thomas.westling@sonyericsson.com>
+Tomas Westling <tomas.westling@sonymobile.com> Tomas Westling <thomas.westling@sonyericsson.com>
+Tomas Westling <tomas.westling@sonymobile.com> Westling, Thomas <thomas.westling@sonyericsson.com>
+Tomas Westling <tomas.westling@sonymobile.com> Westling, Tomas <tomas.westling@sonymobile.com>
+


### PR DESCRIPTION
There are some contributors who have made commits with different
email addresses and/or different formatting of their name.

Adding a .mailmap with entries for these contributors allows to
collate all their commits together in the shortlog, i.e.:

  git shortlog -n -c -s

Note that there are also several contributors whose commits are done
with only a github username rather than a full name. This commit does
not add mailmap entries for those users.

Change-Id: I3ec5769df76642ecdbd0cb58506563a465b4a3a7