### PR TITLE
operator '^' for dynamic trigger must be escaped in regex

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
@@ -95,7 +95,7 @@ public final class GerritDynamicUrlProcessor {
         if (!firstoperator) {
           operators.append("|");
         }
-        operators.append(type.getOperator());
+        operators.append(regexEscapted(type.getOperator()));
         firstoperator = false;
       }
       operators.append(")");
@@ -104,6 +104,22 @@ public final class GerritDynamicUrlProcessor {
               + "\\s*"
               + operators.toString()
               + "\\s*(.+)$");
+    }
+
+    /**
+     * Escapted char for use in regex pattern.
+     *
+     * @param symbol to escapted char
+     *
+     * @return escapted symbol
+     */
+    private static String regexEscapted(char symbol) {
+      switch (symbol) {
+      case '^':
+        return "\\^";
+      default:
+        return String.valueOf(symbol);
+      }
     }
 
     /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/DuplicatesUtil.java
@@ -99,18 +99,20 @@ public abstract class DuplicatesUtil {
      *
      * @param rule the instance of JenkinsRule.
      * @param name the name of the new job.
+     * @param branchSetting the dynamic branch setting with operator e.g. "^**" or "=branch"
      * @return the project.
      *
      * @throws Exception if so.
      */
-    public static FreeStyleProject createGerritDynamicTriggeredJob(JenkinsRule rule, String name) throws Exception {
+    public static FreeStyleProject createGerritDynamicTriggeredJob(JenkinsRule rule, String name,
+            String branchSetting) throws Exception {
         FreeStyleProject p = rule.createFreeStyleProject(name);
         List<GerritProject> projects = new LinkedList<GerritProject>();
 
         File file = File.createTempFile("dynamic", "txt");
         FileWriter fw = new FileWriter(file);
         fw.write("p=project\n");
-        fw.write("b=branch");
+        fw.write("b" + branchSetting);
         fw.close();
         List<PluginGerritEvent> list = new LinkedList<PluginGerritEvent>();
         URI uri = file.toURI();

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
@@ -209,15 +209,35 @@ public class SpecGerritTriggerHudsonTest {
     }
 
     /**
-     * Tests to trigger a build with a dynamic configuration.
+     * Tests to trigger a build with a dynamic plain branch configuration.
      * @throws Exception if so.
      */
     @Test
     @LocalData
-    public void testDynamicTriggeredBuild() throws Exception {
+    public void testDynamicTriggeredBuildWithPlainBranch() throws Exception {
+        testDynamicTriggeredBuild("=branch");
+    }
+
+    /**
+     * Tests to trigger a build with a dynamic ant branch configuration.
+     * @throws Exception if so.
+     */
+    @Test
+    @LocalData
+    public void testDynamicTriggeredBuildWithAntBranch() throws Exception {
+        testDynamicTriggeredBuild("^**");
+    }
+
+    /**
+     * Tests to trigger a build with a dynamic configuration.
+     * @param branchSetting  the dynamic branch setting with operator e.g. "^**" or "=branch"
+     *
+     * @throws Exception if so.
+     */
+    private void testDynamicTriggeredBuild(String branchSetting) throws Exception {
         ((Config)gerritServer.getConfig()).setDynamicConfigRefreshInterval(1);
 
-        FreeStyleProject project = DuplicatesUtil.createGerritDynamicTriggeredJob(j, "projectX");
+        FreeStyleProject project = DuplicatesUtil.createGerritDynamicTriggeredJob(j, "projectX", branchSetting);
         serverMock.waitForCommand(GERRIT_STREAM_EVENTS, 2000);
         waitForDynamicTimer(project, 8000);
         gerritServer.triggerEvent(Setup.createPatchsetCreated());


### PR DESCRIPTION
If you use "Dynamic Trigger Configuration" with line "b^**" there will be an exception "cannot parse" in GerritDynamicUrlProcessor line 154.
Operator "^" must be escaped if used in regex pattern.