### PR TITLE
JENKINS-48155: gerrit-trigger-plugin does not repsect dynamicTriggerConfiguration flag

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1388,6 +1388,10 @@ public class GerritTrigger extends Trigger<Job> {
      */
     @DataBoundSetter
     public void setDynamicTriggerConfiguration(boolean dynamicTriggerConfiguration) {
+        if (!dynamicTriggerConfiguration) {
+            dynamicGerritProjects = Collections.emptyList();
+        }
+
         this.dynamicTriggerConfiguration = dynamicTriggerConfiguration;
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
@@ -29,6 +29,7 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import jenkins.model.Jenkins;
+import org.apache.commons.lang.StringUtils;
 
 /**
  * TimerTasks that are created from a GerritTrigger and periodically calls
@@ -57,6 +58,9 @@ public class GerritTriggerTimerTask extends TimerTask {
     public void run() {
         GerritTrigger trigger = getGerritTrigger();
         if (trigger == null) {
+            return;
+        }
+        if (StringUtils.isEmpty(trigger.getTriggerConfigURL())) {
             return;
         }
         trigger.updateTriggerConfigURL();


### PR DESCRIPTION
If user does not want to use dynamic configuration anymore, let's assign
the list of projects to empty list to avoid possible race conditions.

Also instead of firing update with empty url, better to check it.