### PR TITLE
Correct Missed Events Playback manager init

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -410,9 +410,8 @@ public class GerritServer implements Describable<GerritServer>, Action {
                         name, isProjectCreatedEventsSupported());
         projectListUpdater.start();
 
-        if (missedEventsPlaybackManager.isSupported()) {
-            addListener((GerritEventListener)missedEventsPlaybackManager);
-        }
+        missedEventsPlaybackManager.checkIfEventsLogPluginSupported();
+        addListener((GerritEventListener)missedEventsPlaybackManager);
 
         logger.info(name + " started");
         started = true;
@@ -447,6 +446,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
 
         if (missedEventsPlaybackManager != null) {
             missedEventsPlaybackManager.shutdown();
+            missedEventsPlaybackManager = null;
         }
 
         if (gerritConnection != null) {
@@ -516,10 +516,10 @@ public class GerritServer implements Describable<GerritServer>, Action {
                 gerritConnection.setHandler(gerritEventManager);
                 gerritConnection.addListener(gerritConnectionListener);
                 gerritConnection.addListener(projectListUpdater);
-                if (missedEventsPlaybackManager == null) {
-                    missedEventsPlaybackManager = new GerritMissedEventsPlaybackManager(name);
-                }
+
+                missedEventsPlaybackManager.checkIfEventsLogPluginSupported();
                 gerritConnection.addListener(missedEventsPlaybackManager);
+
                 gerritConnection.start();
             } else {
                 logger.warn("Already started!");
@@ -870,7 +870,12 @@ public class GerritServer implements Describable<GerritServer>, Action {
 
         if (!started) {
             this.start();
+        } else {
+            if (missedEventsPlaybackManager != null) {
+                missedEventsPlaybackManager.checkIfEventsLogPluginSupported();
+            }
         }
+
         rsp.sendRedirect("../..");
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -34,7 +34,6 @@ import com.sonymobile.tools.gerrit.gerritevents.GerritEventListener;
 import com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
-import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 
 import hudson.Util;
@@ -102,7 +101,7 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Ge
     private boolean playBackComplete = false;
 
     /**
-     * @param name Gerrit Server Name
+     * @param name Gerrit Server Name.
      */
     public GerritMissedEventsPlaybackManager(String name) {
         this.serverName = name;
@@ -110,9 +109,9 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Ge
     }
 
     /**
-     * method to verify if plugin is supported
+     * method to verify if plugin is supported.
      */
-    private void checkIfEventsLogPluginSupported() {
+    public void checkIfEventsLogPluginSupported() {
         GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null && server.getConfig() != null) {
             isSupported = GerritPluginChecker.isPluginEnabled(
@@ -323,11 +322,11 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Ge
                 continue;
             }
             GerritEvent evt = GerritJsonEventFactory.getEvent(jsonObject);
-            if (evt instanceof ChangeBasedEvent) {
+            if (evt instanceof GerritTriggeredEvent) {
                 Provider provider = new Provider();
                 provider.setName(serverName);
                 ((GerritTriggeredEvent)evt).setProvider(provider);
-                events.add((ChangeBasedEvent)evt);
+                events.add((GerritTriggeredEvent)evt);
             }
         }
         scanner.close();

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersHudsonTestCase.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersHudsonTestCase.java
@@ -180,6 +180,7 @@ public class DuplicateGerritListenersHudsonTestCase {
                 && server.isProjectCreatedEventsSupported()) {
             nbrOfListeners++; // GerritProjectListUpdater adds 1 listener
         }
+        nbrOfListeners++; // GerritMissedEventsPlaybackManager adds 1 listeners
         assertEquals(nbrOfListeners, gerritEventListeners.size());
     }
 }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersPreloadedProjectHudsonTestCase.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersPreloadedProjectHudsonTestCase.java
@@ -364,6 +364,7 @@ public class DuplicateGerritListenersPreloadedProjectHudsonTestCase {
                 && server.isProjectCreatedEventsSupported()) {
             nbrOfListeners++; // GerritProjectListUpdater adds 1 listener//
         }
+        nbrOfListeners++; // GerritMissedEventsPlaybackManager adds 1 listeners
         assertEquals(nbrOfListeners, gerritEventListeners.size());
     }
 


### PR DESCRIPTION
It is possible for the Missed Events playback manager to not be correctly initialized
once the REST API has been enabled AFTER the connection has been started.

The same issue applies if the Gerrit events-log plugin was installed AFTER the
Gerrit connection was started.

This ensures that the listener is active so that playback can execute when required.

[FIXED JENKINS-31439]