### PR TITLE
Provide GERRIT_MERGED_REVISION after change-merged event

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -37,6 +37,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeRestored;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeMerged;
 import hudson.model.Job;
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
@@ -213,7 +214,11 @@ public enum GerritTriggerParameters {
     /**
      * The type of the event.
      */
-    GERRIT_EVENT_TYPE;
+    GERRIT_EVENT_TYPE,
+    /**
+     * The revision after the merge in a change-merged event.
+    */
+    GERRIT_MERGED_REVISION;
 
     private static final Logger logger = LoggerFactory.getLogger(GerritTriggerParameters.class);
 
@@ -399,6 +404,10 @@ public enum GerritTriggerParameters {
                         parameters, getName(((ChangeAbandoned)event).getAbandoner()), escapeQuotes);
                 GERRIT_CHANGE_ABANDONER_EMAIL.setOrCreateStringParameterValue(
                         parameters, getEmail(((ChangeAbandoned)event).getAbandoner()), escapeQuotes);
+            }
+            if (event instanceof ChangeMerged) {
+                GERRIT_MERGED_REVISION.setOrCreateStringParameterValue(
+                        parameters, ((ChangeMerged)event).getNewRev(), escapeQuotes);
             }
             nameAndEmailParameterMode.setOrCreateParameterValue(GERRIT_CHANGE_OWNER, parameters,
                     getNameAndEmail(event.getChange().getOwner()), ParameterMode.PlainMode.STRING, escapeQuotes);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -171,7 +171,7 @@ public enum GerritTriggerParameters {
      */
     GERRIT_OLDREV,
     /**
-     * The new revision in a ref-updated event.
+     * The new revision in a ref-updated or change-merged event.
      */
     GERRIT_NEWREV,
     /**
@@ -214,11 +214,7 @@ public enum GerritTriggerParameters {
     /**
      * The type of the event.
      */
-    GERRIT_EVENT_TYPE,
-    /**
-     * The revision after the merge in a change-merged event.
-    */
-    GERRIT_MERGED_REVISION;
+    GERRIT_EVENT_TYPE;
 
     private static final Logger logger = LoggerFactory.getLogger(GerritTriggerParameters.class);
 
@@ -406,7 +402,7 @@ public enum GerritTriggerParameters {
                         parameters, getEmail(((ChangeAbandoned)event).getAbandoner()), escapeQuotes);
             }
             if (event instanceof ChangeMerged) {
-                GERRIT_MERGED_REVISION.setOrCreateStringParameterValue(
+                GERRIT_NEWREV.setOrCreateStringParameterValue(
                         parameters, ((ChangeMerged)event).getNewRev(), escapeQuotes);
             }
             nameAndEmailParameterMode.setOrCreateParameterValue(GERRIT_CHANGE_OWNER, parameters,

--- a/src/main/webapp/help-whatIsGerritTrigger.html
+++ b/src/main/webapp/help-whatIsGerritTrigger.html
@@ -58,6 +58,12 @@
         </ul>
     </li>
     <li>
+        <strong>Additionally for Change merged events</strong>
+        <ul>
+            <li><strong>GERRIT_NEWREV</strong>: The revision of the merge commit.</li>
+        </ul>
+    </li>
+    <li>
         <strong>For Reference updated events</strong>
         <ul>
             <li><strong>GERRIT_REFNAME</strong>: Ref name within project.</li>


### PR DESCRIPTION
The newRev field of a change-merged event was not parsed yet. Since this field holds the hash of a merge commit it can be important in certain build conditions.

This patch exposes this field as a GERRIT_MERGED_REVISION variable to Jenkins builds. It requires the following PR in gerrit-events to compile successfully: https://github.com/sonyxperiadev/gerrit-events/pull/55 (which is the reason why Jenkins reports a failure below)

It fixes https://issues.jenkins-ci.org/browse/JENKINS-23873

Some changes to pom.xml to update the gerrit-events version might be required. Since I'm not normally a Java person I leave that to the maintainer.