### PR TITLE
Display full commit message in tooltip

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
@@ -150,7 +150,7 @@
                                                             ${patch.getString('number')}
                                                         </td>
                                                         <td onClick="activateRow('${theId}')">
-                                                            <span title="${res.get('commitMessage')}">
+                                                            <span title="${res.has('commitMessage') ? res.get('commitMessage') : null}">
                                                                 ${it.toReadableHtml(res.getString('subject'))}
                                                             </span>
                                                             <j:if test="${res.has('status')}">

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
@@ -150,7 +150,9 @@
                                                             ${patch.getString('number')}
                                                         </td>
                                                         <td onClick="activateRow('${theId}')">
-                                                            ${it.toReadableHtml(res.getString('subject'))}
+                                                            <span title="${res.get('commitMessage')}">
+                                                                ${it.toReadableHtml(res.getString('subject'))}
+                                                            </span>
                                                             <j:if test="${res.has('status')}">
                                                                 <j:if test="${res.getString('status').equals('ABANDONED')}">
                                                                     (${res.getString('status')})


### PR DESCRIPTION
On *Gerrit Manual Trigger* page, "only" commit message header
(first 65 characters of commit message) is displayed in `Subject`
column.
This change modifies it such that when user hovers over change
subject, native tooltip with full commit message is displayed.
This should provide additional information about a change.