### PR TITLE
JENKINS-30557: Jenkins Gerrit Trigger should use relative URL

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement.java
@@ -115,7 +115,7 @@ public class GerritManagement extends ManagementLink implements StaplerProxy, De
         Jenkins jenkins = Jenkins.getInstance();
         assert jenkins != null;
         ContextMenu menu = new ContextMenu();
-        menu.add("newServer", Functions.joinPath(jenkins.getRootUrl(), Functions.getResourcePath(),
+        menu.add("newServer", Functions.joinPath("/", Functions.getResourcePath(),
                                                  "images", "24x24", "new-package.png"), Messages.AddNewServer());
         for (GerritServer server : getServers()) {
             menu.add(server);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -359,14 +359,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
 
     @Override
     public String getUrlName() {
-        //Lets make an absolute url to circumvent some buggy things in core
-        Jenkins jenkins = Jenkins.getInstance();
-        if (jenkins != null && jenkins.getRootUrl() != null) {
-            return Functions.joinPath(jenkins.getRootUrl(),
-                    getParentUrl(), "server", getUrlEncodedName());
-        } else {
-            return Functions.joinPath("/", getParentUrl(), "server", getUrlEncodedName());
-        }
+        return Functions.joinPath("/", getParentUrl(), "server", getUrlEncodedName());
     }
 
     /**
@@ -1222,7 +1215,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
 
         Jenkins jenkins = Jenkins.getInstance();
         if (jenkins != null) {
-            rsp.sendRedirect(jenkins.getRootUrl() + GerritManagement.get().getUrlName());
+            rsp.sendRedirect("/" + GerritManagement.get().getUrlName());
         }
     }
 

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/index.jelly
@@ -11,8 +11,8 @@
             <l:yui module="connection" />
             <l:yui module="datasource"/>
             <l:yui module="container" />
-            <script type="text/javascript" src="${rootURL}/plugin/${it.urlName}/js/yui/datatable/datatable-${h.yuiSuffix}.js"/>
-            <script type="text/javascript" src="${rootURL}/plugin/${it.urlName}/js/server-table.js"/>
+            <script type="text/javascript" src="/plugin/${it.urlName}/js/yui/datatable/datatable-${h.yuiSuffix}.js"/>
+            <script type="text/javascript" src="/plugin/${it.urlName}/js/server-table.js"/>
             <script type="text/javascript">
                 var textMessages = {
                     confirm: "${%Remove?}",
@@ -27,7 +27,7 @@
                     {key:"", label: "${%Remove}", formatter: "removeServer", className: "align-middle"}
                 ];
                 var imagesURL = "${imagesURL}";
-                var pluginURL = "${rootURL}/plugin/${it.urlName}";
+                var pluginURL = "/plugin/${it.urlName}";
                 YAHOO.util.Event.addListener(window, "load", function() {
                     serverTable();
                 });
@@ -35,7 +35,7 @@
         </l:header>
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="images/24x24/up.gif" href="/" title="${%Back to Dashboard}"/>
                 <l:task icon="images/24x24/new-package.png" href="newServer" title="${%Add New Server}" />
                 <l:task icon="icon-folder icon-md" href="diagnostics" title="${%Diagnostics}" />
             </l:tasks>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/newServer.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/newServer.jelly
@@ -30,8 +30,8 @@ THE SOFTWARE.
   <l:layout norefresh="true" permission="${app.ADMINISTER}" title="${%Add New Server}">
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
-        <l:task icon="images/24x24/up.gif" href="${rootURL}/${it.urlName}/" title="${%Back to Server List}"/>
+        <l:task icon="images/24x24/up.gif" href="/" title="${%Back to Dashboard}"/>
+        <l:task icon="images/24x24/up.gif" href="/${it.urlName}/" title="${%Back to Server List}"/>
       </l:tasks>
     </l:side-panel>
     <l:main-panel>
@@ -40,7 +40,7 @@ THE SOFTWARE.
       <j:set var="serverDescriptors" value="${descriptor.serverDescriptorList()}" />
       <j:set var="servers" value="${it.serverNames}" />
       <n:form action="addNewServer" nameTitle="${%Add New Server}" copyTitle="${%Copy Existing Server Configurations}" showCopyOption="${!empty(servers)}"
-              descriptors="${serverDescriptors}" checkUrl="${rootURL}/${it.urlName}/nameFreeCheck" xmlns:n="/lib/hudson/newFromList" />
+              descriptors="${serverDescriptors}" checkUrl="/${it.urlName}/nameFreeCheck" xmlns:n="/lib/hudson/newFromList" />
     </l:main-panel>
   </l:layout>
 </j:jelly>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -4,8 +4,8 @@
     <l:layout title="${%Gerrit Trigger Plugin Configuration}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/${it.parentUrl}/" title="${%Back to Server List}"/>
+                <l:task icon="images/24x24/up.gif" href="/" title="${%Back to Dashboard}"/>
+                <l:task icon="images/24x24/up.gif" href="/${it.parentUrl}/" title="${%Back to Server List}"/>
                 <l:task icon="images/24x24/edit-delete.png" href="remove" title="Remove Server" />
             </l:tasks>
         </l:side-panel>
@@ -20,7 +20,7 @@
                              help="/plugin/gerrit-trigger/help-GerritServerName.html">
                         <f:textbox name="name"
                                    value="${it.name}"
-                                   checkUrl="'${rootURL}/${serverURL}/nameFreeCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/nameFreeCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%No Connection On Startup}"
                              help="/plugin/gerrit-trigger/help-GerritNoConnectionOnStartup.html">
@@ -39,14 +39,14 @@
                         <f:textbox name="gerritFrontEndUrl"
                                    value="${it.config.gerritFrontEndUrl}"
                                    default="${com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_FRONT_END_URL}"
-                                   checkUrl="'${rootURL}/${serverURL}/urlCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/urlCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%SSH Port}"
                              help="/plugin/gerrit-trigger/help-GerritSshPort.html">
                         <f:textbox name="gerritSshPort"
                                    value="${it.config.gerritSshPort}"
                                    default="${com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_SSH_PORT}"
-                                   checkUrl="'${rootURL}/${serverURL}/positiveIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/positiveIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Proxy}"
                              help="/plugin/gerrit-trigger/help-GerritProxy.html">
@@ -70,7 +70,7 @@
                         <f:textbox name="gerritAuthKeyFile"
                                    value="${it.config.gerritAuthKeyFile}"
                                    default="${com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_GERRIT_AUTH_KEY_FILE}"
-                                   checkUrl="'${rootURL}/${serverURL}/validKeyFileCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/validKeyFileCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%SSH Keyfile Password}"
                              help="/plugin/gerrit-trigger/help-GerritKeyFilePassword.html">
@@ -119,31 +119,31 @@
                              help="/plugin/gerrit-trigger/help-GerritBuildStartedVerified.html">
                         <f:textbox name="gerritBuildStartedVerifiedValue"
                                    value="${it.config.gerritBuildStartedVerifiedValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Successful}"
                              help="/plugin/gerrit-trigger/help-GerritBuildSuccessfulVerified.html">
                         <f:textbox name="gerritBuildSuccessfulVerifiedValue"
                                    value="${it.config.gerritBuildSuccessfulVerifiedValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Failed}"
                              help="/plugin/gerrit-trigger/help-GerritBuildFailedVerified.html">
                         <f:textbox name="gerritBuildFailedVerifiedValue"
                                    value="${it.config.gerritBuildFailedVerifiedValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Unstable}"
                              help="/plugin/gerrit-trigger/help-GerritBuildUnstableVerified.html">
                         <f:textbox name="gerritBuildUnstableVerifiedValue"
                                    value="${it.config.gerritBuildUnstableVerifiedValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Not Built}"
                              help="/plugin/gerrit-trigger/help-GerritBuildNotBuiltVerified.html">
                         <f:textbox name="gerritBuildNotBuiltVerifiedValue"
                                    value="${it.config.gerritBuildNotBuiltVerifiedValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <tr>
                         <td></td>
@@ -157,31 +157,31 @@
                              help="/plugin/gerrit-trigger/help-GerritBuildStartedCodeReview.html">
                         <f:textbox name="gerritBuildStartedCodeReviewValue"
                                    value="${it.config.gerritBuildStartedCodeReviewValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Successful}"
                              help="/plugin/gerrit-trigger/help-GerritBuildSuccessfulCodeReview.html">
                         <f:textbox name="gerritBuildSuccessfulCodeReviewValue"
                                    value="${it.config.gerritBuildSuccessfulCodeReviewValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Failed}"
                              help="/plugin/gerrit-trigger/help-GerritBuildFailedCodeReview.html">
                         <f:textbox name="gerritBuildFailedCodeReviewValue"
                                    value="${it.config.gerritBuildFailedCodeReviewValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Unstable}"
                              help="/plugin/gerrit-trigger/help-GerritBuildUnstableCodeReview.html">
                         <f:textbox name="gerritBuildUnstableCodeReviewValue"
                                    value="${it.config.gerritBuildUnstableCodeReviewValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                     <f:entry title="${%Not Built}"
                              help="/plugin/gerrit-trigger/help-GerritBuildNotBuiltCodeReview.html">
                         <f:textbox name="gerritBuildNotBuiltCodeReviewValue"
                                    value="${it.config.gerritBuildNotBuiltCodeReviewValue}"
-                                   checkUrl="'${rootURL}/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
+                                   checkUrl="'/${serverURL}/emptyOrIntegerCheck?value='+escape(this.value)"/>
                     </f:entry>
                 </f:section>
                 <f:advanced>
@@ -223,14 +223,14 @@
                             <f:textbox name="buildScheduleDelay"
                                        value="${it.config.buildScheduleDelay}"
                                        default="${com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_BUILD_SCHEDULE_DELAY}"
-                                       checkUrl="'${rootURL}/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"/>
+                                       checkUrl="'/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"/>
                         </f:entry>
                         <f:entry title="${%Dynamic Config Refresh Interval}"
                                  help="/plugin/gerrit-trigger/help-DynamicTriggerConfigRefreshInterval.html">
                             <f:textbox name="dynamicConfigRefreshInterval"
                                        value="${it.config.dynamicConfigRefreshInterval}"
                                        default="${com.sonyericsson.hudson.plugins.gerrit.gerritevents.GerritDefaultValues.DEFAULT_DYNAMIC_CONFIG_REFRESH_INTERVAL}"
-                                       checkUrl="'${rootURL}/${serverURL}/dynamicConfigRefreshCheck?value='+escape(this.value)"/>
+                                       checkUrl="'/${serverURL}/dynamicConfigRefreshCheck?value='+escape(this.value)"/>
                         </f:entry>
                         <f:entry title="${%Enable Manual Trigger}"
                                  help="/plugin/gerrit-trigger/help-EnableManualTrigger.html">
@@ -258,7 +258,7 @@
                                      <f:textbox name="projectListFetchDelay"
                                         value="${it.config.projectListFetchDelay}"
                                         default="${com.sonyericsson.gerrithudsontrigger.config.Config.DEFAULT_PROJECT_LIST_FETCH_DELAY}"
-                                        checkUrl="'${rootURL}/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"
+                                        checkUrl="'/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"
                                         style="max-width: 100px;"/>
                                 </div>
                             </div>
@@ -270,7 +270,7 @@
                                      <f:textbox name="projectListRefreshInterval"
                                         value="${it.config.projectListRefreshInterval}"
                                         default="${com.sonyericsson.gerrithudsontrigger.config.Config.DEFAULT_PROJECT_LIST_REFRESH_INTERVAL}"
-                                        checkUrl="'${rootURL}/${serverURL}/positiveIntegerCheck?value='+escape(this.value)"
+                                        checkUrl="'/${serverURL}/positiveIntegerCheck?value='+escape(this.value)"
                                         style="max-width: 100px;"/>
                                 </div>
                             </div>
@@ -362,7 +362,7 @@
                                                      help="/plugin/gerrit-trigger/help-ReplicationSlaveTimeout.html">
                                                 <f:textbox name="timeout"
                                                            value="${slave.timeoutInSeconds}"
-                                                           checkUrl="'${rootURL}/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"/>
+                                                           checkUrl="'/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"/>
                                             </f:entry>
                                             <f:entry title="">
                                                 <div align="right">
@@ -390,7 +390,7 @@
                                  help="/plugin/gerrit-trigger/help-ConnectionWatchdogTimeout.html">
                             <f:textbox name="watchdogTimeoutMinutes"
                                        value="${it.config.watchdogTimeoutMinutes}"
-                                       checkUrl="'${rootURL}/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"/>
+                                       checkUrl="'/${serverURL}/nonNegativeIntegerCheck?value='+escape(this.value)"/>
                         </f:entry>
                         <f:optionalBlock name="watchdogExceptions" title="${%Connection Watchdog Exceptions}" checked="${it.config.exceptionData.enabled}">
                             <f:entry title="${%Exception Days}"
@@ -423,7 +423,7 @@
                                             <td>
                                                 <f:textbox name="from"
                                                            value="${h.appendIfNotNull(t.from.hourAsString,'','00')}:${h.appendIfNotNull(t.from.minuteAsString,'','00')}"
-                                                           checkUrl="'${rootURL}/${serverURL}/validTimeCheck?fromValue='+escape(Form.findMatchingInput(this,'from').value)
+                                                           checkUrl="'/${serverURL}/validTimeCheck?fromValue='+escape(Form.findMatchingInput(this,'from').value)
                                                            +'&amp;toValue='+escape(Form.findMatchingInput(this, 'to').value)"/>
                                             </td>
                                         </tr>
@@ -434,7 +434,7 @@
                                             <td>
                                                 <f:textbox name="to"
                                                            value="${h.appendIfNotNull(t.to.hourAsString,'','00')}:${h.appendIfNotNull(t.to.minuteAsString,'','01')}"
-                                                           checkUrl="'${rootURL}/${serverURL}/validTimeCheck?fromValue='+escape(Form.findMatchingInput(this,'from').value)
+                                                           checkUrl="'/${serverURL}/validTimeCheck?fromValue='+escape(Form.findMatchingInput(this,'from').value)
                                                            +'&amp;toValue='+escape(Form.findMatchingInput(this, 'to').value)"/>
                                             </td>
                                         </tr>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/remove.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/remove.jelly
@@ -4,9 +4,9 @@
     <l:layout title="${%Remove Server}" norefresh="true">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/${it.parentUrl}/" title="${%Back to Server List}"/>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/${it.url}/" title="${%Back to Server Configuration}"/>
+                <l:task icon="images/24x24/up.gif" href="/" title="${%Back to Dashboard}"/>
+                <l:task icon="images/24x24/up.gif" href="/${it.parentUrl}/" title="${%Back to Server List}"/>
+                <l:task icon="images/24x24/up.gif" href="/${it.url}/" title="${%Back to Server Configuration}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>
@@ -24,7 +24,7 @@
                         <f:submit value="${%Yes}" />
                         <ul>
                             <j:forEach var="job" items="${it.configuredJobs}" varStatus="loop">
-                                <li> <a href="${rootURL}/${job.url}/configure"> ${job.name} </a> </li>
+                                <li> <a href="/${job.url}/configure"> ${job.name} </a> </li>
                             </j:forEach>
                         </ul>
                     </j:otherwise>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/BuildMemoryReport/index.groovy
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/BuildMemoryReport/index.groovy
@@ -41,8 +41,8 @@ DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFor
 l.layout(title: _("Build Coordination - Gerrit Trigger Diagnostics"), norefresh: false, permission: Diagnostics.requiredPermission) {
     l.'side-panel' {
         l.tasks {
-            l.task(icon: "images/24x24/up.gif", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
-            l.task(icon: "icon-folder icon-md", href: "${rootURL}/${GerritManagement.URL_NAME}/diagnostics", title: _("Back to Diagnostics"))
+            l.task(icon: "images/24x24/up.gif", href: "/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
+            l.task(icon: "icon-folder icon-md", href: "/${GerritManagement.URL_NAME}/diagnostics", title: _("Back to Diagnostics"))
         }
     }
     l.'main-panel' {
@@ -71,14 +71,14 @@ l.layout(title: _("Build Coordination - Gerrit Trigger Diagnostics"), norefresh:
                         Run run = entry.build
                         td(headers: "hJob ${eventHeaderId}") {
                             if (job != null) {
-                                a(href: "${rootURL}/${job.url}", job.fullDisplayName)
+                                a(href: "/${job.url}", job.fullDisplayName)
                             } else {
                                 raw("&nbsp;")
                             }
                         }
                         td(headers: "hRun ${eventHeaderId}") {
                             if (run != null) {
-                                a(href: "${rootURL}/${run.url}", run.displayName)
+                                a(href: "/${run.url}", run.displayName)
                             } else {
                                 raw("&nbsp;")
                             }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/Diagnostics/index.groovy
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/Diagnostics/index.groovy
@@ -34,7 +34,7 @@ def l = namespace(lib.LayoutTagLib)
 l.layout(title: _("Gerrit Trigger Diagnostics"), norefresh: false, permission: Diagnostics.requiredPermission) {
     l.'side-panel' {
         l.tasks {
-            l.task(icon: "images/24x24/up.gif", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
+            l.task(icon: "images/24x24/up.gif", href: "/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
             l.task(icon: "icon-clipboard icon-md", href: "buildMemory", title: Messages.BuildMemoryReport_DisplayName())
             l.task(icon: "icon-clipboard icon-md", href: "eventListeners", title: Messages.EventListenersReport_DisplayName())
             if (diag.isDebugMode()) {

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/EventListenersReport/index.groovy
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/EventListenersReport/index.groovy
@@ -76,8 +76,8 @@ l.layout(title: _("${report.getDisplayName()} - Gerrit Trigger Diagnostics"), no
 
     l.'side-panel' {
         l.tasks {
-            l.task(icon: "images/24x24/up.gif", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
-            l.task(icon: "icon-folder icon-md", href: "${rootURL}/${GerritManagement.URL_NAME}/diagnostics", title: _("Back to Diagnostics"))
+            l.task(icon: "images/24x24/up.gif", href: "/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
+            l.task(icon: "icon-folder icon-md", href: "/${GerritManagement.URL_NAME}/diagnostics", title: _("Back to Diagnostics"))
         }
     }
     l.'main-panel' {
@@ -98,7 +98,7 @@ l.layout(title: _("${report.getDisplayName()} - Gerrit Trigger Diagnostics"), no
                 tr {
                     td {
                         if (job != null) {
-                            a(href: "${rootURL}/${job.shortUrl}", job.getFullDisplayName())
+                            a(href: "/${job.shortUrl}", job.getFullDisplayName())
                         } else {
                             span(_("_unknown"))
                         }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction/badge.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction/badge.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
     <a href="${it.url}" target="_new">
-        <img src="${rootURL}/plugin/gerrit-trigger/images/icon16.png" border="0"/> ${it.text}
+        <img src="/plugin/gerrit-trigger/images/icon16.png" border="0"/> ${it.text}
     </a>
 </j:jelly>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.jelly
@@ -4,20 +4,20 @@
         <j:when test="${it.manuallyTriggered}">
             <j:choose>
                 <j:when test="${it.silentMode}">
-                    ${%ManuallyTriggeredShortDescriptionInSilentMode(it.url,it.userName,rootURL)}
+                    ${%ManuallyTriggeredShortDescriptionInSilentMode(it.url,it.userName)}
                 </j:when>
                 <j:otherwise>
-                    ${%ManuallyTriggeredShortDescription(it.url,it.userName,rootURL)}
+                    ${%ManuallyTriggeredShortDescription(it.url,it.userName)}
                 </j:otherwise>
             </j:choose>
         </j:when>
         <j:when test="${it.getUserName() != null}">
             <j:choose>
                 <j:when test="${it.silentMode}">
-                    ${%ReTriggeredShortDescriptionInSilentMode(it.url,it.userName,rootURL)}
+                    ${%ReTriggeredShortDescriptionInSilentMode(it.url,it.userName)}
                 </j:when>
                 <j:otherwise>
-                    ${%ReTriggeredShortDescription(it.url,it.userName,rootURL)}
+                    ${%ReTriggeredShortDescription(it.url,it.userName)}
                 </j:otherwise>
             </j:choose>
         </j:when>
@@ -47,9 +47,9 @@
                                 <img src="${imagesURL}/16x16/${other.build.iconColor.image}"/>
                             </td>
                             <td>
-                                <a href="${rootURL}/${other.project.url}">${other.project.displayName}</a>
+                                <a href="/${other.project.url}">${other.project.displayName}</a>
                                 <st:nbsp/><st:nbsp/>
-                                <a href="${rootURL}/${other.build.url}">${other.build.displayName}</a>
+                                <a href="/${other.build.url}">${other.build.displayName}</a>
                             </td>
                         </j:when>
                         <j:otherwise>
@@ -57,7 +57,7 @@
                                 <img src="${imagesURL}/16x16/grey_anime.gif"/>
                             </td>
                             <td>
-                                <a href="${rootURL}/${other.project.url}">${other.project.displayName}</a>
+                                <a href="/${other.project.url}">${other.project.displayName}</a>
                             </td>
                         </j:otherwise>
                     </j:choose>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.properties
@@ -3,12 +3,12 @@ TriggeredShortDescription=\
 TriggeredShortDescriptionInSilentMode=\
   Triggered by Gerrit: <a href="{0}" target="_new">{0}</a> <i>in silent mode.</i>
 ReTriggeredShortDescription=\
-  Retriggered by user <a href="{2}/user/{1}">{1}</a> for Gerrit: <a href="{0}" target="_new">{0}</a>
+  Retriggered by user <a href="/user/{1}">{1}</a> for Gerrit: <a href="{0}" target="_new">{0}</a>
 ReTriggeredShortDescriptionInSilentMode=\
-  Retriggered by user <a href="{2}/user/{1}">{1}</a> for Gerrit: <a href="{0}" target="_new">{0}</a> <i>in silent mode.</i>
+  Retriggered by user <a href="/user/{1}">{1}</a> for Gerrit: <a href="{0}" target="_new">{0}</a> <i>in silent mode.</i>
 ManuallyTriggeredShortDescription=\
-  Manually triggered by user <a href="{2}/user/{1}">{1}</a> for Gerrit: <a href="{0}" target="_new">{0}</a>
+  Manually triggered by user <a href="/user/{1}">{1}</a> for Gerrit: <a href="{0}" target="_new">{0}</a>
 ManuallyTriggeredShortDescriptionInSilentMode=\
-  Manually triggered by user <a href="{2}/user/{1}">{1}</a> for Gerrit: <a href="{0}" target="_new">{0}</a> <i>in silent mode.</i>
+  Manually triggered by user <a href="/user/{1}">{1}</a> for Gerrit: <a href="{0}" target="_new">{0}</a> <i>in silent mode.</i>
 OtherTriggeredBuilds=\
   Other triggered builds for this event.

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/ajaxTriggerMonitor.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/ajaxTriggerMonitor.jelly
@@ -34,7 +34,7 @@
                     </td>
                     <td colspan="2" style="font-weight: bold;">
                         <a href="${it.getGerritUrl(state.event)}" target="_new">
-                            <img src="${rootURL}/plugin/gerrit-trigger/images/icon16.png" border="0"/>
+                            <img src="/plugin/gerrit-trigger/images/icon16.png" border="0"/>
                             ${state.event.change.number},${state.event.patchSet.number}
                         </a>
                     </td>
@@ -59,10 +59,10 @@
                                             <img src="${imagesURL}/16x16/${build.build.iconColor.image}"/>
                                         </td>
                                         <td>
-                                            <a href="${rootURL}/${build.project.url}">${build.project.displayName}</a>
+                                            <a href="/${build.project.url}">${build.project.displayName}</a>
                                             <st:nbsp/>
                                             <st:nbsp/>
-                                            <a href="${rootURL}/${build.build.url}">${build.build.displayName}</a>
+                                            <a href="/${build.build.url}">${build.build.displayName}</a>
                                         </td>
                                     </j:when>
                                     <j:otherwise>
@@ -70,7 +70,7 @@
                                             <img src="${imagesURL}/16x16/grey_anime.gif"/>
                                         </td>
                                         <td>
-                                            <a href="${rootURL}/${build.project.url}">${build.project.displayName}</a>
+                                            <a href="/${build.project.url}">${build.project.displayName}</a>
                                         </td>
                                     </j:otherwise>
                                 </j:choose>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
@@ -3,7 +3,7 @@
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <l:layout title="${%Gerrit Manual trigger}" norefresh="true" permission="${it.requiredPermission}">
         <l:header>
-            <script src="${rootURL}${it.getJsUrl('gerrit-search.js')}" type="text/javascript"></script>
+            <script src="/${it.getJsUrl('gerrit-search.js')}" type="text/javascript"></script>
             <style type="text/css">
                 tr.disablehover:hover {
                 background-color: white;
@@ -12,7 +12,7 @@
         </l:header>
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="images/24x24/up.gif" href="/" title="${%Back to Dashboard}"/>
             </l:tasks>
             <j:if test="${!empty(request.session.getAttribute('trigger_monitor'))}">
                 <st:include page="ajaxTriggerMonitor.jelly"/>
@@ -108,9 +108,9 @@
                                             <td class="pane-header">${%R}</td>
                                         </tr>
                                         <j:set var="collapsedImg"
-                                               value="${rootURL}/plugin/gerrit-trigger/images/collapsed.gif"/>
+                                               value="/plugin/gerrit-trigger/images/collapsed.gif"/>
                                         <j:set var="expandedImg"
-                                               value="${rootURL}/plugin/gerrit-trigger/images/expanded.gif"/>
+                                               value="/plugin/gerrit-trigger/images/expanded.gif"/>
                                         <j:forEach var="res" items="${result}">
                                             <j:if test="${!res.has('type')}">
                                                 <j:forEach var="patch" items="${res.getJSONArray('patchSets')}">
@@ -186,11 +186,11 @@
                                                             <j:set var="v" value="${it.getVerified(res, patch.getInt('number'))}"/>
                                                             <j:choose>
                                                                 <j:when test="${v.low &lt; 0}">
-                                                                    <img src="${rootURL}/plugin/gerrit-trigger/images/x.gif"
+                                                                    <img src="/plugin/gerrit-trigger/images/x.gif"
                                                                          alt="${v.low}"/>
                                                                 </j:when>
                                                                 <j:when test="${v.low &gt; 0}">
-                                                                    <img src="${rootURL}/plugin/gerrit-trigger/images/v.gif"
+                                                                    <img src="/plugin/gerrit-trigger/images/v.gif"
                                                                          alt="${v.low}"/>
                                                                 </j:when>
                                                                 <j:otherwise>
@@ -203,11 +203,11 @@
                                                             <j:set var="v" value="${it.getCodeReview(res, patch.getInt('number'))}"/>
                                                             <j:choose>
                                                                 <j:when test="${v.low &lt; -1}">
-                                                                    <img src="${rootURL}/plugin/gerrit-trigger/images/x.gif"
+                                                                    <img src="/plugin/gerrit-trigger/images/x.gif"
                                                                          alt="${v.low}"/>
                                                                 </j:when>
                                                                 <j:when test="${v.high &gt; 1}">
-                                                                    <img src="${rootURL}/plugin/gerrit-trigger/images/v.gif"
+                                                                    <img src="/plugin/gerrit-trigger/images/v.gif"
                                                                          alt="${v.high}"/>
                                                                 </j:when>
                                                                 <j:when test="${v.low &lt; 0}">


### PR DESCRIPTION
Time to time we raise Jenkins master on the host with existing master (for testing or release updates) and keep root url the same. In this setup it becomes a really tricky to configure Gerrit :)