### PR TITLE
Rename category deprecated default names CRVW and VRIF

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -394,8 +394,8 @@ public class GerritServer implements Describable<GerritServer>, Action {
             categories = new LinkedList<VerdictCategory>();
         }
         if (categories.isEmpty()) {
-            categories.add(new VerdictCategory("CRVW", "Code Review"));
-            categories.add(new VerdictCategory("VRIF", "Verified"));
+            categories.add(new VerdictCategory("Code-Review", "Code Review"));
+            categories.add(new VerdictCategory("Verified", "Verified"));
         }
         config.setCategories(categories);
         gerritEventManager = PluginImpl.getHandler_();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
@@ -649,13 +649,13 @@ public class ManualTriggerAction implements RootAction {
      */
     public static enum Approval {
         /**
-         * A Code Review Approval type <i>CRVW</i>.
+         * A Code Review Approval type <i>Code-Review</i>.
          */
-        CODE_REVIEW("CRVW"),
+        CODE_REVIEW("Code-Review"),
         /**
-         * A Verified Approval type <i>VRIF</i>.
+         * A Verified Approval type <i>Verified</i>.
          */
-        VERIFIED("VRIF");
+        VERIFIED("Verified");
         private String type;
 
         /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionTest.java
@@ -58,7 +58,7 @@ public class ManualTriggerActionTest {
 
     /**
      * Tests {@link ManualTriggerAction#getCodeReview(net.sf.json.JSONObject)}.
-     * With CRVW patchset info.
+     * With Code-Review patchset info.
      * @throws Exception if so.
      */
     @Test
@@ -68,19 +68,19 @@ public class ManualTriggerActionTest {
 
         JSONArray approvals = new JSONArray();
         JSONObject crw = new JSONObject();
-        crw.put("type", "CRVW");
+        crw.put("type", "Code-Review");
         crw.put("value", "2");
         approvals.add(crw);
         crw = new JSONObject();
-        crw.put("type", "CRVW");
+        crw.put("type", "Code-Review");
         crw.put("value", "1");
         approvals.add(crw);
         crw = new JSONObject();
-        crw.put("type", "VRIF");
+        crw.put("type", "Verified");
         crw.put("value", "1");
         approvals.add(crw);
         crw = new JSONObject();
-        crw.put("type", "CRVW");
+        crw.put("type", "Code-Review");
         crw.put("value", "-1");
         approvals.add(crw);
         currentPatchSet.put("approvals", approvals);
@@ -114,7 +114,7 @@ public class ManualTriggerActionTest {
 
     /**
      * Tests {@link ManualTriggerAction#getVerified(net.sf.json.JSONObject)}.
-     * With VRIF patchset info.
+     * With Verified patchset info.
      * @throws Exception if so.
      */
     @Test
@@ -124,19 +124,19 @@ public class ManualTriggerActionTest {
 
         JSONArray approvals = new JSONArray();
         JSONObject crw = new JSONObject();
-        crw.put("type", "VRIF");
+        crw.put("type", "Verified");
         crw.put("value", "2");
         approvals.add(crw);
         crw = new JSONObject();
-        crw.put("type", "VRIF");
+        crw.put("type", "Verified");
         crw.put("value", "1");
         approvals.add(crw);
         crw = new JSONObject();
-        crw.put("type", "CRVW");
+        crw.put("type", "Code-Review");
         crw.put("value", "1");
         approvals.add(crw);
         crw = new JSONObject();
-        crw.put("type", "VRIF");
+        crw.put("type", "Verified");
         crw.put("value", "-1");
         approvals.add(crw);
         currentPatchSet.put("approvals", approvals);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
@@ -152,7 +152,7 @@ public abstract class DuplicatesUtil {
         List<GerritProject> projects = new LinkedList<GerritProject>();
         projects.add(new GerritProject(CompareType.ANT, "**",
                 Collections.singletonList(new Branch(CompareType.ANT, "**")), null, null, null, false));
-        PluginCommentAddedEvent event = new PluginCommentAddedEvent("CRVW", "1");
+        PluginCommentAddedEvent event = new PluginCommentAddedEvent("Code-Review", "1");
         List<PluginGerritEvent> list = new LinkedList<PluginGerritEvent>();
         list.add(event);
         p.addTrigger(new GerritTrigger(projects, null,

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
@@ -447,7 +447,7 @@ public final class Setup {
         event.setPatchset(patch);
         List<Approval> approvals = new LinkedList<Approval>();
         Approval approval = new Approval();
-        approval.setType("CRVW");
+        approval.setType("Code-Review");
         approval.setValue("1");
         approvals.add(approval);
         event.setApprovals(approvals);
@@ -669,7 +669,7 @@ public final class Setup {
      * @return the List.
      */
     public static List<VerdictCategory> createCodeReviewVerdictCategoryList() {
-        VerdictCategory cat = new VerdictCategory("CRVW", "Code review");
+        VerdictCategory cat = new VerdictCategory("Code-Review", "Code review");
         List<VerdictCategory> list = new LinkedList<VerdictCategory>();
         list.add(cat);
         return list;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/project/GerritTriggerProjectHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/project/GerritTriggerProjectHudsonTest.java
@@ -87,10 +87,10 @@ public class GerritTriggerProjectHudsonTest {
         HtmlElement option = iterator.next();
         String value = option.getAttribute("value");
         //This will test that the default values are correct.
-        assertEquals("First value should be CRVW", "CRVW", value);
+        assertEquals("First value should be Code-Review", "Code-Review", value);
         option = iterator.next();
         value = option.getAttribute("value");
-        assertEquals("Second value should be VRIF", "VRIF", value);
+        assertEquals("Second value should be Verified", "Verified", value);
     }
 
     /**
@@ -133,10 +133,10 @@ public class GerritTriggerProjectHudsonTest {
         HtmlElement option = iterator.next();
         String value = option.getAttribute("value");
         //This will test that the default values are correct.
-        assertEquals("First value should be VRIF", "VRIF", value);
+        assertEquals("First value should be Verified", "Verified", value);
         option = iterator.next();
         value = option.getAttribute("value");
-        assertEquals("Second value should be CRVW", "CRVW", value);
+        assertEquals("Second value should be Code-Review", "Code-Review", value);
         option = iterator.next();
         value = option.getAttribute("value");
         assertEquals("Third value should be Code-Review", "Code-Review", value);


### PR DESCRIPTION
Rename category deprecated default names CRVW and VRIF
removed in Gerrit 2.6 (2 years old) to current
label names Code-Review and Verified

Default values concerns only to newly created servers in gerrit trigger. Copied servers also copies verdict categories from the parent. So this change is mainly for new Jenkins users with >= 2.6 Gerrit server.
CRVW and VRIF were used last time in Gerrit 2.5.6

Sorry for new pull request (previous was #269). I was pushed my new master and #269 was closed.

Merge as you wish, it is not a bug.
