### PR TITLE
Provide the data about parent builds as environment variable to the dependent build

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/BecauseDependentBuildIsBuilding.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/BecauseDependentBuildIsBuilding.java
@@ -26,9 +26,6 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.dependency;
 import hudson.model.Job;
 import hudson.model.queue.CauseOfBlockage;
 
-import java.util.List;
-
-import com.google.common.base.Joiner;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
 
 /**
@@ -37,18 +34,18 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
  */
 public class BecauseDependentBuildIsBuilding extends CauseOfBlockage {
 
-    private List<Job> blockingProjects;
+    private Job blockingProject;
 
     /**
      * Standard constructor.
-     * @param blockingProjects The list of dependant builds which are blocking this one.
+     * @param blockingProject The dependant build which are blocking this one.
      */
-    public BecauseDependentBuildIsBuilding(List<Job> blockingProjects) {
-        this.blockingProjects = blockingProjects;
+    public BecauseDependentBuildIsBuilding(Job blockingProject) {
+        this.blockingProject = blockingProject;
     }
 
     @Override
     public String getShortDescription() {
-        return Messages.DependentBuildIsBuilding(Joiner.on(", ").join(blockingProjects));
+        return Messages.DependentBuildIsBuilding(blockingProject);
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcher.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcher.java
@@ -182,15 +182,40 @@ public final class DependencyQueueTaskDispatcher extends QueueTaskDispatcher
         }
 
 
-        List<Job> blockingProjects = getBlockingDependencyProjects(dependencies, event);
+        Job blockingProject = getBlockingDependencyProjects(dependencies, event);
 
-        if (blockingProjects.size() > 0) {
-            return new BecauseDependentBuildIsBuilding(blockingProjects);
+        if (blockingProject != null) {
+            return new BecauseDependentBuildIsBuilding(blockingProject);
         } else {
             logger.info("No active dependencies on project: {} , it will now build", p);
+
+            ToGerritRunListener toGerritRunListener = ToGerritRunListener.getInstance();
+            if (toGerritRunListener != null) {
+                List<Run> parentRuns = toGerritRunListener.getRuns(event);
+
+                if (parentRuns == null) {
+                    logger.info("All dependencies on project: {}, are triggered in silent mode. "
+                            + "Can not get list of actual dependencies", p);
+                    return null;
+                }
+
+                List<Run> actualDependencies = new ArrayList<Run>(dependencies.size());
+                for (Run run : parentRuns) {
+                    if (dependencies.contains(run.getParent())) {
+                        actualDependencies.add(run);
+                    }
+                }
+
+                // TODO: returning `null` from a QueueTaskDispatcher does not mean the build will start immediately.
+                // So, this line can be called multiple times. In case of performance/stability issues it makes sense to
+                // mode to TransientActionFactory or maybe a QueueListener would be better.
+                item.replaceAction(new GerritDependencyAction(actualDependencies));
+            }
+
             return null;
         }
     }
+
 
     /**
      * Gets the subset of projects which have a building element needing to complete for the same event.
@@ -198,19 +223,17 @@ public final class DependencyQueueTaskDispatcher extends QueueTaskDispatcher
      * @param event The event should have also caused the blocking builds.
      * @return the sublist of dependencies which need to be completed before this event is resolved.
      */
-    protected List<Job> getBlockingDependencyProjects(List<Job> dependencies,
-            GerritTriggeredEvent event) {
-        List<Job> blockingProjects = new ArrayList<Job>();
+    private Job getBlockingDependencyProjects(List<Job> dependencies, GerritTriggeredEvent event) {
         ToGerritRunListener toGerritRunListener = ToGerritRunListener.getInstance();
         if (toGerritRunListener != null) {
             for (Job dependency : dependencies) {
                 if (toGerritRunListener.isTriggered(dependency, event)
                         && toGerritRunListener.isBuilding(dependency, event)) {
-                    blockingProjects.add(dependency);
+                    return dependency;
                 }
             }
         }
-        return blockingProjects;
+        return null;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/GerritDependencyAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/GerritDependencyAction.java
@@ -1,0 +1,74 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.dependency;
+
+import hudson.EnvVars;
+import hudson.model.AbstractBuild;
+import hudson.model.EnvironmentContributingAction;
+import hudson.model.InvisibleAction;
+import hudson.model.Run;
+
+import javax.annotation.Nonnull;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Adds Action that stores the data about dependency jobs.
+ */
+public class GerritDependencyAction extends InvisibleAction implements EnvironmentContributingAction {
+    @Nonnull
+    private final List<String> deps;
+
+    /**
+     * Saves the important information about the parent runs to be persistent.
+     * Stores string to keep the data even if original execution of parent job would be removed from history.
+     * @param runs List of runs it depend on
+     */
+    public GerritDependencyAction(List<Run> runs) {
+        deps = new ArrayList<String>(runs.size());
+        for (Run run : runs) {
+            deps.add(run.getParent().getFullName() + "#" + run.getNumber() + "#" + run.getResult());
+        }
+    }
+
+
+    /**
+     * The same as {@code buildEnvVars}, but for Run. Part of Core API since Jenkins 2.76.
+     * See https://issues.jenkins-ci.org/browse/JENKINS-29537 for more details.
+     *  @param run The calling build.
+     *  @param env Environment variables should be added to this map.
+     */
+    @SuppressWarnings("unused")
+    public void buildEnvironment(@Nonnull Run<?, ?> run, @Nonnull EnvVars env) {
+        fillEnv(env);
+    }
+
+    @Override
+    public void buildEnvVars(AbstractBuild<?, ?> build, EnvVars env) {
+        fillEnv(env);
+    }
+
+    /**
+     * Fills the environment variables based on build dependencies.
+     * @param env Environment variables should be added to this map.
+     */
+    private void fillEnv(EnvVars env) {
+        final StringBuilder depKeys = new StringBuilder();
+        for (String dependency : deps) {
+            String[] tokens = dependency.split("#");
+            String originalName = tokens[0];
+            String number = tokens[1];
+            String result = tokens[2];
+
+            String keyName = originalName.replaceAll("[^a-zA-Z0-9]+", "_");
+            String prefix = "TRIGGER_" + keyName;
+
+            env.put(prefix + "_BUILD_NAME", originalName);
+            env.put(prefix + "_BUILD_NUMBER", number);
+            env.put(prefix + "_BUILD_RESULT", result);
+
+            depKeys.append(keyName);
+            depKeys.append(" ");
+            }
+
+        env.put("TRIGGER_DEPENDENCY_KEYS", depKeys.toString().trim());
+    }
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
@@ -251,6 +251,17 @@ public final class ToGerritRunListener extends RunListener<Run> {
     }
 
     /**
+     * Get runs triggered for event.
+     *
+     * @param event   the Gerrit Event which is being checked.
+     * @return the list of triggered runs for the event.
+     */
+    @Nullable
+    public List<Run> getRuns(GerritTriggeredEvent event) {
+        return memory.getBuilds(event);
+    }
+
+    /**
      * Updates the {@link com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.TriggerContext}s for all the
      * {@link GerritCause}s in the build.
      *

--- a/src/main/webapp/trigger/help-DependencyJobs.html
+++ b/src/main/webapp/trigger/help-DependencyJobs.html
@@ -1,1 +1,16 @@
-Insert all jobs on which this job depends. If a commit should trigger both a dependency and this job, the dependency will be built first. Use commas to separate job names. Beware of cyclic dependencies.
+<div>
+Insert all jobs on which this job actually depends (skips triggered in silent mode jobs).
+If a commit should trigger both a dependency and this job, the dependency will be built first.
+Use commas to separate job names. Beware of cyclic dependencies.
+
+With this option enabled the parent builds are available as Env variables for the build<br/>
+<ul>
+    <li><b>TRIGGER_DEPENDENCY_KEYS</b>="Space separated list of all key names of triggered parent projects"</li>
+    <li><b>TRIGGER_&lt;project name&gt;_BUILD_NAME</b>="The build name of triggered project"</li>
+    <li><b>TRIGGER_&lt;project name&gt;_BUILD_NUMBER</b>="The build number of triggered project"</li>
+    <li><b>TRIGGER_&lt;project name&gt;_BUILD_RESULT</b>="The build result of triggered project"</li>
+</ul>
+The project key name is produced from full project name using simple regular expression:
+    <b>replaceAll("[^a-zA-Z0-9]+", "_")</b>.
+So, all non-alphanumerical characters will be replaced by "_".
+</div>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcherTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcherTest.java
@@ -25,6 +25,7 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.dependency;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.doReturn;
@@ -34,13 +35,19 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import hudson.EnvVars;
 import hudson.ExtensionList;
-import hudson.model.Action;
+import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
+import hudson.model.Action;
 import hudson.model.CauseAction;
 import hudson.model.Item;
+import hudson.model.ItemGroup;
 import hudson.model.Queue;
 import hudson.model.Queue.WaitingItem;
+import hudson.model.Result;
+import hudson.model.Run;
 import hudson.model.queue.CauseOfBlockage;
 
 import java.util.ArrayList;
@@ -60,6 +67,7 @@ import jenkins.model.TransientActionFactory;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -232,6 +240,40 @@ public class DependencyQueueTaskDispatcherTest {
     }
 
     /**
+     * Test that child job contains the list of builds it depends on as a StringParameters.
+     */
+    @Test
+    public void unblockedItemContainsParamsFromDependencies() {
+        PatchsetCreated patchsetCreated = Setup.createPatchsetCreated("someGerritServer", "someProject",
+                "refs/changes/1/1/1");
+
+        Queue.Item item = createItem(patchsetCreated, "upstream");
+        dispatcher.onDoneTriggeringAll(patchsetCreated);
+
+        List<Run> runs = new ArrayList<Run>();
+        AbstractBuild build = Mockito.mock(AbstractBuild.class);
+        runs.add(build);
+        when(build.getResult()).thenReturn(Result.SUCCESS);
+        when(build.getNumber()).thenReturn(1);
+        when(build.getParent()).thenReturn(abstractProjectDependencyMock);
+        EnvVars envVars = Mockito.mock(EnvVars.class);
+        when(envVars.put(anyString(), anyString())).thenReturn("");
+
+        doReturn(runs).when(toGerritRunListenerMock).getRuns(patchsetCreated);
+        dispatcher.canRun(item);
+
+        GerritDependencyAction dependencyAction = item.getAction(GerritDependencyAction.class);
+        assertNotNull(dependencyAction);
+
+        dependencyAction.buildEnvVars(build, envVars);
+
+        verify(envVars).put("TRIGGER_upstream_BUILD_NAME", "upstream");
+        verify(envVars).put("TRIGGER_upstream_BUILD_NUMBER", "1");
+        verify(envVars).put("TRIGGER_upstream_BUILD_RESULT", "SUCCESS");
+        verify(envVars).put("TRIGGER_DEPENDENCY_KEYS", "upstream");
+    }
+
+    /**
      * Test that it should not block a project whose dependencies are all built.
      */
     @Test
@@ -241,7 +283,9 @@ public class DependencyQueueTaskDispatcherTest {
         Queue.Item item = createItem(patchsetCreated, "upstream");
         //Setting the dependency as "triggered and built"
         doReturn(false).when(toGerritRunListenerMock).
-            isProjectTriggeredAndIncomplete(abstractProjectDependencyMock, patchsetCreated);
+                isTriggered(abstractProjectDependencyMock, patchsetCreated);
+        doReturn(false).when(toGerritRunListenerMock).
+                isBuilding(abstractProjectDependencyMock, patchsetCreated);
         CauseOfBlockage cause = dispatcher.canRun(item);
         assertNull("Build should not be blocked", cause);
     }
@@ -311,6 +355,12 @@ public class DependencyQueueTaskDispatcherTest {
         when(abstractProjectDependencyMock.getTrigger(GerritTrigger.class)).thenReturn(gerritTriggerMock);
         when(gerritTriggerMock.getDependencyJobsNames()).thenReturn(dependency);
         when(jenkinsMock.getItem(eq("upstream"), any(Item.class), Item.class)).thenReturn(abstractProjectDependencyMock);
+
+        ItemGroup abstractProjectDependencyMockParent = mock(ItemGroup.class);
+        when(abstractProjectDependencyMockParent.getFullName()).thenReturn("");
+        when(abstractProjectDependencyMock.getParent()).thenReturn(abstractProjectDependencyMockParent);
+        when(abstractProjectDependencyMock.getName()).thenReturn("upstream");
+
         WaitingItem waitingItem = PowerMockito.spy(new WaitingItem(Calendar.getInstance(),
                 abstractProjectMock, actions));
         when(waitingItem.getInQueueSince()).thenReturn(System.currentTimeMillis()

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/IntegrationTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/IntegrationTest.java
@@ -1,0 +1,181 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.dependency;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.GerritServer;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.CompareType;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginGerritEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+import hudson.model.FreeStyleProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.CaptureEnvironmentBuilder;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * The set of integration tests for dependency feature of Gerrit Trigger Plugin.
+ * Can be moved or renamed in future to be more generic.
+ */
+public class IntegrationTest {
+    /**
+     * An instance of Jenkins Rule.
+     */
+    // CS IGNORE VisibilityModifier FOR NEXT 2 LINES. REASON: JenkinsRule.
+    @Rule
+    public final JenkinsRule jenkinsRule = new JenkinsRule();
+
+    private static final int TIMEOUT = 10;
+    private static final int POLLING_INTERVAL = 1000;
+
+    /**
+     * Test that child build see the env variables that contains information about "parent" build.
+     * @throws Exception throw if so
+     */
+    @Test
+    public void testChildBuildSeeParametersOfParentJob() throws Exception {
+        String gerritServerName = "";
+        GerritServer gerritServer = createMockGerritServer(gerritServerName);
+        PluginImpl.getInstance().addServer(gerritServer);
+
+        ChangeBasedEvent gerritEvent = createMockChangeBasedEvent(gerritServerName);
+        List<GerritProject> projectList = createMockGerritProjectList();
+        List<PluginGerritEvent> triggerOnEvents = createMockPluginGerritEventList();
+
+        GerritTrigger parentTrigger = new GerritTrigger(projectList);
+        FreeStyleProject parent = createJobWithGerritTrigger("parent", parentTrigger, triggerOnEvents);
+
+        GerritTrigger childTrigger = new GerritTrigger(projectList);
+        childTrigger.setDependencyJobsNames(parent.getName());
+        FreeStyleProject child = createJobWithGerritTrigger("child", childTrigger, triggerOnEvents);
+        CaptureEnvironmentBuilder environmentBuilder = new CaptureEnvironmentBuilder();
+        child.getBuildersList().add(environmentBuilder);
+
+        PluginImpl.getInstance().getHandler().notifyListeners(gerritEvent);
+
+        waitCompletedBuild(parent, TIMEOUT);
+        waitCompletedBuild(child, TIMEOUT);
+
+        jenkinsRule.assertBuildStatusSuccess(parent.getLastCompletedBuild());
+        assertEquals(environmentBuilder.getEnvVars().get("TRIGGER_parent_BUILD_NAME"), "parent");
+        assertEquals(environmentBuilder.getEnvVars().get("TRIGGER_DEPENDENCY_KEYS"), "parent");
+    }
+
+    /**
+     * Wait for the first completed build of specified project.
+     * @param project the instance of project
+     * @param timeout timeout in seconds
+     * @throws InterruptedException throw if so
+     */
+    private void waitCompletedBuild(FreeStyleProject project, int timeout) throws InterruptedException {
+        long timeStarted = System.currentTimeMillis();
+        long timeoutMs = TimeUnit.SECONDS.toMillis(timeout);
+
+        while (project.getLastCompletedBuild() == null && System.currentTimeMillis() - timeStarted < timeoutMs) {
+            Thread.sleep(POLLING_INTERVAL);
+        }
+    }
+
+    /**
+     * Creates FreeStyleProject with specified Gerrit Trigger
+     * and configure it to be triggered on provided list of events.
+     *
+     * @param name the project name
+     * @param trigger the trigger to attach
+     * @param triggerOnEvents the list of event to be triggered on
+     * @return configured project
+     * @throws IOException in case of failure during project creation
+     */
+    private FreeStyleProject createJobWithGerritTrigger(String name,
+                                                        GerritTrigger trigger,
+                                                        List<PluginGerritEvent> triggerOnEvents) throws IOException {
+        FreeStyleProject project = jenkinsRule.createFreeStyleProject(name);
+        project.addTrigger(trigger);
+        trigger.setTriggerOnEvents(triggerOnEvents);
+        trigger.start(project, true);
+        return project;
+    }
+
+    /**
+     * Creates basic mock for PluginGerritEvent and returns the list that contains exactly one object.
+     * @return list with one mocked instance of PluginGerritEvent class
+     */
+    private List<PluginGerritEvent> createMockPluginGerritEventList() {
+        PluginGerritEvent triggeredEvent = mock(PluginGerritEvent.class);
+        when(triggeredEvent.shouldTriggerOn(any(GerritTriggeredEvent.class))).thenReturn(true);
+
+        List<PluginGerritEvent> triggerOnEvents = new ArrayList<PluginGerritEvent>(1);
+        triggerOnEvents.add(triggeredEvent);
+        return triggerOnEvents;
+    }
+
+    /**
+     * Creates basic mock for GerritProject and returns the list that contains exactly one object.
+     * @return list with one mocked instance of GerritProject class
+     */
+    private List<GerritProject> createMockGerritProjectList() {
+        List<GerritProject> projectList = new ArrayList<GerritProject>();
+
+        GerritProject project = mock(GerritProject.class);
+
+        when(project.getCompareType()).thenReturn(CompareType.PLAIN);
+        when(project.isInteresting(anyString(), anyString(), anyString())).thenReturn(true);
+        projectList.add(project);
+        return projectList;
+    }
+
+    /**
+     * Creates basic mock for Change Based event.
+     * @param gerritServerName gerrit server name
+     * @return mocked instance of ChangeBasedEvent class
+     */
+    private ChangeBasedEvent createMockChangeBasedEvent(String gerritServerName) {
+        ChangeBasedEvent gerritEvent = mock(ChangeBasedEvent.class);
+        Change change = mock(Change.class);
+        when(change.getNumber()).thenReturn("1");
+        when(gerritEvent.getChange()).thenReturn(change);
+        PatchSet patchSet = mock(PatchSet.class);
+        when(gerritEvent.getPatchSet()).thenReturn(patchSet);
+        when(gerritEvent.getEventType()).thenReturn(GerritEventType.TOPIC_CHANGED);
+        when(gerritEvent.getEventCreatedOn()).thenReturn(new Date());
+        Provider provider = mock(Provider.class);
+        when(provider.getName()).thenReturn(gerritServerName);
+        when(gerritEvent.getProvider()).thenReturn(provider);
+
+        when(change.getProject()).thenReturn("mockProject");
+        when(change.getId()).thenReturn("mockChange");
+        when(change.getBranch()).thenReturn("mockBranch");
+        when(patchSet.getNumber()).thenReturn("mockPatchSetNumber");
+        when(patchSet.getRevision()).thenReturn("mockRevision");
+        when(patchSet.getRef()).thenReturn("mockRefSpec");
+        return gerritEvent;
+    }
+
+    /**
+     * Creates basic mock for Gerrit Server with provided name.
+     * @param gerritServerName gerrit server name
+     * @return mocked instance of GerritServer class
+     */
+    private GerritServer createMockGerritServer(String gerritServerName) {
+        GerritServer gerritServer = mock(GerritServer.class);
+        when(gerritServer.getName()).thenReturn(gerritServerName);
+        return gerritServer;
+    }
+}


### PR DESCRIPTION
Idea is quite simple: we have build and test jobs and we want to get rid of intermediate steps. So, test job has build job as dependency and know how to download artifacts.
Other possible use cases:
* build some shared code once and re-use in dependent builds
* re-trigger only small pieces
* provide more granular feedback