### PR TITLE
Do not query Jenkins Core API if it's possible

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
@@ -342,7 +342,7 @@ public class BuildMemory {
             return false;
         } else {
             for (Entry entry : pb.getEntries()) {
-                if (project.equals(entry.getProject())) {
+                if (entry.isProject(project)) {
                     return true;
                 }
             }


### PR DESCRIPTION
`Entity.getProject` uses Jenkins Core API to get the instance of Job. As result
it leads to big memory footprint because `getItemByFullName` needs to pass
ACL checks.

![screen shot 2017-10-25 at 14 49 33](https://user-images.githubusercontent.com/4785672/31999518-c9f98d00-b993-11e7-8fd3-27095bcbe60b.png)
