### PR TITLE
Protect PlaybackManager from null EventCreatedOn

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -405,12 +405,18 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Ge
      * @param evt Gerrit Event to persist.
      * @return true if was able to persist event.
      */
-    private synchronized boolean persist(GerritTriggeredEvent evt) {
+    synchronized boolean persist(GerritTriggeredEvent evt) {
+
+        if (evt == null || evt.getEventCreatedOn() == null) {
+            logger.warn("Event CreatedOn is null...Gerrit Server might not support attribute eventCreatedOn. "
+                    + "Will NOT persist this event and Missed Events will be disabled!");
+            isSupported = false;
+            return false;
+        }
 
         long ts = evt.getEventCreatedOn().getTime();
-
         if (ts == 0) {
-            logger.warn("Event CreatedOn is 0...Gerrit Server does not support attribute eventCreateOn. "
+            logger.warn("Event CreatedOn is 0...Gerrit Server does not support attribute eventCreatedOn. "
                     + "Will NOT persist this event and Missed Events will be disabled!");
             isSupported = false;
             return false;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsLoadPersistTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsLoadPersistTest.java
@@ -30,12 +30,17 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTrigge
 import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.Setup;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.utils.GerritPluginChecker;
 import com.sonymobile.tools.gerrit.gerritevents.GerritHandler;
+import com.sonymobile.tools.gerrit.gerritevents.GerritJsonEventFactory;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 
 import hudson.XmlFile;
 import jenkins.model.Jenkins;
 import junit.framework.TestCase;
+import net.sf.json.JSONObject;
 
+import org.apache.commons.io.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -47,6 +52,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.util.Date;
 import java.util.Random;
@@ -133,6 +139,25 @@ public class GerritMissedEventsLoadPersistTest {
                 , anyString())).thenReturn(true);
     }
 
+    /**
+     * Test if Gerrit returns a null eventCreated attribute.
+     * @throws IOException if occurs.
+     */
+    @Test
+    public void testNullEventCreatedOn() throws IOException {
+        InputStream stream = getClass().getResourceAsStream("DeserializeEventCreatedOnTest.json");
+        String json = IOUtils.toString(stream);
+        JSONObject jsonObject = JSONObject.fromObject(json);
+        GerritEvent evt = GerritJsonEventFactory.getEvent(jsonObject);
+        GerritTriggeredEvent gEvt = (GerritTriggeredEvent)evt;
+        assertNull(gEvt.getEventCreatedOn());
+
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager
+        = new GerritMissedEventsPlaybackManager("defaultServer");
+
+        assertTrue(!missingEventsPlaybackManager.persist(gEvt));
+
+    }
     /**
      * Given a non-existing timestamp file
      * When we attempt to load it

--- a/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/DeserializeEventCreatedOnTest.json
+++ b/src/test/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/DeserializeEventCreatedOnTest.json
@@ -1,0 +1,11 @@
+{"type":"change-restored","change":{"project":"playback-test","branch":"master"
+,"id":"Ibafad9613934fdec650d6186dc1021bc2cf5d2f5","number":"654","subject":"Mon Dec  8 20:53:56 EST 2014"
+,"owner":{"name":"Scott","email":"scott@company.com","username":"scott"
+  },"url":"http://localhost:9090/654"
+,"commitMessage":"Mon Dec  8 20:53:56 EST 2014\n\nChange-Id: Ibafad9613934fdec650d6186dc1021bc2cf5d2f5\n"
+,"status":"NEW"},"patchSet":{"number":"1","revision":"b2b5f7c8fb8f96312d629d4d4f379f34f5b9b651"
+,"parents":["6cf2d28cc07d22a49e0e614c7bde0a4e5fd0c8f5"],"ref":"refs/changes/54/654/1"
+,"uploader":{"name":"Scott","email":"scott@company.com","username":"scott"}
+,"createdOn":1418090036,"author":{"name":"Scott","email":"scott@company.com","username":"scott"}
+,"isDraft":false,"sizeInsertions":1,"sizeDeletions":0},"restorer":{"name":"Scott"
+,"email":"scott@company.com","username":"scott"}}


### PR DESCRIPTION
It is possible that Gerrit might return a null eventCreated attribute for some events.

This protects the persistence of events from this situation.

[FIXED JENKINS-30975]