### PR TITLE
Fix NPE involving null server CR/Ver labels

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -521,8 +521,8 @@ public class ParameterExpander {
             command = config.getGerritCmdBuildFailed();
         }
 
-        int verified = 0;
-        int codeReview = 0;
+        Integer verified = 0;
+        Integer codeReview = 0;
         Notify notifyLevel = Notify.ALL;
         if (memoryImprint.getEvent().isScorable()) {
             verified = getMinimumVerifiedValue(memoryImprint, onlyCountBuilt);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJob.java
@@ -96,7 +96,7 @@ public class BuildCompletedRestCommandJob extends AbstractRestCommandJob {
                     if (verValue != null && verValue != Integer.MAX_VALUE) {
                         scoredLabels.add(new ReviewLabel(
                                 LABEL_VERIFIED,
-                                parameterExpander.getMinimumVerifiedValue(memoryImprint, true)));
+                                verValue));
                     }
                 }
             }
@@ -117,7 +117,6 @@ public class BuildCompletedRestCommandJob extends AbstractRestCommandJob {
             }
 
             return new ReviewInput(message, scoredLabels, commentedFiles).setNotify(notificationLevel);
-
         } finally {
             SecurityContextHolder.setContext(old);
         }


### PR DESCRIPTION
This fixes a possible NPE when the Server level Code-Review/Verified values are null at the server level
and no job has overridden the values.
