### PR TITLE
Option to permit disable Strict Forbidden files

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
@@ -176,7 +176,7 @@ public final class GerritDynamicUrlProcessor {
           topics = new ArrayList<Topic>();
           filePaths = new ArrayList<FilePath>();
           forbiddenFilePaths = new ArrayList<FilePath>();
-          dynamicGerritProject = new GerritProject(type, text, branches, topics, filePaths, forbiddenFilePaths);
+          dynamicGerritProject = new GerritProject(type, text, branches, topics, filePaths, forbiddenFilePaths, false);
         } else if (SHORTNAME_BRANCH.equals(item)) { // Branch
           if (branches == null) {
             throw new ParseException("Line " + lineNr + ": attempt to use 'Branch' before 'Project'", lineNr);

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -387,6 +387,13 @@
                             </f:repeatable>
                             </td>
                         </tr>
+                       <tr>
+                            <td colspan="4" valign="top" style="border-left: 1px solid black; border-right: 1px solid black; border-bottom: 1px solid black;">
+                                    <label>Disable Strict Forbidden File Verification</label>
+                                    <f:checkbox name="disableStrictForbiddenFileVerification"
+                                     checked="${loop.isDisableStrictForbiddenFileVerification()}"/>
+                            </td>
+                      </tr>
                     </j:if>
                 </table>
             </f:repeatable>

--- a/src/main/webapp/trigger/help-GerritTriggerConfiguration.html
+++ b/src/main/webapp/trigger/help-GerritTriggerConfiguration.html
@@ -43,3 +43,8 @@
 <p>
     You can add more file path patterns by clicking on &quot;Add File path&quot;
 </p>
+<p><strong>Disabling strict forbidden file verification</strong></p>
+<ul>
+  <li>Enabling this option will allow an event to trigger a build if the event contains <strong>BOTH</strong> one or more wanted file paths <strong>AND</strong> one or more forbidden file paths. </li>
+  <li>In other words, with this option, the build will not get triggered if the change contains only forbidden files, otherwise it will get triggered.</li>
+</ul>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJobHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJobHudsonTest.java
@@ -95,7 +95,7 @@ public class BuildCompletedRestCommandJobHudsonTest {
         trigger.setGerritProjects(Collections.singletonList(
                 new GerritProject(CompareType.PLAIN, event.getChange().getProject(),
                         Collections.singletonList(new Branch(CompareType.PLAIN, event.getChange().getBranch())),
-                        null, null, null)
+                        null, null, null, false)
         ));
         trigger.setSilentMode(false);
         trigger.setGerritBuildSuccessfulCodeReviewValue(1);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectListTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritProjectListTest.java
@@ -63,7 +63,7 @@ public class GerritProjectListTest {
         List<Branch> branches = new LinkedList<Branch>();
         Branch branch = new Branch(compareType, "master");
         branches.add(branch);
-        GerritProject config = new GerritProject(CompareType.PLAIN, pattern, branches, null, null, null);
+        GerritProject config = new GerritProject(CompareType.PLAIN, pattern, branches, null, null, null, false);
         return config;
     }
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
@@ -918,7 +918,7 @@ public class GerritTriggerTest {
         branches.add(br);
 
         GerritProject gP = new GerritProject(
-                CompareType.PLAIN, "job", branches, null, null, null);
+                CompareType.PLAIN, "job", branches, null, null, null, false);
 
         GerritTrigger trigger = Setup.createRefUpdatedTrigger(project);
         Setup.setTrigger(trigger, project);
@@ -956,7 +956,7 @@ public class GerritTriggerTest {
         branches.add(br);
 
         GerritProject gP = new GerritProject(
-                CompareType.PLAIN, "job", branches, null, null, null);
+                CompareType.PLAIN, "job", branches, null, null, null, false);
 
         GerritTrigger trigger = Setup.createRefUpdatedTrigger(project);
         Setup.setTrigger(trigger, project);
@@ -994,7 +994,7 @@ public class GerritTriggerTest {
         branches.add(br);
 
         GerritProject gP = new GerritProject(
-                CompareType.PLAIN, "job", branches, null, null, null);
+                CompareType.PLAIN, "job", branches, null, null, null, false);
 
         GerritTrigger trigger = Setup.createRefUpdatedTrigger(project);
         Setup.setTrigger(trigger, project);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/WorkflowTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/WorkflowTest.java
@@ -152,7 +152,7 @@ public class WorkflowTest {
         trigger.setGerritProjects(Collections.singletonList(
                 new GerritProject(CompareType.PLAIN, event.getChange().getProject(),
                         Collections.singletonList(new Branch(CompareType.PLAIN, event.getChange().getBranch())),
-                        null, null, null)
+                        null, null, null, false)
         ));
         trigger.setSilentMode(false);
         trigger.setGerritBuildSuccessfulCodeReviewValue(1);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
@@ -75,20 +75,20 @@ public class GerritProjectInterestingTest {
         List<Topic> topics = new LinkedList<Topic>();
         Branch branch = new Branch(CompareType.PLAIN, "master");
         branches.add(branch);
-        GerritProject config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
+        GerritProject config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "origin/master", null, true), });
 
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
         branches = new LinkedList<Branch>();
