### PR TITLE
Fix problem where approvals were not displayed in Query and Trigger

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
@@ -220,7 +220,7 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
             }
         }
         try {
-            logger.info("Trying to load project list.");
+            logger.trace("Trying to load project list.");
             if (isConnected()) {
                 IGerritHudsonTriggerConfig activeConfig = getConfig();
                 SshConnection sshConnection = SshConnectionFactory.getConnection(
@@ -232,7 +232,7 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
                 List<String> projects = readProjects(sshConnection.executeCommandReader(GERRIT_LS_PROJECTS));
                 if (projects.size() > 0) {
                     setGerritProjects(projects);
-                    logger.info("Project list from {} contains {} entries", serverName, projects.size());
+                    logger.trace("Project list from {} contains {} entries", serverName, projects.size());
                 } else {
                     logger.warn("Project list from {} contains 0 projects", serverName);
                 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
@@ -236,20 +236,22 @@ public class ManualTriggerAction implements RootAction {
      * Finds the highest and lowest code review vote for the provided patch set.
      *
      * @param res the patch set.
+     * @param patchSetNumber the patch set number.
      * @return the highest and lowest code review vote for the patch set.
      */
-    public HighLow getCodeReview(JSONObject res) {
-        return Approval.CODE_REVIEW.getApprovals(res);
+    public HighLow getCodeReview(JSONObject res, int patchSetNumber) {
+        return Approval.CODE_REVIEW.getApprovals(res, patchSetNumber);
     }
 
     /**
      * Finds the lowest and highest verified vote for the provided patch set.
      *
      * @param res the patch-set.
+     * @param patchSetNumber the patch set number.
      * @return the highest and lowest verified vote.
      */
-    public HighLow getVerified(JSONObject res) {
-        return Approval.VERIFIED.getApprovals(res);
+    public HighLow getVerified(JSONObject res, int patchSetNumber) {
+        return Approval.VERIFIED.getApprovals(res, patchSetNumber);
     }
 
     /**
@@ -316,7 +318,6 @@ public class ManualTriggerAction implements RootAction {
                             JSONArray jsonArray = new JSONArray();
                             jsonArray.add(j.getJSONObject("currentPatchSet"));
                             j.put("patchSets", jsonArray);
-                            j.remove("currentPatchSet");
                         }
                     }
                 }
@@ -324,7 +325,7 @@ public class ManualTriggerAction implements RootAction {
                 //TODO Implement some smart default selection.
                 //That can notice that a specific revision is searched or that there is only one result etc.
             } catch (GerritQueryException gqe) {
-                logger.debug("Bad query. ", gqe);
+                logger.debug("Bad query {}", gqe);
                 session.setAttribute(SESSION_SEARCH_ERROR, gqe);
             } catch (Exception ex) {
                 logger.warn("Could not query Gerrit for [" + queryString + "]", ex);
@@ -671,28 +672,31 @@ public class ManualTriggerAction implements RootAction {
          * Finds the highest and lowest approval value of the approval's type for the specified change.
          *
          * @param res the change.
+         * @param patchSetNumber the patch set number.
          * @return the highest and lowest value. Or 0,0 if there are no values.
          */
-        public HighLow getApprovals(JSONObject res) {
+        public HighLow getApprovals(JSONObject res, int patchSetNumber) {
             logger.trace("Get Approval: {} {}", type, res);
             int highValue = Integer.MIN_VALUE;
             int lowValue = Integer.MAX_VALUE;
             if (res.has("currentPatchSet")) {
                 logger.trace("Has currentPatchSet");
                 JSONObject patchSet = res.getJSONObject("currentPatchSet");
-                if (patchSet.has("approvals")) {
-                    JSONArray approvals = patchSet.getJSONArray("approvals");
-                    logger.trace("Approvals: ", approvals);
-                    for (Object o : approvals) {
-                        JSONObject ap = (JSONObject)o;
-                        if (type.equalsIgnoreCase(ap.optString("type"))) {
-                            logger.trace("A {}", type);
-                            try {
-                                int approval = Integer.parseInt(ap.getString("value"));
-                                highValue = Math.max(highValue, approval);
-                                lowValue = Math.min(lowValue, approval);
-                            } catch (NumberFormatException nfe) {
-                                logger.warn("Gerrit is bad at giving me Approval-numbers!", nfe);
+                if (patchSet.has("number") && patchSet.has("approvals")) {
+                    if (patchSet.getInt("number") == patchSetNumber) {
+                        JSONArray approvals = patchSet.getJSONArray("approvals");
+                        logger.trace("Approvals: {}", approvals);
+                        for (Object o : approvals) {
+                            JSONObject ap = (JSONObject)o;
+                            if (type.equalsIgnoreCase(ap.optString("type"))) {
+                                logger.trace("A {}", type);
+                                try {
+                                    int approval = Integer.parseInt(ap.getString("value"));
+                                    highValue = Math.max(highValue, approval);
+                                    lowValue = Math.min(lowValue, approval);
+                                } catch (NumberFormatException nfe) {
+                                    logger.warn("Gerrit is bad at giving me Approval-numbers! {}", nfe);
+                                }
                             }
                         }
                     }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
@@ -169,7 +169,7 @@
                                                         </td>
                                                         <td align="center" valign="middle"
                                                             onClick="activateRow('${theId}')">
-                                                            <j:set var="v" value="${it.getVerified(res)}"/>
+                                                            <j:set var="v" value="${it.getVerified(res, patch.getInt('number'))}"/>
                                                             <j:choose>
                                                                 <j:when test="${v.low &lt; 0}">
                                                                     <img src="${rootURL}/plugin/gerrit-trigger/images/x.gif"
@@ -186,7 +186,7 @@
                                                         </td>
                                                         <td align="center" valign="middle"
                                                             onClick="activateRow('${theId}')">
-                                                            <j:set var="v" value="${it.getCodeReview(res)}"/>
+                                                            <j:set var="v" value="${it.getCodeReview(res, patch.getInt('number'))}"/>
                                                             <j:choose>
                                                                 <j:when test="${v.low &lt; -1}">
                                                                     <img src="${rootURL}/plugin/gerrit-trigger/images/x.gif"


### PR DESCRIPTION
Fix problem where approvals were not displayed in Query and Trigger Gerrit Patches window for patchsets which already has Verified or Code-Review approval.
Approvals are displayed only for latest patchset.
Decrease log verbosity for GerritProjectListUpdater.

[FIXED JENKINS-31894]