### PR TITLE
Fix problem where approvals were not displayed in Query and Trigger

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
@@ -169,7 +169,7 @@
                                                         </td>
                                                         <td align="center" valign="middle"
                                                             onClick="activateRow('${theId}')">
-                                                            <j:set var="v" value="${it.getVerified(res)}"/>
+                                                            <j:set var="v" value="${it.getVerified(res, patch.getInt('number'))}"/>
                                                             <j:choose>
                                                                 <j:when test="${v.low &lt; 0}">
                                                                     <img src="${rootURL}/plugin/gerrit-trigger/images/x.gif"
@@ -186,7 +186,7 @@
                                                         </td>
                                                         <td align="center" valign="middle"
                                                             onClick="activateRow('${theId}')">
-                                                            <j:set var="v" value="${it.getCodeReview(res)}"/>
+                                                            <j:set var="v" value="${it.getCodeReview(res, patch.getInt('number'))}"/>
                                                             <j:choose>
                                                                 <j:when test="${v.low &lt; -1}">
                                                                     <img src="${rootURL}/plugin/gerrit-trigger/images/x.gif"

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionApprovalTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionApprovalTest.java
@@ -1,0 +1,225 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2015 Jiri Engelthaler. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.actions.manual;
+
+import static org.mockito.Mockito.any;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.config.Config;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.DuplicatesUtil;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+import com.sonymobile.tools.gerrit.gerritevents.mock.SshdServerMock;
+
+import net.sf.json.JSONObject;
+
+import org.apache.sshd.SshServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import org.kohsuke.stapler.StaplerRequest;
+import org.kohsuke.stapler.StaplerResponse;
+
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+
+import java.util.List;
+
+import javax.servlet.http.HttpSession;
+
+import hudson.model.FreeStyleProject;
+
+//CS IGNORE LineLength FOR NEXT 1 LINES. REASON: static import
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+//CS IGNORE LineLength FOR NEXT 1 LINES. REASON: static java import.
+
+/**
+ * @author Jiri Engelthaler &lt;EngyCZ@gmail.com&gt;
+ */
+
+public class ManualTriggerActionApprovalTest {
+
+    /**
+     * An instance of Jenkins Rule.
+     */
+    // CS IGNORE VisibilityModifier FOR NEXT 2 LINES. REASON: JenkinsRule.
+    @Rule
+    public final JenkinsRule j = new JenkinsRule();
+
+    private final String gerritServerName = "testServer";
+    private final String projectName = "testProject";
+    private final int port = 29418;
+
+    private SshdServerMock server;
+    private SshServer sshd;
+    private SshdServerMock.KeyPairFiles sshKey;
+
+    /**
+     * Runs before test method.
+     *
+     * @throws Exception throw if so.
+     */
+    @Before
+    public void setUp() throws Exception {
+        sshKey = SshdServerMock.generateKeyPair();
+        System.setProperty(PluginImpl.TEST_SSH_KEYFILE_LOCATION_PROPERTY, sshKey.getPrivateKey().getAbsolutePath());
+        server = new SshdServerMock();
+        sshd = SshdServerMock.startServer(port, server);
+        server.returnCommandFor("gerrit ls-projects", SshdServerMock.EofCommandMock.class);
+        server.returnCommandFor("gerrit version", SshdServerMock.EofCommandMock.class);
+        server.returnCommandFor("gerrit query --format=JSON --current-patch-set \"status:open\"",
+            SshdServerMock.SendQueryLastPatchSet.class);
+        server.returnCommandFor("gerrit query --format=JSON --patch-sets --current-patch-set \"status:open\"",
+            SshdServerMock.SendQueryAllPatchSets.class);
+    }
+
+    /**
+     * Runs after test method.
+     *
+     * @throws Exception throw if so.
+     */
+    @After
+    public void tearDown() throws Exception {
+        sshd.stop(true);
+        sshd = null;
+    }
+
+    /**
+     * Tests {@link ManualTriggerAction#getApprovals(net.sf.json.JSONObject, int)}.
+     * With an last patchset
+     * @throws Exception if so.
+     */
+    @Test
+    public void testDoGerritSearchLastPatchSet() throws Exception {
+        GerritServer gerritServer = new GerritServer(gerritServerName);
+        PluginImpl.getInstance().addServer(gerritServer);
+        gerritServer.start();
+
+        Config config = (Config)gerritServer.getConfig();
+        config.setGerritAuthKeyFile(sshKey.getPrivateKey());
+        config.setGerritHostName("localhost");
+        config.setGerritSshPort(port);
+        gerritServer.startConnection();
+
+        FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJob(j, projectName, gerritServerName);
+
+        final ManualTriggerAction action = new ManualTriggerAction();
+        HttpSession session = mock(HttpSession.class);
+
+        StaplerRequest request = mock(StaplerRequest.class);
+        StaplerResponse response = mock(StaplerResponse.class);
+
+        when(request.getSession(true)).thenReturn(session);
+
+        doAnswer(new Answer() {
+            /**
+             * @see org.mockito.stubbing.Answer#answer(org.mockito.invocation.InvocationOnMock)
+             */
+            @Override
+            public Object answer(InvocationOnMock aInvocation) throws Throwable {
+                List<JSONObject> json = (List<JSONObject>)aInvocation.getArguments()[1];
+
+                ManualTriggerAction.HighLow highLow = action.getCodeReview(json.get(0), 2);
+                assertEquals(2, highLow.getHigh());
+                assertEquals(-1, highLow.getLow());
+
+                highLow = action.getVerified(json.get(0), 2);
+                assertEquals(2, highLow.getHigh());
+                assertEquals(-1, highLow.getLow());
+
+                return null;
+            }
+
+        }).when(session).setAttribute(eq("result"), any());
+
+        action.doGerritSearch("status:open", gerritServerName, false, request, response);
+    }
+
+    /**
+     * Tests {@link ManualTriggerAction#getApprovals(net.sf.json.JSONObject, int)}.
+     * With an all patchsets
+     * @throws Exception if so.
+     */
+    @Test
+    public void testDoGerritSearchAllPatchSets() throws Exception {
+        GerritServer gerritServer = new GerritServer(gerritServerName);
+        PluginImpl.getInstance().addServer(gerritServer);
+        gerritServer.start();
+
+        Config config = (Config)gerritServer.getConfig();
+        config.setGerritAuthKeyFile(sshKey.getPrivateKey());
+        config.setGerritHostName("localhost");
+        config.setGerritSshPort(port);
+        gerritServer.startConnection();
+
+        FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJob(j, projectName, gerritServerName);
+
+        final ManualTriggerAction action = new ManualTriggerAction();
+        HttpSession session = mock(HttpSession.class);
+
+        StaplerRequest request = mock(StaplerRequest.class);
+        StaplerResponse response = mock(StaplerResponse.class);
+
+        when(request.getSession(true)).thenReturn(session);
+
+        doAnswer(new Answer() {
+            /**
+             * @see org.mockito.stubbing.Answer#answer(org.mockito.invocation.InvocationOnMock)
+             */
+            @Override
+            public Object answer(InvocationOnMock aInvocation) throws Throwable {
+                List<JSONObject> json = (List<JSONObject>)aInvocation.getArguments()[1];
+
+                ManualTriggerAction.HighLow highLow = action.getCodeReview(json.get(0), 1);
+                assertEquals(0, highLow.getHigh());
+                assertEquals(0, highLow.getLow());
+
+                highLow = action.getCodeReview(json.get(0), 2);
+                assertEquals(2, highLow.getHigh());
+                assertEquals(-1, highLow.getLow());
+
+                highLow = action.getVerified(json.get(0), 1);
+                assertEquals(0, highLow.getHigh());
+                assertEquals(0, highLow.getLow());
+
+                highLow = action.getVerified(json.get(0), 2);
+                assertEquals(2, highLow.getHigh());
+                assertEquals(-1, highLow.getLow());
+
+                return null;
+            }
+
+        }).when(session).setAttribute(eq("result"), any());
+
+        action.doGerritSearch("status:open", gerritServerName, true, request, response);
+    }
+}

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionTest.java
@@ -57,7 +57,7 @@ import static org.mockito.Mockito.when;
 public class ManualTriggerActionTest {
 
     /**
-     * Tests {@link ManualTriggerAction#getCodeReview(net.sf.json.JSONObject)}.
+     * Tests {@link ManualTriggerAction#getCodeReview(net.sf.json.JSONObject, int)}.
      * With Code-Review patchset info.
      * @throws Exception if so.
      */
@@ -84,15 +84,21 @@ public class ManualTriggerActionTest {
         crw.put("value", "-1");
         approvals.add(crw);
         currentPatchSet.put("approvals", approvals);
+        currentPatchSet.put("number", 2);
 
         json.put("currentPatchSet", currentPatchSet);
 
         ManualTriggerAction action = new ManualTriggerAction();
 
-        ManualTriggerAction.HighLow highLow = action.getCodeReview(json);
+        ManualTriggerAction.HighLow highLow = action.getCodeReview(json, 2);
 
         assertEquals(2, highLow.getHigh());
         assertEquals(-1, highLow.getLow());
+
+        highLow = action.getCodeReview(json, 1);
+
+        assertEquals(0, highLow.getHigh());
+        assertEquals(0, highLow.getLow());
     }
 
     /**
@@ -106,14 +112,14 @@ public class ManualTriggerActionTest {
 
         ManualTriggerAction action = new ManualTriggerAction();
 
-        ManualTriggerAction.HighLow highLow = action.getCodeReview(json);
+        ManualTriggerAction.HighLow highLow = action.getCodeReview(json, 2);
 
         assertEquals(0, highLow.getHigh());
         assertEquals(0, highLow.getLow());
     }
 
     /**
-     * Tests {@link ManualTriggerAction#getVerified(net.sf.json.JSONObject)}.
+     * Tests {@link ManualTriggerAction#getVerified(net.sf.json.JSONObject, int)}.
      * With Verified patchset info.
      * @throws Exception if so.
      */
@@ -140,15 +146,21 @@ public class ManualTriggerActionTest {
         crw.put("value", "-1");
         approvals.add(crw);
         currentPatchSet.put("approvals", approvals);
+        currentPatchSet.put("number", 2);
 
         json.put("currentPatchSet", currentPatchSet);
 
         ManualTriggerAction action = new ManualTriggerAction();
 
-        ManualTriggerAction.HighLow highLow = action.getVerified(json);
+        ManualTriggerAction.HighLow highLow = action.getVerified(json, 2);
 
         assertEquals(2, highLow.getHigh());
         assertEquals(-1, highLow.getLow());
+
+        highLow = action.getVerified(json, 1);
+
+        assertEquals(0, highLow.getHigh());
+        assertEquals(0, highLow.getLow());
     }
 
     /**
@@ -162,7 +174,7 @@ public class ManualTriggerActionTest {
 
         ManualTriggerAction action = new ManualTriggerAction();
 
-        ManualTriggerAction.HighLow highLow = action.getVerified(json);
+        ManualTriggerAction.HighLow highLow = action.getVerified(json, 2);
 
         assertEquals(0, highLow.getHigh());
         assertEquals(0, highLow.getLow());

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
@@ -47,12 +47,37 @@ import java.io.PrintWriter;
 import java.io.UnsupportedEncodingException;
 import java.lang.reflect.Constructor;
 
+import net.sf.json.JSONArray;
+import net.sf.json.JSONObject;
+
 import com.jcraft.jsch.KeyPair;
 
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.regex.Pattern;
+
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.APPROVALS;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.AUTHOR;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.BRANCH;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.COMMIT_MESSAGE;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.CREATED_ON;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.EMAIL;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.ID;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.LAST_UPDATED;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.NAME;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.NUMBER;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.OWNER;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.PARENTS;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.PROJECT;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.REF;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.REVISION;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.STATUS;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.SUBJECT;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.TYPE;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.UPLOADER;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.URL;
+import static com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventKeys.VALUE;
 
 /**
  * The beginning of a mock of a sshd server. When it is done the idea is to use this to send in stream-events over the
@@ -657,6 +682,228 @@ public class SshdServerMock implements CommandFactory {
                         new OutputStreamWriter(getOutputStream(), "UTF-8")));
                 System.out.println("Sending: " + line);
                 out.println(line);
+                out.flush();
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+            this.stop(0);
+        }
+    }
+
+    /**
+     * A Command that returns last patcheset with approvals.
+     */
+    public static class SendQueryLastPatchSet extends CommandMock {
+
+        /**
+         * Standard constructor.
+         *
+         * @param command the command
+         */
+        public SendQueryLastPatchSet(String command) {
+            super(command);
+        }
+
+        @Override
+        public void start(final Environment environment) throws IOException {
+
+            final int createdOn1 = 1449170072;
+            final int createdOn2 = 1449168976;
+            final int lastUpdated = 1449170950;
+
+            JSONObject jsonAccount = new JSONObject();
+            jsonAccount.put(EMAIL, "EngyCZ@gmail.com");
+            jsonAccount.put(NAME, "Engy");
+
+            JSONArray parents = new JSONArray();
+            parents.add("31581608d63510c13d7cb12d3e9a245ca4f72a62");
+
+            JSONObject currentPatchSet = new JSONObject();
+            currentPatchSet.put(NUMBER, "2");
+            currentPatchSet.put(REVISION, "87861b77a7614f8e6da19b017c588b741911983c");
+            currentPatchSet.put(PARENTS, parents);
+            currentPatchSet.put(REF, "refs/changes/00/100/2");
+            currentPatchSet.put(UPLOADER, jsonAccount);
+            currentPatchSet.put(CREATED_ON, createdOn1);
+            currentPatchSet.put(AUTHOR, jsonAccount);
+
+            JSONArray approvals = new JSONArray();
+
+            JSONObject crw = new JSONObject();
+            crw.put(TYPE, "Code-Review");
+            crw.put(VALUE, "2");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Code-Review");
+            crw.put(VALUE, "1");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Code-Review");
+            crw.put(VALUE, "-1");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Verified");
+            crw.put(VALUE, "2");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Verified");
+            crw.put(VALUE, "1");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Verified");
+            crw.put(VALUE, "-1");
+            approvals.add(crw);
+
+            currentPatchSet.put(APPROVALS, approvals);
+
+            JSONObject change = new JSONObject();
+            change.put(PROJECT, "project");
+            change.put(BRANCH, "branch");
+            change.put(ID, "I2343434344");
+            change.put(NUMBER, "100");
+            change.put(SUBJECT, "subject");
+            change.put(OWNER, jsonAccount);
+            change.put(URL, "http://localhost:8080");
+            change.put(COMMIT_MESSAGE, "Change");
+            change.put(CREATED_ON, createdOn2);
+            change.put(LAST_UPDATED, lastUpdated);
+            change.put("open", true);
+            change.put(STATUS, "NEW");
+            change.put("currentPatchSet", currentPatchSet);
+
+            System.out.println("Starting QueryLastPatchSet: " + getCommand());
+            try {
+                PrintWriter out = new PrintWriter(new BufferedWriter(
+                        new OutputStreamWriter(getOutputStream(), "UTF-8")));
+                System.out.println("Sending: " + change);
+                out.println(change);
+                out.flush();
+            } catch (UnsupportedEncodingException e) {
+                e.printStackTrace();
+            }
+            this.stop(0);
+        }
+    }
+
+    /**
+     * A Command that returns last patcheset with approvals.
+     */
+    public static class SendQueryAllPatchSets extends CommandMock {
+
+        /**
+         * Standard constructor.
+         *
+         * @param command the command
+         */
+        public SendQueryAllPatchSets(String command) {
+            super(command);
+        }
+
+        @Override
+        public void start(final Environment environment) throws IOException {
+            final int createdOn1 = 1449170072;
+            final int createdOn2 = 1449168976;
+            final int lastUpdated = 1449170950;
+
+            JSONObject jsonAccount = new JSONObject();
+            jsonAccount.put(EMAIL, "EngyCZ@gmail.com");
+            jsonAccount.put(NAME, "Engy");
+
+            JSONArray parents = new JSONArray();
+            parents.add("31581608d63510c13d7cb12d3e9a245ca4f72a62");
+
+            JSONObject currentPatchSet = new JSONObject();
+            currentPatchSet.put(NUMBER, "2");
+            currentPatchSet.put(REVISION, "87861b77a7614f8e6da19b017c588b741911983c");
+            currentPatchSet.put(PARENTS, parents);
+            currentPatchSet.put(REF, "refs/changes/00/100/2");
+            currentPatchSet.put(UPLOADER, jsonAccount);
+            currentPatchSet.put(CREATED_ON, createdOn1);
+            currentPatchSet.put(AUTHOR, jsonAccount);
+
+            JSONArray approvals = new JSONArray();
+
+            JSONObject crw = new JSONObject();
+            crw.put(TYPE, "Code-Review");
+            crw.put(VALUE, "2");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Code-Review");
+            crw.put(VALUE, "1");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Code-Review");
+            crw.put(VALUE, "-1");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Verified");
+            crw.put(VALUE, "2");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Verified");
+            crw.put(VALUE, "1");
+            approvals.add(crw);
+
+            crw = new JSONObject();
+            crw.put(TYPE, "Verified");
+            crw.put(VALUE, "-1");
+            approvals.add(crw);
+
+            currentPatchSet.put(APPROVALS, approvals);
+
+            JSONObject patchSet1 = new JSONObject();
+            patchSet1.put(NUMBER, "1");
+            patchSet1.put(REVISION, "009365b77a69cd5ecd05a699b19213682f7f8d79");
+            patchSet1.put(PARENTS, parents);
+            patchSet1.put(REF, "refs/changes/00/100/1");
+            patchSet1.put(UPLOADER, jsonAccount);
+            patchSet1.put(CREATED_ON, createdOn2);
+            patchSet1.put(AUTHOR, jsonAccount);
+
+            JSONObject patchSet2 = new JSONObject();
+            patchSet2.put(NUMBER, "2");
+            patchSet2.put(REVISION, "87861b77a7614f8e6da19b017c588b741911983c");
+            patchSet2.put(PARENTS, parents);
+            patchSet2.put(REF, "refs/changes/00/100/1");
+            patchSet2.put(UPLOADER, jsonAccount);
+            patchSet2.put(CREATED_ON, createdOn1);
+            patchSet2.put(AUTHOR, jsonAccount);
+
+            JSONArray patchSets = new JSONArray();
+            patchSets.add(patchSet1);
+            patchSets.add(patchSet2);
+
+            JSONObject change = new JSONObject();
+            change.put(PROJECT, "project");
+            change.put(BRANCH, "branch");
+            change.put(ID, "I2343434344");
+            change.put(NUMBER, "100");
+            change.put(SUBJECT, "subject");
+            change.put(OWNER, jsonAccount);
+            change.put(URL, "http://localhost:8080");
+            change.put(COMMIT_MESSAGE, "Change");
+            change.put(CREATED_ON, createdOn2);
+            change.put(LAST_UPDATED, lastUpdated);
+            change.put("open", true);
+            change.put(STATUS, "NEW");
+            change.put("currentPatchSet", currentPatchSet);
+            change.put("patchSets", patchSets);
+
+            System.out.println("Starting QueryAllPatchSets: " + getCommand());
+            try {
+                PrintWriter out = new PrintWriter(new BufferedWriter(
+                        new OutputStreamWriter(getOutputStream(), "UTF-8")));
+                System.out.println("Sending: " + change);
+                out.println(change);
                 out.flush();
             } catch (UnsupportedEncodingException e) {
                 e.printStackTrace();


### PR DESCRIPTION
Fix problem where approvals were not displayed in Query and Trigger Gerrit Patches window for patchsets which already has Verified or Code-Review approval.
Approvals are displayed only for latest patchset.
Decrease log verbosity for GerritProjectListUpdater.

[FIXED JENKINS-31894]
