### PR TITLE
Eclipse warning cleanup

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement.java
@@ -281,7 +281,7 @@ public class GerritManagement extends ManagementLink implements StaplerProxy, De
 
     @Override
     public Object getTarget() {
-        Hudson.getInstance().checkPermission(Hudson.ADMINISTER);
+        Hudson.getInstance().checkPermission(Jenkins.ADMINISTER);
         return this;
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
@@ -39,7 +39,6 @@ import hudson.Plugin;
 import hudson.model.Item;
 import hudson.model.Job;
 import hudson.model.Api;
-import hudson.model.Hudson;
 import hudson.model.Items;
 import hudson.model.Run;
 import hudson.model.queue.QueueTaskDispatcher;
@@ -89,7 +88,7 @@ public class PluginImpl extends Plugin {
     public static final Permission MANUAL_TRIGGER = new Permission(PERMISSION_GROUP,
             "ManualTrigger",
             Messages._ManualTriggerPermissionDescription(),
-            Hudson.ADMINISTER);
+            Jenkins.ADMINISTER);
     /**
      * The permission that allows users to perform the
      * {@link com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.actions.RetriggerAction}.
@@ -526,7 +525,7 @@ public class PluginImpl extends Plugin {
 
         //Register it in all known XStreams just to be sure.
         Items.XSTREAM.registerConverter(new TriggerContextConverter());
-        Hudson.XSTREAM.registerConverter(new TriggerContextConverter());
+        Jenkins.XSTREAM.registerConverter(new TriggerContextConverter());
         //This is where the problems where, reading builds.
         Run.XSTREAM.registerConverter(new TriggerContextConverter());
         Run.XSTREAM2.addCompatibilityAlias(
@@ -535,7 +534,7 @@ public class PluginImpl extends Plugin {
 
         Items.XSTREAM.aliasPackage("com.sonyericsson.hudson.plugins.gerrit.gerritevents",
                 "com.sonymobile.tools.gerrit.gerritevents");
-        Hudson.XSTREAM.aliasPackage("com.sonyericsson.hudson.plugins.gerrit.gerritevents",
+        Jenkins.XSTREAM.aliasPackage("com.sonyericsson.hudson.plugins.gerrit.gerritevents",
                 "com.sonymobile.tools.gerrit.gerritevents");
         Run.XSTREAM.aliasPackage("com.sonyericsson.hudson.plugins.gerrit.gerritevents",
                 "com.sonymobile.tools.gerrit.gerritevents");

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -1014,6 +1014,7 @@ public class Config implements IGerritHudsonTriggerConfig {
      *
      * @return the watchdogTimeoutMinutes.
      */
+    @Override
     public int getWatchdogTimeoutMinutes() {
         return watchdogTimeoutMinutes;
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/IGerritHudsonTriggerConfig.java
@@ -59,6 +59,7 @@ public interface IGerritHudsonTriggerConfig extends GerritConnectionConfig2 {
      * Base URL for the Gerrit UI.
      * @return the gerrit front end URL. Always ends with '/'
      */
+    @Override
     String getGerritFrontEndUrl();
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/PluginConfig.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/PluginConfig.java
@@ -119,6 +119,7 @@ public class PluginConfig implements GerritWorkersConfig {
      *
      * @return the number of worker threads.
      */
+    @Override
     public int getNumberOfReceivingWorkerThreads() {
         if (numberOfReceivingWorkerThreads <= 0) {
             numberOfReceivingWorkerThreads = DEFAULT_NR_OF_RECEIVING_WORKER_THREADS;
@@ -141,6 +142,7 @@ public class PluginConfig implements GerritWorkersConfig {
      *
      * @return the number of worker threads.
      */
+    @Override
     public int getNumberOfSendingWorkerThreads() {
         if (numberOfSendingWorkerThreads <= 0) {
             numberOfSendingWorkerThreads = DEFAULT_NR_OF_SENDING_WORKER_THREADS;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ReplicationConfig.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/ReplicationConfig.java
@@ -104,7 +104,7 @@ public class ReplicationConfig {
      */
     public boolean isEnableReplication() {
         return enableReplication;
-    };
+    }
 
     /**
      * Get the list of GerritSlave objects.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcher.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcher.java
@@ -152,7 +152,7 @@ public final class DependencyQueueTaskDispatcher extends QueueTaskDispatcher
         }
         //Dependency projects in the build queue
         List<Job> dependencies = getProjectsFromString(trigger.getDependencyJobsNames(),
-                (Item)p);
+                p);
         if ((dependencies == null) || (dependencies.size() == 0)) {
             logger.debug("No dependencies on project: {}", p);
             return null;
@@ -246,7 +246,7 @@ public final class DependencyQueueTaskDispatcher extends QueueTaskDispatcher
                     Item item = jenkins.getItem(projectName, context, Item.class);
                     if ((item != null) && (item instanceof Job)) {
                         dependencyJobs.add((Job)item);
-                        logger.debug("project dependency job added : {}", (Job)item);
+                        logger.debug("project dependency job added : {}", item);
                     }
                 }
             }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -260,10 +260,10 @@ public class ParameterExpander {
      */
     private String expandParameters(String gerritCommand, Run r, TaskListener taskListener,
             Map<String, String> parameters) {
-
+        String command = gerritCommand;
         if (r != null && taskListener != null) {
             try {
-                gerritCommand = r.getEnvironment(taskListener).expand(gerritCommand);
+                command = r.getEnvironment(taskListener).expand(command);
             } catch (Exception ex) {
                 logger.error("Failed to expand env vars into gerrit cmd. Gerrit won't be notified!!", ex);
                 return null;
@@ -271,15 +271,15 @@ public class ParameterExpander {
         }
 
         for (Map.Entry<String, String> param : parameters.entrySet()) {
-            gerritCommand = gerritCommand.replace("<" + param.getKey() + ">", param.getValue());
+            command = command.replace("<" + param.getKey() + ">", param.getValue());
         }
         //replace null and Integer.MAX_VALUE code review value
-        gerritCommand = gerritCommand.replace("--code-review null", "");
-        gerritCommand = gerritCommand.replace("--code-review " + Integer.MAX_VALUE, "");
-        gerritCommand = gerritCommand.replace("--verified null", "");
-        gerritCommand = gerritCommand.replace("--verified " + Integer.MAX_VALUE, "");
+        command = command.replace("--code-review null", "");
+        command = command.replace("--code-review " + Integer.MAX_VALUE, "");
+        command = command.replace("--verified null", "");
+        command = command.replace("--verified " + Integer.MAX_VALUE, "");
 
-        return gerritCommand;
+        return command;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildStartedRestCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildStartedRestCommandJob.java
@@ -70,6 +70,7 @@ public class BuildStartedRestCommandJob extends AbstractRestCommandJob {
      *
      * @return ReviewInput
      */
+    @Override
     protected ReviewInput createReview() {
         String message = parameterExpander.getBuildStartedMessage(build, listener, event, stats);
         Notify notificationLevel = Notify.ALL;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1804,6 +1804,7 @@ public class GerritTrigger extends Trigger<Job> {
      * @return the resolved instance.
      * @throws ObjectStreamException if something beneath goes wrong.
      */
+    @Override
     public Object readResolve() throws ObjectStreamException {
         initializeServerName();
         initializeTriggerOnEvents();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1939,7 +1939,7 @@ public class GerritTrigger extends Trigger<Job> {
                     }
                     String currentDependenciesString = getTrigger(currentlyExploring).getDependencyJobsNames();
                     List<Job> currentDependencies = DependencyQueueTaskDispatcher.getProjectsFromString(
-                            currentDependenciesString, (Item)project);
+                            currentDependenciesString, project);
                     if (currentDependencies == null) {
                         continue;
                     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
@@ -214,7 +214,7 @@ public class GerritTriggerBuildChooser extends BuildChooser {
         static final long serialVersionUID = 0L;
         @Override
         public String invoke(Run<?, ?> build, VirtualChannel channel) {
-            GerritCause cause = (GerritCause)build.getCause(GerritCause.class);
+            GerritCause cause = build.getCause(GerritCause.class);
             if (cause != null) {
                 GerritTriggeredEvent event = cause.getEvent();
                 if (event instanceof ChangeBasedEvent) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextConverter.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextConverter.java
@@ -170,7 +170,7 @@ public class TriggerContextConverter implements Converter {
         }
         Class<? extends GerritTriggeredEvent> theClass = null;
         try {
-            theClass = (Class<? extends GerritTriggeredEvent>)Run.XSTREAM2.getMapper().realClass(clazz);
+            theClass = Run.XSTREAM2.getMapper().realClass(clazz);
             return theClass;
         } catch (CannotResolveClassException e) {
             logger.error("Failed to unmarshall event type for trigger context!", e);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginChangeMergedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginChangeMergedEvent.java
@@ -51,6 +51,7 @@ public class PluginChangeMergedEvent extends PluginGerritEvent implements Serial
      * Getter for the Descriptor.
      * @return the Descriptor for the PluginChangeMergedEvent.
      */
+    @Override
     public Descriptor<PluginGerritEvent> getDescriptor() {
         return Hudson.getInstance().getDescriptorByType(PluginChangeMergedEventDescriptor.class);
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedEvent.java
@@ -93,6 +93,7 @@ public class PluginCommentAddedEvent extends PluginGerritEvent implements Serial
      * Getter for the Descriptor.
      * @return the Descriptor for the PluginCommentAddedEvent.
      */
+    @Override
     public Descriptor<PluginGerritEvent> getDescriptor() {
         return Hudson.getInstance().getDescriptorByType(PluginCommentAddedEventDescriptor.class);
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginDraftPublishedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginDraftPublishedEvent.java
@@ -57,6 +57,7 @@ public class PluginDraftPublishedEvent extends PluginGerritEvent implements Seri
      * Getter for the Descriptor.
      * @return the Descriptor for the PluginDraftPublishedEvent.
      */
+    @Override
     public Descriptor<PluginGerritEvent> getDescriptor() {
         return Hudson.getInstance().getDescriptorByType(PluginDraftPublishedEventDescriptor.class);
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -74,6 +74,7 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
      * Getter for the Descriptor.
      * @return the Descriptor for the PluginPatchsetCreatedEvent.
      */
+    @Override
     public Descriptor<PluginGerritEvent> getDescriptor() {
         return Hudson.getInstance().getDescriptorByType(PluginPatchsetCreatedEventDescriptor.class);
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRefUpdatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRefUpdatedEvent.java
@@ -51,6 +51,7 @@ public class PluginRefUpdatedEvent extends PluginGerritEvent implements Serializ
      * Getter for the Descriptor.
      * @return the Descriptor for the PluginRefUpdatedEvent.
      */
+    @Override
     public Descriptor<PluginGerritEvent> getDescriptor() {
         return Hudson.getInstance().getDescriptorByType(PluginRefUpdatedEventDescriptor.class);
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -203,7 +203,7 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Ge
                 } else {
 
                     //do we have this event in the time slice?
-                    long currentEventCreatedTime = ((GerritTriggeredEvent)evt).getEventCreatedOn().getTime();
+                    long currentEventCreatedTime = evt.getEventCreatedOn().getTime();
                     if (serverTimestamp.getTimeSlice() == currentEventCreatedTime) {
                         if (serverTimestamp.getEvents().contains(evt)) {
                             logger.debug("({}) Event already triggered from time slice...skipping trigger.", serverName);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtil.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/StringUtil.java
@@ -46,7 +46,7 @@ public final class StringUtil {
     /**
      * the field will be used as quote "\""
      */
-    private static final Pattern QUOTES_PATTERN = Pattern.compile("\"");;
+    private static final Pattern QUOTES_PATTERN = Pattern.compile("\"");
 
     /**
      * The base URL of the plugin images.

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
@@ -97,8 +97,6 @@ public final class GerritVersionChecker {
         }
     }
 
-    ;
-
     /**
      * Private constructor to prevent instantiation of the util class.
      */

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/events/lifecycle/ManualPatchsetCreatedTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/events/lifecycle/ManualPatchsetCreatedTest.java
@@ -228,7 +228,8 @@ public class ManualPatchsetCreatedTest {
          *
          * @return the list of listeners.
          */
-        public List<GerritEventLifecycleListener> getListeners() {
+        @Override
+        public synchronized List<GerritEventLifecycleListener> getListeners() {
             return super.getListeners();
         }
     }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
@@ -56,13 +56,13 @@ import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
 import hudson.model.Cause;
 import hudson.model.CauseAction;
-import hudson.model.Hudson;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.TaskListener;
 import hudson.security.SecurityRealm;
 import hudson.triggers.Trigger;
 import hudson.triggers.TriggerDescriptor;
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 
 import org.jenkinsci.plugins.workflow.job.WorkflowJob;
@@ -818,7 +818,7 @@ public final class Setup {
         SecurityRealm securityRealm = j.createDummySecurityRealm();
         j.getInstance().setSecurityRealm(securityRealm);
         j.getInstance().setAuthorizationStrategy(
-                new MockAuthorizationStrategy().grant(Hudson.READ).everywhere().toAuthenticated());
+                new MockAuthorizationStrategy().grant(Jenkins.READ).everywhere().toAuthenticated());
     }
 
     /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsFunctionalTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsFunctionalTest.java
@@ -142,7 +142,7 @@ public class GerritMissedEventsFunctionalTest {
 
         config.setGerritProxy("");
         config.setGerritAuthKeyFile(sshKey.getPrivateKey());
-        config = (Config)SshdServerMock.getConfigFor(sshd, config);
+        config = SshdServerMock.getConfigFor(sshd, config);
         gerritServer.setConfig(config);
 
 


### PR DESCRIPTION
- Add missing Override annotations
- Remove unnecessary semicolons
- Remove unnecessary casts
