### PR TITLE
Support sending multiline comments

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -182,31 +182,31 @@
                     <f:section title="${%Gerrit Verified Commands}">
                         <f:entry title="${%Started}"
                                  help="/plugin/gerrit-trigger/help-GerritVerifiedCmdBuildStarted.html">
-                            <f:textbox name="gerritVerifiedCmdBuildStarted"
+                            <f:textarea name="gerritVerifiedCmdBuildStarted"
                                        value="${it.config.gerritCmdBuildStarted}"
                                        default="gerrit review &lt;CHANGE&gt;,&lt;PATCHSET&gt; --message 'Build Started &lt;BUILDURL&gt; &lt;STARTED_STATS&gt;' --verified &lt;VERIFIED&gt; --code-review &lt;CODE_REVIEW&gt;"/>
                         </f:entry>
                         <f:entry title="${%Successful}"
                                  help="/plugin/gerrit-trigger/help-GerritVerifiedCmdBuildSuccessful.html">
-                            <f:textbox name="gerritVerifiedCmdBuildSuccessful"
+                            <f:textarea name="gerritVerifiedCmdBuildSuccessful"
                                        value="${it.config.gerritCmdBuildSuccessful}"
                                        default="gerrit review &lt;CHANGE&gt;,&lt;PATCHSET&gt; --message 'Build Successful &lt;BUILDS_STATS&gt;' --verified &lt;VERIFIED&gt; --code-review &lt;CODE_REVIEW&gt;"/>
                         </f:entry>
                         <f:entry title="${%Failed}"
                                  help="/plugin/gerrit-trigger/help-GerritVerifiedCmdBuildFailed.html">
-                            <f:textbox name="gerritVerifiedCmdBuildFailed"
+                            <f:textarea name="gerritVerifiedCmdBuildFailed"
                                        value="${it.config.gerritCmdBuildFailed}"
                                        default="gerrit review &lt;CHANGE&gt;,&lt;PATCHSET&gt; --message 'Build Failed &lt;BUILDS_STATS&gt;' --verified &lt;VERIFIED&gt; --code-review &lt;CODE_REVIEW&gt;"/>
                         </f:entry>
                         <f:entry title="${%Unstable}"
                                  help="/plugin/gerrit-trigger/help-GerritVerifiedCmdBuildUnstable.html">
-                            <f:textbox name="gerritVerifiedCmdBuildUnstable"
+                            <f:textarea name="gerritVerifiedCmdBuildUnstable"
                                        value="${it.config.gerritCmdBuildUnstable}"
                                        default="gerrit review &lt;CHANGE&gt;,&lt;PATCHSET&gt; --message 'Build Unstable &lt;BUILDS_STATS&gt;' --verified &lt;VERIFIED&gt; --code-review &lt;CODE_REVIEW&gt;"/>
                         </f:entry>
                         <f:entry title="${%Not Built}"
                                  help="/plugin/gerrit-trigger/help-GerritVerifiedCmdBuildNotBuilt.html">
-                            <f:textbox name="gerritVerifiedCmdBuildNotBuilt"
+                            <f:textarea name="gerritVerifiedCmdBuildNotBuilt"
                                        value="${it.config.gerritCmdBuildNotBuilt}"
                                        default="gerrit review &lt;CHANGE&gt;,&lt;PATCHSET&gt; --message 'No Builds Executed &lt;BUILDS_STATS&gt;' --verified &lt;VERIFIED&gt; --code-review &lt;CODE_REVIEW&gt;"/>
                         </f:entry>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -159,27 +159,27 @@
                 <f:entry title="${%Build Start Message}"
                          field="buildStartMessage"
                          help="/plugin/gerrit-trigger/trigger/help-BuildStartMessage.html">
-                   <f:textbox/>
+                   <f:textarea/>
                 </f:entry>
                 <f:entry title="${%Build Successful Message}"
                          field="buildSuccessfulMessage"
                          help="/plugin/gerrit-trigger/trigger/help-BuildSuccessfulMessage.html">
-                   <f:textbox/>
+                   <f:textarea/>
                 </f:entry>
                 <f:entry title="${%Build Unstable Message}"
                          field="buildUnstableMessage"
                          help="/plugin/gerrit-trigger/trigger/help-BuildUnstableMessage.html">
-                   <f:textbox/>
+                   <f:textarea/>
                 </f:entry>
                 <f:entry title="${%Build Failure Message}"
                          field="buildFailureMessage"
                          help="/plugin/gerrit-trigger/trigger/help-BuildFailureMessage.html">
-                   <f:textbox/>
+                   <f:textarea/>
                 </f:entry>
                 <f:entry title="${%Build Not Built Message}"
                          field="buildNotBuiltMessage"
                          help="/plugin/gerrit-trigger/trigger/help-BuildNotBuiltMessage.html">
-                   <f:textbox/>
+                   <f:textarea/>
                 </f:entry>
                 <j:if test="${descriptor.isUnsuccessfulMessageFileSupported(it)}">
                     <f:entry title="${%Unsuccessful Message File}"

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
@@ -135,6 +135,7 @@ public class ParameterExpanderTest {
         assertTrue("Missing ENV_REFSPEC", result.indexOf("ENV_REFSPEC=" + expectedRefSpec) >= 0);
         assertTrue("Missing ENV_CHANGEURL", result.indexOf("ENV_CHANGEURL=http://gerrit/1000") >= 0);
         assertTrue("Missing CUSTOM_MESSAGE", result.indexOf("CUSTOM_MESSAGE_BUILD_STARTED") >= 0);
+        assertTrue("Newlines are stripped", result.indexOf("Message\nwith newline") >= 0);
     }
 
     /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -65,7 +65,8 @@ public class MockGerritHudsonTriggerConfig implements
                 + " ENV_CHANGE=$CHANGE"
                 + " ENV_PATCHSET=$PATCHSET"
                 + " ENV_REFSPEC=$REFSPEC"
-                + " ENV_CHANGEURL=$CHANGE_URL";
+                + " ENV_CHANGEURL=$CHANGE_URL"
+                + " Message\nwith newline";
     }
 
     @Override


### PR DESCRIPTION
While Gerrit's API supports multiline review comments the Gerrit Trigger
UI limits the user to single line inputs. Improve this by using a
textarea widget instead.