### PR TITLE
Expand parameters supplied by trigger.getBuild*Message()

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -115,7 +115,7 @@ public class ParameterExpander {
         }
         String buildStartMessage = trigger.getBuildStartMessage();
         if (buildStartMessage != null && !buildStartMessage.isEmpty()) {
-            startedStats.append("\n\n").append(buildStartMessage);
+            startedStats.append("\n\n").append(expandParameters(buildStartMessage, r, taskListener, parameters));
         }
 
         if (config.isEnablePluginMessages()) {
@@ -585,8 +585,6 @@ public class ParameterExpander {
                     if (res == null) {
                         res = Result.NOT_BUILT;
                     }
-                    String customMessage = null;
-
                     /* Gerrit comments cannot contain single-newlines, as they will be joined
                      * together. Double newlines are interpreted as paragraph breaks. Lines that
                      * begin with a space (even if the space occurs somewhere in the middle of
@@ -603,6 +601,7 @@ public class ParameterExpander {
                     }
                     str.append(MESSAGE_DELIMITER);
 
+                    String customMessage = null;
                     if (res == Result.SUCCESS) {
                         customMessage = trigger.getBuildSuccessfulMessage();
                     } else if (res == Result.FAILURE || res == Result.ABORTED) {
@@ -623,7 +622,7 @@ public class ParameterExpander {
                             str.append(" (skipped)");
                         }
                     } else {
-                        str.append(customMessage);
+                        str.append(expandParameters(customMessage, build, listener, parameters));
                     }
 
                     if (res.isWorseThan(Result.SUCCESS)) {

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
@@ -101,7 +101,9 @@ public class ParameterExpanderTest {
         GerritTrigger trigger = mock(GerritTrigger.class);
         when(trigger.getGerritBuildStartedVerifiedValue()).thenReturn(null);
         when(trigger.getGerritBuildStartedCodeReviewValue()).thenReturn(32);
+        when(trigger.getBuildStartMessage()).thenReturn("${START_MESSAGE_VAR}");
         AbstractProject project = mock(AbstractProject.class);
+
         Setup.setTrigger(trigger, project);
 
         AbstractBuild r = Setup.createBuild(project, taskListener, Setup.createEnvVars());
@@ -123,7 +125,8 @@ public class ParameterExpanderTest {
 
         String result = instance.getBuildStartedCommand(r, taskListener, event, stats);
         System.out.println("result: " + result);
-
+        assertTrue("Missing START_MESSAGE_VAL from getBuildStartMessage()",
+                result.indexOf("START_MESSAGE_VAL") >= 0);
         assertTrue("Missing CHANGE_ID", result.indexOf("CHANGE_ID=Iddaaddaa123456789") >= 0);
         assertTrue("Missing PATCHSET", result.indexOf("PATCHSET=1") >= 0);
         assertTrue("Missing VERIFIED", result.indexOf("VERIFIED=1") >= 0);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
@@ -568,6 +568,7 @@ public final class Setup {
         env.put("PATCHSET", "1");
         env.put("REFSPEC", StringUtil.REFSPEC_PREFIX + "00/1000/1");
         env.put("CHANGE_URL", "http://gerrit/1000");
+        env.put("START_MESSAGE_VAR", "START_MESSAGE_VAL");
         return env;
     }
 


### PR DESCRIPTION
Example use-case: An URL is generated to a staging environment based
on the commit. We want to send back that url to the user:

"This change is staged at http://staging-host/$GERRIT_PATCHSET_REVISION"