### PR TITLE
[JENKINS-38974] fill in commentTextParameterMode if it's missing

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1851,6 +1851,9 @@ public class GerritTrigger extends Trigger<Job> {
         if (changeSubjectParameterMode == null) {
             changeSubjectParameterMode = GerritTriggerParameters.ParameterMode.PLAIN;
         }
+        if (commentTextParameterMode == null) {
+            commentTextParameterMode = GerritTriggerParameters.ParameterMode.PLAIN;
+        }
         return super.readResolve();
     }
     /*

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java
@@ -106,6 +106,8 @@ public class BackCompat2173JenkinsTest {
         //Setting introduced after the version under test, so it should have the default value
         assertSame("Change subject mode == PLAIN", GerritTriggerParameters.ParameterMode.PLAIN,
                 trigger.getChangeSubjectParameterMode());
+        assertSame("Comment text mode == PLAIN", GerritTriggerParameters.ParameterMode.PLAIN,
+                trigger.getCommentTextParameterMode());
         assertEquals(GerritServer.ANY_SERVER, trigger.getServerName());
 
         assertThat(trigger.getGerritProjects(), hasItem(


### PR DESCRIPTION
Any existing jobs which were configured before this option was added (or
jobs uploaded as raw XML produced by Jenkins Job Builder, for example)
will not have <commentTextParameterMode/>. Ensure it is filled in with
the default value to avoid a NullPointerException later in the comment
event handling.