### PR TITLE
WIP [JENKINS-37885] Expanding Build parameters in the Job Custom build message

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -115,7 +115,7 @@ public class ParameterExpander {
         }
         String buildStartMessage = trigger.getBuildStartMessage();
         if (buildStartMessage != null && !buildStartMessage.isEmpty()) {
-            startedStats.append("\n\n").append(buildStartMessage);
+            gerritCmd += "\n\n" + buildStartMessage;
         }
 
         if (config.isEnablePluginMessages()) {


### PR DESCRIPTION
This PR is related to the below ticket:
- https://issues.jenkins-ci.org/browse/JENKINS-37885

Unfortunately STARTED_STATS is just a generated parameter and it doesn't use the expandedParameters function as the gerritCmd string does. Therefore, we cannot use parameters/build variables but only hardcoded strings.

List of tasks:
- [ ] Implement feature
- [ ] Add further details in the helper
- [ ] Implement unit tests
 
Just wondering if you can help me out to know whether this is an expected feature and what kind of tests you'd like to be included to make this feature robust/reliable enough.

Thanks
