### PR TITLE
Fix CommentAdded event for Gerrit snapshot version < 2.13

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1032,13 +1032,16 @@ public class GerritTrigger extends Trigger<Job> {
             if (e instanceof PluginCommentAddedEvent) {
                 commentAdded = (PluginCommentAddedEvent)e;
                 for (Approval approval : event.getApprovals()) {
-                    /** Ensure that this trigger is backwards compatible.
+                    /* Ensure that this trigger is backwards compatible.
                      * Gerrit stream events changed to append approval info to
-                     * every comment-added event.
-                     **/
+                     * every comment-added event. We need to exclude snapshot
+                     * versions from this check. Otherwise, Gerrit snapshot
+                     * versions that are < 2.13 will handle comment added event
+                     * the way they are supposed to be for Gerrit >= 2.13.
+                     */
                     if (GerritVersionChecker.isCorrectVersion(
                                 GerritVersionChecker.Feature.commentAlwaysApproval,
-                                serverName)) {
+                                serverName, true)) {
                         if (approval.isUpdated()
                                 && approval.getType().equals(
                                     commentAdded.getVerdictCategory())


### PR DESCRIPTION
0a8e1c246 adapted CommentAdded event firing for Gerrit version >= 2.13
and backward compatibility is kept for Gerrit version < 2.13.

The version check done to maintain backward compatibility was not
excluding snapshot so snapshot versions that are < 2.13 were handling
CommentAdded event the way they are supposed to be for Gerrit >= 2.13.