### PR TITLE
Reliable dependency magic

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/BecauseDependentBuildIsBuilding.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/BecauseDependentBuildIsBuilding.java
@@ -46,6 +46,6 @@ public class BecauseDependentBuildIsBuilding extends CauseOfBlockage {
 
     @Override
     public String getShortDescription() {
-        return Messages.DependentBuildIsBuilding(blockingProject);
+        return Messages.DependentBuildIsBuilding(blockingProject.getFullDisplayName());
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -936,7 +936,7 @@ public class GerritTrigger extends Trigger<Job> {
      * @param event the event
      * @return true if we should.
      */
-    /*package*/ boolean isInteresting(GerritTriggeredEvent event) {
+    public boolean isInteresting(GerritTriggeredEvent event) {
         if (!job.isBuildable()) {
             logger.trace("Disabled.");
             return false;

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -147,7 +147,7 @@ Replication of {0} to {1} failed.
 AbortedByNewPatchSet=\
   Aborted by new patch set.
 DependentBuildIsBuilding=\
-  Waiting for dependant jobs {0} to complete.
+  Waiting for dependant job {0} to complete.
 AddingDependentProjectWouldCreateLoop=\
   Adding project {0} as a dependency will create a loop because {1} already depends on this project.
 CannotAddSelfAsDependency=\


### PR DESCRIPTION
If triggering new jobs takes a lot of time ( > 3 seconds), it's possible to hit the race condition between parent-child.

To avoid it I added explicit check just before allowing job to be executed.