### PR TITLE
Don't used ReflectiveOperationException

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -261,7 +261,7 @@ public enum GerritTriggerParameters {
             constructor = clazz.getConstructor(types);
             parameter = constructor.newInstance(args);
             parameters.add(parameter);
-        } catch (ReflectiveOperationException ex) {
+        } catch (Exception ex) {
             parameter = null;
         }
     }


### PR DESCRIPTION
Using ReflectiveOperationException breaks Java 6 runtime compatibility.

[FIXED JENKINS-30857]

Change-Id: Ic8c88102cf9ef3a3286f5311d1b3ed661ac2d77c