@@ -96,7 +96,7 @@ public class GerritProjectInterestingTest {
         branches.add(branch);
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
         branches.add(branch);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", null, true)});
 
         branches = new LinkedList<Branch>();
@@ -104,14 +104,14 @@ public class GerritProjectInterestingTest {
         branches.add(branch);
         branch = new Branch(CompareType.REG_EXP, "feature/.*master");
         branches.add(branch);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "feature/mymaster", null, true), });
 
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.ANT, "**/master");
         branches.add(branch);
-        config = new GerritProject(CompareType.ANT, "vendor/**/project", branches, topics, null, null);
+        config = new GerritProject(CompareType.ANT, "vendor/**/project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "vendor/semc/master/project", "origin/master", null, true), });
 
@@ -121,20 +121,20 @@ public class GerritProjectInterestingTest {
         topics = new LinkedList<Topic>();
         Topic topic = new Topic(CompareType.PLAIN, "topic");
         topics.add(topic);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config, "project", "master", "topic", true)});
 
         topics = new LinkedList<Topic>();
         topic = new Topic(CompareType.ANT, "**/topic");
         topics.add(topic);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "master", "team/topic", true), });
 
         topics = new LinkedList<Topic>();
         topic = new Topic(CompareType.REG_EXP, ".*_topic");
         topics.add(topic);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "master", "team-wolf_topic", true), });
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
@@ -78,7 +78,7 @@ public class GerritProjectWithFilesInterestingTest {
         filePaths.add(filePath);
         List<FilePath> forbiddenFilePaths = null;
         GerritProject config = new GerritProject(
-                CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths);
+                CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths, false);
         List<String> files = new LinkedList<String>();
         files.add("test.txt");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
@@ -93,7 +93,8 @@ public class GerritProjectWithFilesInterestingTest {
         files = new LinkedList<String>();
         files.add("tests/test.txt");
         forbiddenFilePaths = null;
-        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
+        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths,
+                false);
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "projectNumber5", "feature/mymaster", null, files, true), });
 
@@ -105,7 +106,7 @@ public class GerritProjectWithFilesInterestingTest {
         filePaths.add(filePath);
         forbiddenFilePaths = null;
         config = new GerritProject(
-                CompareType.ANT, "vendor/**/project", branches, topics, filePaths, forbiddenFilePaths);
+                CompareType.ANT, "vendor/**/project", branches, topics, filePaths, forbiddenFilePaths, false);
         files = new LinkedList<String>();
         files.add("resources/test.xml");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
@@ -120,7 +121,8 @@ public class GerritProjectWithFilesInterestingTest {
         files = new LinkedList<String>();
         files.add("notintests/test.txt");
         forbiddenFilePaths = null;
-        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
+        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths,
+                false);
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "projectNumber5", "feature/mymaster", null, files, false), });
 
@@ -135,12 +137,31 @@ public class GerritProjectWithFilesInterestingTest {
         forbiddenFilePaths = new LinkedList<FilePath>();
         FilePath forbiddenFilePath = new FilePath(CompareType.PLAIN, "test2.txt");
         forbiddenFilePaths.add(forbiddenFilePath);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths, false);
         files = new LinkedList<String>();
         files.add("test.txt");
         files.add("test2.txt");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "project", "master", null, files, false), });
