### PR TITLE
Fix link to the job in memory report

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/BuildMemoryReport/index.groovy
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/BuildMemoryReport/index.groovy
@@ -71,7 +71,7 @@ l.layout(title: _("Build Coordination - Gerrit Trigger Diagnostics"), norefresh:
                         Run run = entry.build
                         td(headers: "hJob ${eventHeaderId}") {
                             if (job != null) {
-                                a(href: "${rootURL}/${job.shortUrl}", job.fullDisplayName)
+                                a(href: "${rootURL}/${job.url}", job.fullDisplayName)
                             } else {
                                 raw("&nbsp;")
                             }


### PR DESCRIPTION
Now memory report gives the incorrect url to the job.