### PR TITLE
Fix [JENKINS-12690] issue with AES passphrase encryption of keys

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.9.1</version>
+            <version>2.9.2</version>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
         </dependency>
         <dependency>


### PR DESCRIPTION
By pulling in gerrit-events version with support for AES encryption passphrase

See comments in [gerrit-events PR](https://github.com/sonyxperiadev/gerrit-events/pull/45)