### PR TITLE
Fixing JENKINS-20808 by escaping single quotes inside BUILDS_STATS

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -532,7 +532,11 @@ public class ParameterExpander {
 
         Map<String, String> parameters = createStandardParameters(null, memoryImprint.getEvent(),
                 codeReview, verified, notifyLevel.name());
-        parameters.put("BUILDS_STATS", createBuildsStats(memoryImprint, listener, parameters));
+        // escapes ' as '"'"' in order to avoid breaking command line param
+        // Details: http://stackoverflow.com/a/26165123/99834
+        parameters.put("BUILDS_STATS", createBuildsStats(memoryImprint,
+                                                         listener,
+                                                         parameters).replaceAll("'", "'\"'\"'"));
 
         Run build = null;
         Entry[] entries = memoryImprint.getEntries();


### PR DESCRIPTION
This should fix https://issues.jenkins-ci.org/browse/JENKINS-20808 which was reported multiple times.