### PR TITLE
Reduce memory usage

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
@@ -341,8 +341,9 @@ public class BuildMemory {
         if (pb == null) {
             return false;
         } else {
+            String fullName = project.getFullName();
             for (Entry entry : pb.getEntries()) {
-                if (entry.isProject(project)) {
+                if (entry.isProject(fullName)) {
                     return true;
                 }
             }
@@ -357,13 +358,14 @@ public class BuildMemory {
      * @param project the project.
      * @return true if so.
      */
-    public synchronized boolean isBuilding(GerritTriggeredEvent event, Job project) {
+    public synchronized boolean isBuilding(GerritTriggeredEvent event, @Nonnull Job project) {
         MemoryImprint pb = memory.get(event);
         if (pb == null) {
             return false;
         } else {
+            String fullName = project.getFullName();
             for (Entry entry : pb.getEntries()) {
-                if (entry.isProject(project)) {
+                if (entry.isProject(fullName)) {
                     if (entry.getBuild() != null) {
                         return !entry.isBuildCompleted();
                     } else {
@@ -908,12 +910,14 @@ public class BuildMemory {
             @CheckForNull
             @WithBridgeMethods(AbstractBuild.class)
             public Run getBuild() {
-                Job p = getProject();
-                if (p != null && build != null) {
-                    return p.getBuild(build);
-                } else {
-                    return null;
+                if (build != null && project != null) {
+                    Job p = getProject();
+                    if (p != null) {
+                        return p.getBuild(build);
+                    }
                 }
+
+                return null;
             }
 
             /**
@@ -1057,16 +1061,29 @@ public class BuildMemory {
              * If the provided project is the same as this entry is referencing.
              * It does so by checking the fullName for equality.
              *
-             * @param other the other project to check
+             * @param otherName the other project name to check
              * @return true if so.
              * @see #getProject()
              */
-            public boolean isProject(Job other) {
-                if (this.project != null && other != null) {
-                    return this.project.equals(other.getFullName());
+            public boolean isProject(String otherName) {
+                if (this.project != null && otherName != null) {
+                    return this.project.equals(otherName);
                 } else {
-                    return this.project == null && other == null;
+                    return this.project == null && otherName == null;
                 }
+            }
+
+            /**
+             * If the provided project is the same as this entry is referencing.
+             * It does so by checking the fullName for equality.
+             *
+             * @param other the other project to check
+             * @return true if so.
+             * @deprecated use {@link #isProject(String)} instead
+             */
+            @Deprecated
+            public boolean isProject(Job other) {
+                return isProject(other.getFullName());
             }
         }
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/TriggerMonitor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/TriggerMonitor.java
@@ -188,8 +188,9 @@ public class TriggerMonitor implements GerritEventLifecycleListener {
          * @param build the build.
          */
         void setBuild(Run build) {
+            String fullName = build.getParent().getFullName();
             for (TriggeredItemEntity entity : builds) {
-                if (entity.equals(build.getParent())) {
+                if (entity.equals(fullName)) {
                     entity.setBuild(build);
                 }
             }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContext.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContext.java
@@ -206,8 +206,9 @@ public class TriggerContext {
      * @return the other object if there is one, null if there is none.
      */
     private synchronized TriggeredItemEntity findOtherBuild(Run build) {
+        String parentName = build.getParent().getFullName();
         for (TriggeredItemEntity other : others) {
-            if (other.equals(build)) {
+            if (other.isSameBuild(build.getNumber(), parentName)) {
                 return other;
             }
         }
@@ -221,8 +222,9 @@ public class TriggerContext {
      * @return the other object, or null if none.
      */
     private synchronized TriggeredItemEntity findOtherProject(Job project) {
+        String fullName = project.getFullName();
         for (TriggeredItemEntity other : others) {
-            if (other.equals(project)) {
+            if (other.equals(fullName)) {
                 return other;
             }
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggeredItemEntity.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggeredItemEntity.java
@@ -31,6 +31,8 @@ import hudson.model.Job;
 import hudson.model.Run;
 import jenkins.model.Jenkins;
 
+import javax.annotation.Nonnull;
+
 /**
  * Wrapper class for smoother serialization of {@link Run } and {@link Job }.
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
@@ -201,25 +203,50 @@ public class TriggeredItemEntity {
         }
 
         /**
-         * If this object represents the same build as aBuild.
-         * @param aBuild the build.
+         * If this object represents the same build as specified by parameters.
+         * @param otherBuildNumber build number
+         * @param otherParentName project full name
          * @return true if it is so.
          */
-        public boolean equals(Run aBuild) {
-            if (this.buildNumber != null) {
-                return projectId.equals(aBuild.getParent().getFullName())
-                        && this.buildNumber.equals(aBuild.getNumber());
-            }
-            return false;
+        public boolean isSameBuild(int otherBuildNumber, String otherParentName) {
+            return this.buildNumber != null
+                    && this.buildNumber == otherBuildNumber
+                    && projectId.equals(otherParentName);
         }
 
         /**
-         * If this object represents the same project as aProject.
-         * @param aProject the project to compare.
+         * If this object represents the same build as aBuild.
+         *
+         * @deprecated Use {@link #isSameBuild(int, String)} instead
+         *
+         * @param aBuild the build to compare.
          * @return true if it is so.
          */
-        public boolean equals(Job aProject) {
-            return projectId.equals(aProject.getFullName());
+        @Deprecated
+        public boolean equals(@Nonnull Run aBuild) {
+            return isSameBuild(aBuild.getNumber(), aBuild.getParent().getFullName());
+        }
+
+        /**
+         * If this object represents the same project as aProjectFullname.
+         * @param aProjectFullname the project to compare.
+         * @return true if it is so.
+         */
+        public boolean equals(String aProjectFullname) {
+            return projectId.equals(aProjectFullname);
+        }
+
+        /**
+         * If this object represents the same project as other.
+         *
+         * @deprecated Use {@link #equals(String)} instead
+         *
+         * @param other the project to compare.
+         * @return true if it is so.
+         */
+        @Deprecated
+        public boolean equals(Job other) {
+            return equals(other.getFullName());
         }
 
         @Override


### PR DESCRIPTION
Taking the full name of project from Jenkins leads to string duplication
problem as well as involves recursion. So, it's better to limit the
number of requests to Jenkins Core API as much as possible.