### PR TITLE
[JENKINS-40059] CommentAdded trigger firing on every comment

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1036,14 +1036,18 @@ public class GerritTrigger extends Trigger<Job> {
                      * Gerrit stream events changed to append approval info to
                      * every comment-added event.
                      **/
-                    if (approval.isUpdated()
-                            && approval.getType().equals(
-                                commentAdded.getVerdictCategory())
-                            && (approval.getValue().equals(
-                                commentAdded.getCommentAddedTriggerApprovalValue())
-                            || ("+" + approval.getValue()).equals(
-                                commentAdded.getCommentAddedTriggerApprovalValue()))) {
-                            return true;
+                    if (GerritVersionChecker.isCorrectVersion(
+                                GerritVersionChecker.Feature.commentAlwaysApproval,
+                                serverName)) {
+                        if (approval.isUpdated()
+                                && approval.getType().equals(
+                                    commentAdded.getVerdictCategory())
+                                && (approval.getValue().equals(
+                                    commentAdded.getCommentAddedTriggerApprovalValue())
+                                || ("+" + approval.getValue()).equals(
+                                    commentAdded.getCommentAddedTriggerApprovalValue()))) {
+                                return true;
+                        }
                     } else {
                         if (approval.getType().equals(
                                 commentAdded.getVerdictCategory())

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
@@ -60,7 +60,13 @@ public final class GerritVersionChecker {
         /**
          * Project created events, added in Gerrit 2.12.
          */
-        projectCreatedEvents("Project created events", "2.12");
+        projectCreatedEvents("Project created events", "2.12"),
+
+
+        /**
+         * Gerrit CommentAdded always contains approval information, added in Gerrit 2.13.
+         */
+        commentAlwaysApproval("CommentAdded always contains approval", "2.13");
 
         private final String displayName;
         private final String version;


### PR DESCRIPTION
The CommentAdded trigger was firing on any comment after
the necessary value of an approval had been met.
This was happening due to that in previous versions of gerrit
before 2.13.0 approval information only appeared once
something had changed.
This changed to use the oldValue that would optionally
be included on state change. The logic added
to the gerrit-trigger-plugin was based on an earlier
patchset that had an ever present variable for state
change.
This led to a fall through to the old style of checking
for whether to trigger based on a comment.