### PR TITLE
Abort ongoing builds of topic if new change to the same topic was submitted

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/BuildCancellationPolicy.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/BuildCancellationPolicy.java
@@ -34,6 +34,7 @@ public class BuildCancellationPolicy {
     private boolean enabled = false;
     private boolean abortNewPatchsets = false;
     private boolean abortManualPatchsets = false;
+    private boolean abortSameTopic = false;
 
     /**
      * Getter for if build cancellation is turned off or on.
@@ -90,6 +91,24 @@ public class BuildCancellationPolicy {
     }
 
     /**
+     * Standard getter for the abortSameTopic value.
+     *
+     * @return the abortSameTopic value.
+     */
+    public boolean isAbortSameTopic() {
+        return abortSameTopic;
+    }
+
+    /**
+     * Standard setter for the abortSameTopic value.
+     *
+     * @param abortSameTopic true if patchsets with same topic should be cancelled.
+     */
+    public void setAbortSameTopic(boolean abortSameTopic) {
+        this.abortSameTopic = abortSameTopic;
+    }
+
+    /**
      * Creates a new BuildCancellationPolicy object from JSON.
      *
      * @param obj the JSONObject.
@@ -98,10 +117,12 @@ public class BuildCancellationPolicy {
     public static BuildCancellationPolicy createPolicyFromJSON(JSONObject obj) {
         boolean newPatchsets = obj.getBoolean("abortNewPatchsets");
         boolean manualPatchsets = obj.getBoolean("abortManualPatchsets");
+        boolean abortSameTopic = obj.optBoolean("abortSameTopic");
         BuildCancellationPolicy policy = new BuildCancellationPolicy();
         policy.setEnabled(true);
         policy.setAbortNewPatchsets(newPatchsets);
         policy.setAbortManualPatchsets(manualPatchsets);
+        policy.setAbortSameTopic(abortSameTopic);
         return policy;
     }
 }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -94,6 +94,12 @@
                                                                 checked="${it.config.buildCurrentPatchesOnly.abortManualPatchsets}"
                                                                 default="false"/>
                                                 </f:entry>
+                                                <f:entry title="${%Abort patch sets with same topic}"
+                                                         help="/plugin/gerrit-trigger/help-GerritAbortPatchSetsWithSameTopic.html">
+                                                    <f:checkbox name="abortSameTopic"
+                                                                checked="${it.config.buildCurrentPatchesOnly.abortSameTopic}"
+                                                                default="false"/>
+                                                </f:entry>
                                             </f:optionalBlock>
                     <f:validateButton title="${%Test Connection}"
                                       progress="${%Testing...}"

--- a/src/main/webapp/help-GerritAbortPatchSetsWithSameTopic.html
+++ b/src/main/webapp/help-GerritAbortPatchSetsWithSameTopic.html
@@ -1,0 +1,5 @@
+<p>This option is only relevant if the "Build Current Patches Only" is checked.</p>
+<p>If this is enabled, builds triggered with topic will be aborted when a new patch set with the same topic arrives.</p>
+<p>If build was triggered by renaming topic the builds with old topic name will be aborted.</p>
+<p>Be aware that manual triggers will cancel other running builds for the same topic.</p>
+<p>Also if this option is enabled "Abort new patch sets" is not checked for changes with topic</p>


### PR DESCRIPTION
I'm not sure that this feature would be useful to other teams, but in our case we need to abort on-going builds if new patch-set was added to the topic or the topic itself was changed.

- [x] test is added
- [x] help is added