### PR TITLE
[JENKINS-39010] CommentAddedRegex: Input is a multiline message

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedContainsEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginCommentAddedContainsEvent.java
@@ -111,8 +111,9 @@ public class PluginCommentAddedContainsEvent extends PluginGerritEvent
             return false;
         }
         Pattern p = Pattern
-                .compile(commentAddedCommentContains, Pattern.DOTALL);
+                .compile(commentAddedCommentContains, Pattern.DOTALL | Pattern.MULTILINE);
         CommentAdded ca = (CommentAdded)event;
+        logger.debug("input comment: '{}'", ca.getComment());
         return p.matcher(ca.getComment()).find();
     }
 }


### PR DESCRIPTION
Interpret the incoming comment message as multi-line text, as gerrit
prefixes some heading to the input.

Add debug logging as well.

Fixes: [JENKINS-39010](https://issues.jenkins-ci.org/browse/JENKINS-39010)