### PR TITLE
build completed for RefUpdated events with REST

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/NotificationFactory.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/NotificationFactory.java
@@ -120,7 +120,8 @@ public class NotificationFactory {
         if (serverName != null) {
             IGerritHudsonTriggerConfig config = getConfig(serverName);
             if (config != null) {
-                if (config.isUseRestApi()) {
+                if (config.isUseRestApi()
+                        && memoryImprint.getEvent() instanceof ChangeBasedEvent) {
                     GerritSendCommandQueue.queue(new BuildCompletedRestCommandJob(config, memoryImprint, listener));
                 } else {
                     GerritSendCommandQueue.queue(new BuildCompletedCommandJob(config, memoryImprint, listener));


### PR DESCRIPTION
If REST API enabled, sending of build completed notifications for RefUpdated events are incorrectly attempted.

[FIXED JENKINS-31781]