### PR TITLE
Update Gerrit documentation links to latest major release

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/help-Search.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/help-Search.jelly
@@ -4,7 +4,7 @@
         <j:set var="frontEndUrl" value="${it.getFrontEndUrl(request.session.getAttribute('selectedServer'))}"/>
         <j:choose>
             <j:when test="${empty(frontEndUrl)}">
-                <j:set var="helpUrl" value="https://gerrit-documentation.storage.googleapis.com/Documentation/2.8/user-search.html"/>
+                <j:set var="helpUrl" value="https://gerrit-documentation.storage.googleapis.com/Documentation/2.13/user-search.html"/>
             </j:when>
             <j:otherwise>
                 <j:set var="helpUrl" value="${frontEndUrl + 'Documentation/user-search.html'}"/>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
@@ -32,7 +32,7 @@
                             <j:set var="frontEndUrl" value="${it.getFrontEndUrl(request.session.getAttribute('selectedServer'))}"/>
                             <j:choose>
                                 <j:when test="${empty(frontEndUrl)}">
-                                    <j:set var="helpUrl" value="https://gerrit-documentation.storage.googleapis.com/Documentation/2.8/user-search.html"/>
+                                    <j:set var="helpUrl" value="https://gerrit-documentation.storage.googleapis.com/Documentation/2.13/user-search.html"/>
                                 </j:when>
                                 <j:otherwise>
                                     <j:set var="helpUrl" value="${frontEndUrl + 'Documentation/user-search.html'}"/>


### PR DESCRIPTION
The links point to the documentation for Gerrit version 2.8 but the
latest major release is 2.13.

Change-Id: I21452845f1854667cbe598e200728c7ea8e387a6
Signed-off-by: David Pursehouse <david.pursehouse@gmail.com>