### PR TITLE
Permit use of Forbidden files without File Paths

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -818,8 +818,12 @@ public class GerritTrigger extends Trigger<Job> {
                          && p.isInteresting(changeBasedEvent.getChange().getProject(),
                                             changeBasedEvent.getChange().getBranch(),
                                             changeBasedEvent.getChange().getTopic())) {
-                        if (isFileTriggerEnabled() && p.getFilePaths() != null
-                                && p.getFilePaths().size() > 0) {
+
+                        boolean containsFilePathsOrForbiddenFilePaths =
+                                ((p.getFilePaths() != null && p.getFilePaths().size() > 0)
+                                        || (p.getForbiddenFilePaths() != null && p.getForbiddenFilePaths().size() > 0));
+
+                        if (isFileTriggerEnabled() && containsFilePathsOrForbiddenFilePaths) {
                             if (isServerInteresting(event)
                                  && p.isInteresting(changeBasedEvent.getChange().getProject(),
                                                     changeBasedEvent.getChange().getBranch(),

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
@@ -142,6 +142,22 @@ public class GerritProjectWithFilesInterestingTest {
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "project", "master", null, files, false), });
 
+        //Testing with Forbidden File Paths now BUT no filepaths defined
+        branches = new LinkedList<Branch>();
+        branch = new Branch(CompareType.PLAIN, "master");
+        branches.add(branch);
+        topics = new LinkedList<Topic>();
+        filePaths = null;
+        forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePath = new FilePath(CompareType.PLAIN, "test2.txt");
+        forbiddenFilePaths.add(forbiddenFilePath);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths);
+        files = new LinkedList<String>();
+        files.add("test.txt");
+        files.add("test2.txt");
+        parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
+                config, "project", "master", null, files, false), });
+
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
         branches.add(branch);


### PR DESCRIPTION
When a job is configured to be triggered with the use of a Forbidden path,
this path is only inspected if the configuration ALSO contains a File path.

This patch corrects this requirement.

[JENKINS-29663]
