### PR TITLE
Fix trigger for changes to Gerrit comment-added stream event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.9.3</version>
+            <version>2.9.5</version>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
         </dependency>
         <dependency>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1006,12 +1006,9 @@ public class GerritTrigger extends Trigger<Job> {
                 for (Approval approval : event.getApprovals()) {
                     /** Ensure that this trigger is backwards compatible.
                      * Gerrit stream events changed to append approval info to
-                     * every comment-added event.  The change also includes a
-                     * new `updated` attribute to indicate whether the score
-                     * was changed.
+                     * every comment-added event.
                      **/
-                    if (approval.getUpdated() != null) {
-                        if (approval.getUpdated()
+                    if (approval.isUpdated()
                             && approval.getType().equals(
                                 commentAdded.getVerdictCategory())
                             && (approval.getValue().equals(
@@ -1019,7 +1016,6 @@ public class GerritTrigger extends Trigger<Job> {
                             || ("+" + approval.getValue()).equals(
                                 commentAdded.getCommentAddedTriggerApprovalValue()))) {
                             return true;
-                         }
                     } else {
                         if (approval.getType().equals(
                                 commentAdded.getVerdictCategory())


### PR DESCRIPTION
This is a redo of change 406ae59.  More info can be found in
the dependent gerrit-events pull request[1].  In summary
the Gerrit change[2] that initially planned on adding an
`updated` flag for approvals ended up adding an `oldValue`
property instead.

[1] https://github.com/sonyxperiadev/gerrit-events/pull/51
[2] https://gerrit-review.googlesource.com/#/c/71051