### PR TITLE
Explicitly provide GerritTrigger object to `schedule` method

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
@@ -26,6 +26,8 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
 import hudson.model.Job;
 import java.util.TimerTask;
 import javax.annotation.CheckForNull;
+import javax.annotation.Nonnull;
+
 import jenkins.model.Jenkins;
 
 /**
@@ -43,9 +45,9 @@ public class GerritTriggerTimerTask extends TimerTask {
      *
      * @param gerritTrigger the GerritTrigger that created this timerTask
      */
-    GerritTriggerTimerTask(GerritTrigger gerritTrigger) {
+    GerritTriggerTimerTask(@Nonnull GerritTrigger gerritTrigger) {
         job = gerritTrigger.getJob().getFullName();
-        GerritTriggerTimer.getInstance().schedule(this);
+        GerritTriggerTimer.getInstance().schedule(this, gerritTrigger);
     }
 
     /**
@@ -58,6 +60,11 @@ public class GerritTriggerTimerTask extends TimerTask {
             return;
         }
         trigger.updateTriggerConfigURL();
+    }
+
+    @Override
+    public String toString() {
+        return "GerritTriggerTimerTask{job='" + job + '\'' + '}';
     }
 
     /**


### PR DESCRIPTION
Before it was possible to hit the race condtion during Jenkins
initalization: GerritTrigger was already completely initialized, but Job
object was still "under construction". As result
`calculateDynamicConfigRefreshInterval` did a fallback to Average
interval. Unfortnately, the list of server could be non-initilized as
well. That leads to using `MINIMUM_DYNAMIC_CONFIG_REFRESH_INTERVAL`
instead of specified one.