+
+        //Testing with Forbidden File Paths now BUT disableStrictForbiddenFileVerification
+        // is true
+        branches = new LinkedList<Branch>();
+        branch = new Branch(CompareType.PLAIN, "master");
+        branches.add(branch);
+        topics = new LinkedList<Topic>();
+        filePaths = new LinkedList<FilePath>();
+        filePath = new FilePath(CompareType.PLAIN, "test.txt");
+        filePaths.add(filePath);
+        forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePath = new FilePath(CompareType.PLAIN, "test2.txt");
+        forbiddenFilePaths.add(forbiddenFilePath);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths, true);
+        files = new LinkedList<String>();
+        files.add("test.txt");
+        files.add("test2.txt");
+        parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
+                config, "project", "master", null, files, true), });
 
         //Testing with Forbidden File Paths now BUT no filepaths defined
         branches = new LinkedList<Branch>();
@@ -151,7 +172,7 @@ public class GerritProjectWithFilesInterestingTest {
         forbiddenFilePaths = new LinkedList<FilePath>();
         forbiddenFilePath = new FilePath(CompareType.PLAIN, "test2.txt");
         forbiddenFilePaths.add(forbiddenFilePath);
-        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths);
+        config = new GerritProject(CompareType.PLAIN, "project", branches, topics, filePaths, forbiddenFilePaths, false);
         files = new LinkedList<String>();
         files.add("test.txt");
         files.add("test2.txt");
@@ -170,7 +191,8 @@ public class GerritProjectWithFilesInterestingTest {
         files = new LinkedList<String>();
         files.add("tests/test.txt");
         files.add("tests/test2.txt");
-        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths);
+        config = new GerritProject(CompareType.REG_EXP, "project.*5", branches, topics, filePaths, forbiddenFilePaths,
+                false);
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "projectNumber5", "feature/mymaster", null, files, false), });
 
@@ -184,7 +206,7 @@ public class GerritProjectWithFilesInterestingTest {
         forbiddenFilePath = new FilePath(CompareType.ANT, "**/*skip*");
         forbiddenFilePaths.add(forbiddenFilePath);
         config = new GerritProject(
-                CompareType.ANT, "vendor/**/project", branches, topics, filePaths, forbiddenFilePaths);
+                CompareType.ANT, "vendor/**/project", branches, topics, filePaths, forbiddenFilePaths, false);
         files = new LinkedList<String>();
         files.add("resources/test.xml");
         files.add("files/skip.txt");

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
@@ -82,7 +82,7 @@ public abstract class DuplicatesUtil {
         FreeStyleProject p = rule.createFreeStyleProject(projectName);
         List<GerritProject> projects = new LinkedList<GerritProject>();
         projects.add(new GerritProject(CompareType.ANT, "**",
-                Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null));
+                Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null, false));
         p.addTrigger(new GerritTrigger(projects, null,
                 null, null, null, null, null, null, null, null, null, null,
                 false, false, true, false, false, null, null, null, null, null, null, null,
@@ -151,7 +151,7 @@ public abstract class DuplicatesUtil {
         FreeStyleProject p = rule.createFreeStyleProject(name);
         List<GerritProject> projects = new LinkedList<GerritProject>();
         projects.add(new GerritProject(CompareType.ANT, "**",
-                Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null));
+                Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null, false));
         PluginCommentAddedEvent event = new PluginCommentAddedEvent("CRVW", "1");
         List<PluginGerritEvent> list = new LinkedList<PluginGerritEvent>();
         list.add(event);


### PR DESCRIPTION
Add option to gerrit project to permit the disable of the default strict forbidden file verification of an event.

Enabling this option will allow an event to trigger a build if the event contains BOTH one or more wanted file paths AND one or more forbidden file paths.

In other words, with this option, the build will not get triggered if the change contains only forbidden files, otherwise it will get triggered.

[FIXED JENKINS-30620]

Change-Id: Icb84111c82a38db722ec09bf7538441bc1b9424a