### PR TITLE
HACK: Set Notify on the build started trigger as well

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -482,7 +482,7 @@ public class ParameterExpander {
      * @param trigger the trigger.
      * @return the level value.
      */
-    private Notify getNotificationLevel(GerritTrigger trigger) {
+    public Notify getNotificationLevel(GerritTrigger trigger) {
         String level = trigger.getNotificationLevel();
         if (level != null && level.length() > 0) {
             return Notify.valueOf(level);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildStartedRestCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildStartedRestCommandJob.java
@@ -29,6 +29,8 @@ import com.sonymobile.tools.gerrit.gerritevents.workers.rest.AbstractRestCommand
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ParameterExpander;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildsStartedStats;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger;
+import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Notify;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ReviewInput;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -70,7 +72,12 @@ public class BuildStartedRestCommandJob extends AbstractRestCommandJob {
      */
     protected ReviewInput createReview() {
         String message = parameterExpander.getBuildStartedMessage(build, listener, event, stats);
-        return new ReviewInput(message);
+        Notify notificationLevel = Notify.ALL;
+        GerritTrigger trigger = GerritTrigger.getTrigger(build.getParent());
+        if (trigger != null) {
+            notificationLevel = parameterExpander.getNotificationLevel(trigger);
+        }
+        return new ReviewInput(message).setNotify(notificationLevel);
     }
 
 }


### PR DESCRIPTION
It should probably be changed more to get the BuildMemory.MemoryImprint
from the outer context and use the same iteration loop. This should be
good enough to silence some of the output.