### PR TITLE
Support specification of variable patterns

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/CompareType.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/CompareType.java
@@ -46,7 +46,13 @@ public enum CompareType {
     /**
      * Regular expression comparison.
      */
-    REG_EXP(new RegExpCompareUtil());
+    REG_EXP(new RegExpCompareUtil()),
+
+    /**
+     * Plain comparison however, the pattern will be expanded with the system environment.
+     * This allows comparisons such as "${PROJECTNAME}".
+     */
+    PLAIN_VAR(new CompareUtil.PlainVarCompareUtil());
 
     /**
      * Gets a list of all CompareType's displayNames.
@@ -88,7 +94,7 @@ public enum CompareType {
         return PLAIN;
     }
 
-    private CompareUtil util;
+    CompareUtil util;
 
     /**
      * Private Constructor.

--- a/src/main/webapp/trigger/help-GerritTriggerConfiguration.html
+++ b/src/main/webapp/trigger/help-GerritTriggerConfiguration.html
@@ -8,7 +8,9 @@
     You can specify the name pattern in three different ways, as provided by the &quot;Type&quot; drop-down menu.
 </p>
 <ul>
-    <li><strong>Plain:</strong> The exact name in Gerrit, case sensitive equality.</li>
+    <li><strong>Plain:</strong> The exact name in Gerrit, case insensitive equality.</li>
+    <li><strong>PlainVar:</strong> The exact name in Gerrit, case insensitive equality, allows usage of system environment
+        variables defined on the gerrit host (e.g. <code>${ENVIRONMENT}</code>).</li>
     <li><strong>Path:</strong> ANT style pattern. <i>Ex: &quot;**/base/*&quot;</i></li>
     <li><strong>RegExp:</strong> Regular expression.</li>
 </ul>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectWithFilesInterestingTest.java
@@ -23,6 +23,7 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data;
 
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -58,6 +59,13 @@ public class GerritProjectWithFilesInterestingTest {
     public void testInteresting() {
         assertEquals(scenarioWithFiles.expected, scenarioWithFiles.config.isInteresting(
                 scenarioWithFiles.project, scenarioWithFiles.branch, scenarioWithFiles.topic, scenarioWithFiles.files));
+    }
+
+    @BeforeClass
+    public static void setupEnv() {
+        // this is a somewhat hacky way to deal with the fact that the compare util was already set up before
+        // we get the chance to update the system environment
+        ((CompareUtil.PlainVarCompareUtil) CompareType.PLAIN_VAR.util).inject("PROJECTNAME", "myproject");
     }
 
     /**
@@ -212,6 +220,14 @@ public class GerritProjectWithFilesInterestingTest {
         files.add("files/skip.txt");
         parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
                 config, "vendor/semc/master/project", "origin/master", null, files, false), });
+
+        branches = new LinkedList<Branch>();
+        branch = new Branch(CompareType.PLAIN, "master");
+        branches.add(branch);
+        config = new GerritProject(CompareType.PLAIN_VAR, "${PROJECTNAME}", branches, null, null, null,
+                false);
+        parameters.add(new InterestingScenarioWithFiles[]{new InterestingScenarioWithFiles(
+                config, "myproject", "master", null, null, true),});
 
         return parameters;
     }


### PR DESCRIPTION
- this change allows the use of system environment patterns for
  project and branch specification such as

  ${PROJECT_NAME}

- Example:
  the gerrit host has a configured environment variable defined as

  export PROJECT_NAME=myproject

  now when we push a review commit for "myproject" then the gerrit
  trigger will automatically react

- one use case for this is to be able to specfiy a generic seed
  job for a jenkins instance which will automatically trigger
  a build on the variable based project