### PR TITLE
Add Replication status to queued item and failures

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritSlave.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritSlave.java
@@ -51,6 +51,9 @@ public class GerritSlave extends AbstractDescribableImpl<GerritSlave> {
     private String host;
     private int timeoutInSeconds;
 
+    //Hold the replication status
+    private transient ReplicationStatus replicationStatus;
+
     /**
      * Standard Constructor.
      * @param id the ID or {@code null} to generate a new one
@@ -109,6 +112,55 @@ public class GerritSlave extends AbstractDescribableImpl<GerritSlave> {
      */
     public int getTimeoutInSeconds() {
         return timeoutInSeconds;
+    }
+
+    /**
+     * Getter for replication status.
+     * @return the replication status
+     */
+    public ReplicationStatus getReplicationStatus() {
+        return replicationStatus;
+    }
+
+    /**
+     * Setter for replication status.
+     * @param replicationStatus the replication status.
+     */
+    public void setReplicationStatus(ReplicationStatus replicationStatus) {
+        this.replicationStatus = replicationStatus;
+    }
+
+    /**
+     * Possible replication status.
+     */
+    public enum ReplicationStatus {
+
+        /**
+         * Replication is in progress.
+         **/
+        INPROGRESS("in progress"),
+        /**
+         * Replication is failing.
+         */
+        ISFAILING("is failing");
+
+        private String statusMessage;
+
+        /**
+         * Set Replication status.
+         * @param s status.
+         */
+        private ReplicationStatus(String s) {
+            statusMessage = s;
+        }
+
+        /**
+         * Get status message.
+         * @return statusMessage.
+         */
+        public String getStatusMessage() {
+            return statusMessage;
+        }
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/WaitingForReplication.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/WaitingForReplication.java
@@ -65,7 +65,11 @@ public class WaitingForReplication extends CauseOfBlockage {
         @Override
         public String apply(@Nullable GerritSlave gerritSlave) {
             if (gerritSlave != null) {
-                return gerritSlave.getName();
+                if (gerritSlave.getReplicationStatus() != null) {
+                    return gerritSlave.getName() + " (" + gerritSlave.getReplicationStatus().getStatusMessage() + ")";
+                } else {
+                    return gerritSlave.getName();
+                }
             } else {
                 return null;
             }


### PR DESCRIPTION
This change adds the replication status to the reason for the fact
that an item is in the queue.

For example, if a replication is failing towards a mirror, its status will added as shown below:

(pending—Replication to sekimirror (is failing) not completed.)

In addition, if the replication has timed-out, the status will be displayed in the console log
as shown below:

ERROR: Waiting for replication of refs/changes/55/899655/1 to sekimirror timed out.

Replication Status:
-------------------

** Replication to sekimirror is failing!

Change-Id: I254d006629ddae375a3b95ad9a1b137c4a8006be