### PR TITLE
[JENKINS-30821] Add comment-added comment as job parameter

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -165,6 +165,7 @@ public class GerritTrigger extends Trigger<Job> {
     private String dependencyJobsNames;
     private GerritTriggerParameters.ParameterMode commitMessageParameterMode;
     private GerritTriggerParameters.ParameterMode changeSubjectParameterMode;
+    private GerritTriggerParameters.ParameterMode commentTextParameterMode;
     private String buildStartMessage;
     private String buildFailureMessage;
     private String buildSuccessfulMessage;
@@ -210,6 +211,7 @@ public class GerritTrigger extends Trigger<Job> {
         this.commitMessageParameterMode = GerritTriggerParameters.ParameterMode.BASE64;
         this.nameAndEmailParameterMode = GerritTriggerParameters.ParameterMode.PLAIN;
         this.changeSubjectParameterMode = GerritTriggerParameters.ParameterMode.PLAIN;
+        this.commentTextParameterMode = GerritTriggerParameters.ParameterMode.BASE64;
 
         this.dependencyJobsNames = "";
         this.buildStartMessage = "";
@@ -315,6 +317,7 @@ public class GerritTrigger extends Trigger<Job> {
             commitMessageParameterMode = GerritTriggerParameters.ParameterMode.BASE64;
         }
         this.changeSubjectParameterMode = GerritTriggerParameters.ParameterMode.PLAIN;
+        this.commentTextParameterMode = GerritTriggerParameters.ParameterMode.BASE64;
         this.dependencyJobsNames = dependencyJobsNames;
         this.buildStartMessage = buildStartMessage;
         this.buildSuccessfulMessage = buildSuccessfulMessage;
@@ -408,6 +411,29 @@ public class GerritTrigger extends Trigger<Job> {
     public void setChangeSubjectParameterMode(
             @Nonnull GerritTriggerParameters.ParameterMode changeSubjectParameterMode) {
         this.changeSubjectParameterMode = changeSubjectParameterMode;
+    }
+
+    /**
+     * What mode the comment text parameter {@link GerritTriggerParameters#GERRIT_EVENT_COMMENT_TEXT} should be used
+     * when adding it.
+     *
+     * @return the mode
+     */
+    @Nonnull
+    public GerritTriggerParameters.ParameterMode getCommentTextParameterMode() {
+        return commentTextParameterMode;
+    }
+
+    /**
+     * What mode the comment text parameter {@link GerritTriggerParameters#GERRIT_EVENT_COMMENT_TEXT} should be used
+     * when adding it.
+     *
+     * @param commentTextParameterMode the mode
+     */
+    @DataBoundSetter
+    public void setCommentTextParameterMode(
+            @Nonnull GerritTriggerParameters.ParameterMode commentTextParameterMode) {
+        this.commentTextParameterMode = commentTextParameterMode;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -38,6 +38,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeRestored;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeMerged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.CommentAdded;
 import hudson.model.Job;
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
@@ -216,7 +217,11 @@ public enum GerritTriggerParameters {
     /**
      * The type of the event.
      */
-    GERRIT_EVENT_TYPE;
+    GERRIT_EVENT_TYPE,
+    /**
+     * Comment posted to Gerrit in a comment-added event.
+     */
+    GERRIT_EVENT_COMMENT_TEXT;
 
     private static final Logger logger = LoggerFactory.getLogger(GerritTriggerParameters.class);
 
@@ -434,6 +439,11 @@ public enum GerritTriggerParameters {
                     parameters, getName(uploader), escapeQuotes);
             GERRIT_PATCHSET_UPLOADER_EMAIL.setOrCreateStringParameterValue(
                     parameters, getEmail(uploader), escapeQuotes);
+            if (event instanceof CommentAdded) {
+                commitMessageMode.setOrCreateParameterValue(GERRIT_EVENT_COMMENT_TEXT,
+                        parameters, ((CommentAdded)event).getComment(),
+                        ParameterMode.PlainMode.TEXT, escapeQuotes);
+            }
         } else if (gerritEvent instanceof RefUpdated) {
             RefUpdated event = (RefUpdated)gerritEvent;
             GERRIT_REFNAME.setOrCreateStringParameterValue(

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -356,6 +356,7 @@ public enum GerritTriggerParameters {
         boolean escapeQuotes = false;
         ParameterMode commitMessageMode = ParameterMode.BASE64;
         ParameterMode changeSubjectMode = ParameterMode.PLAIN;
+        ParameterMode commentTextMode = ParameterMode.BASE64;
         if (project != null) {
             GerritTrigger trigger = GerritTrigger.getTrigger(project);
             if (trigger != null) {
@@ -363,6 +364,7 @@ public enum GerritTriggerParameters {
                 escapeQuotes = trigger.isEscapeQuotes();
                 commitMessageMode = trigger.getCommitMessageParameterMode();
                 changeSubjectMode = trigger.getChangeSubjectParameterMode();
+                commentTextMode = trigger.getCommentTextParameterMode();
             }
         }
 
@@ -442,7 +444,7 @@ public enum GerritTriggerParameters {
             if (event instanceof CommentAdded) {
                 String comment = ((CommentAdded)event).getComment();
                 if (comment != null) {
-                    commitMessageMode.setOrCreateParameterValue(GERRIT_EVENT_COMMENT_TEXT,
+                    commentTextMode.setOrCreateParameterValue(GERRIT_EVENT_COMMENT_TEXT,
                             parameters, comment, ParameterMode.PlainMode.TEXT, escapeQuotes);
                 }
             }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerParameters.java
@@ -440,9 +440,11 @@ public enum GerritTriggerParameters {
             GERRIT_PATCHSET_UPLOADER_EMAIL.setOrCreateStringParameterValue(
                     parameters, getEmail(uploader), escapeQuotes);
             if (event instanceof CommentAdded) {
-                commitMessageMode.setOrCreateParameterValue(GERRIT_EVENT_COMMENT_TEXT,
-                        parameters, ((CommentAdded)event).getComment(),
-                        ParameterMode.PlainMode.TEXT, escapeQuotes);
+                String comment = ((CommentAdded)event).getComment();
+                if (comment != null) {
+                    commitMessageMode.setOrCreateParameterValue(GERRIT_EVENT_COMMENT_TEXT,
+                            parameters, comment, ParameterMode.PlainMode.TEXT, escapeQuotes);
+                }
             }
         } else if (gerritEvent instanceof RefUpdated) {
             RefUpdated event = (RefUpdated)gerritEvent;

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -38,6 +38,11 @@
                     ${it.toString()}
                 </ff:enum>
             </f:entry>
+            <f:entry title="${%Comment text parameter}" field="commentTextParameterMode">
+                <ff:enum default="BASE64"> <!-- TODO change to f when core dep >= 1.640 -->
+                    ${it.toString()}
+                </ff:enum>
+            </f:entry>
             <f:entry field="dependencyJobsNames" title="${%Other jobs on which this job depends}"
                  help="/plugin/gerrit-trigger/trigger/help-DependencyJobs.html">
                 <f:textbox autoCompleteDelimChar=","/>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/help-commentTextParameterMode.html
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/help-commentTextParameterMode.html
@@ -1,0 +1,11 @@
+<p>
+    How the comment text parameter <em>(GERRIT_EVENT_COMMENT_TEXT)</em> should be added to the build, if available.
+</p>
+<ul>
+    <li><strong>Human readable:</strong>
+        Plain text, as it arrives to Jenkins. With quotes escaped if configured above.</li>
+    <li><strong>Encoded (Base64) <em>(default)</em>:</strong>
+        Base64 encoded string.</li>
+    <li><strong>Do not add:</strong>
+        The parameter isn't added to the build at all.</li>
+</ul>

--- a/src/main/webapp/help-whatIsGerritTrigger.html
+++ b/src/main/webapp/help-whatIsGerritTrigger.html
@@ -64,6 +64,12 @@
         </ul>
     </li>
     <li>
+        <strong>Additionally for Comment added events</strong>
+        <ul>
+            <li><strong>GERRIT_EVENT_COMMENT_TEXT</strong>: The comment posted to Gerrit, UTF-8 Base64 encoded.</li>
+        </ul>
+    </li>
+    <li>
         <strong>For Reference updated events</strong>
         <ul>
             <li><strong>GERRIT_REFNAME</strong>: Ref name within project.</li>


### PR DESCRIPTION
Expose the comment posted to Gerrit on a comment-added event as a job parameter named GERRIT_CHANGE_COMMENT_TEXT. Use the option for commit message encoding also for this parameter for now. If desired, I can look into introducing a separate option for this.

Disclaimer: no tests done due to lack of a suitable environment, but the change should be mostly trivial and most other functionality in GerritTriggerParameters does not seem to be covered by tests, either.