### PR TITLE
Update for change to Gerrit stream events

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.9.2</version>
+            <version>2.9.3</version>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
         </dependency>
         <dependency>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -882,10 +882,31 @@ public class GerritTrigger extends Trigger<Job> {
             if (e instanceof PluginCommentAddedEvent) {
                 commentAdded = (PluginCommentAddedEvent)e;
                 for (Approval approval : event.getApprovals()) {
-                    if (approval.getType().equals(commentAdded.getVerdictCategory())
-                        && (approval.getValue().equals(commentAdded.getCommentAddedTriggerApprovalValue())
-                        || ("+" + approval.getValue()).equals(commentAdded.getCommentAddedTriggerApprovalValue()))) {
-                    return true;
+                    /** Ensure that this trigger is backwards compatible.
+                     * Gerrit stream events changed to append approval info to
+                     * every comment-added event.  The change also includes a
+                     * new `updated` attribute to indicate whether the score
+                     * was changed.
+                     **/
+                    if (approval.getUpdated() != null) {
+                        if (approval.getUpdated()
+                            && approval.getType().equals(
+                                commentAdded.getVerdictCategory())
+                            && (approval.getValue().equals(
+                                commentAdded.getCommentAddedTriggerApprovalValue())
+                            || ("+" + approval.getValue()).equals(
+                                commentAdded.getCommentAddedTriggerApprovalValue()))) {
+                            return true;
+                         }
+                    } else {
+                        if (approval.getType().equals(
+                                commentAdded.getVerdictCategory())
+                            && (approval.getValue().equals(
+                                commentAdded.getCommentAddedTriggerApprovalValue())
+                            || ("+" + approval.getValue()).equals(
+                                commentAdded.getCommentAddedTriggerApprovalValue()))) {
+                            return true;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
A pending Gerrit stream events change[1] will append approval info
to every comment-added event.  That change also adds an `updated`
attribute to the approvals info.  This change will ensure that the label
trigger will continue to work with existing Gerrit versions and with the
upcoming stream events change in newer Gerrit versions.

This change dependings on a pending gerrit-events update[2]

[1] https://gerrit-review.googlesource.com/#/c/71051
[2] https://github.com/sonyxperiadev/gerrit-events/pull/48