### PR TITLE
JENKINS-36139: Use try-with-resource for RevWalk in JGit4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,9 +52,9 @@
     </developers>
 
     <properties>
-        <jenkins.version>1.609.3</jenkins.version>
+        <jenkins.version>1.625</jenkins.version>
         <!--<jenkins.version>2.5-SNAPSHOT</jenkins.version>-->
-        <java.level>6</java.level>
+        <java.level>7</java.level>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <findbugs.failOnError>false</findbugs.failOnError>
         <concurrency>1C</concurrency>
@@ -80,13 +80,13 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.3</version>
+            <version>3.0.0-beta1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git-client</artifactId>
-            <version>1.11.1</version>
+            <version>2.0.0-beta1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -302,8 +302,8 @@
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java16</artifactId>
-                        <version>1.1</version>
+                        <artifactId>java17</artifactId>
+                        <version>1.0</version>
                     </signature>
                 </configuration>
                 <executions>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
@@ -167,10 +167,8 @@ public class GerritTriggerBuildChooser extends BuildChooser {
             @Override
             public ObjectId invoke(Repository repository, VirtualChannel virtualChannel)
                     throws IOException, InterruptedException {
-                RevWalk walk = null;
                 ObjectId result = null;
-                try {
-                    walk = new RevWalk(repository);
+                try (RevWalk walk = new RevWalk(repository)) {
                     RevCommit commit = walk.parseCommit(id);
                     if (commit.getParentCount() > 0) {
                         result = commit.getParent(0);
@@ -180,10 +178,6 @@ public class GerritTriggerBuildChooser extends BuildChooser {
                     }
                 } catch (Exception e) {
                     throw new GitException("Failed to find parent id. ", e);
-                } finally {
-                    if (walk != null) {
-                        walk.release();
-                    }
                 }
                 return result;
             }


### PR DESCRIPTION
Supersedes pull request #288.

This resolves but JENKINS-36139.

JGit4 is targeted towards java 7, and RevWalk is now a Closeable, hence the release() method is renamed to close(). Use the new try-with-resource syntax for RevWalk.

@rsandell 