### PR TITLE
Change the order of Unstable and Failure custom messages

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -166,14 +166,14 @@
                          help="/plugin/gerrit-trigger/trigger/help-BuildSuccessfulMessage.html">
                    <f:textarea/>
                 </f:entry>
-                <f:entry title="${%Build Unstable Message}"
-                         field="buildUnstableMessage"
-                         help="/plugin/gerrit-trigger/trigger/help-BuildUnstableMessage.html">
-                   <f:textarea/>
-                </f:entry>
                 <f:entry title="${%Build Failure Message}"
                          field="buildFailureMessage"
                          help="/plugin/gerrit-trigger/trigger/help-BuildFailureMessage.html">
+                   <f:textarea/>
+                </f:entry>
+                <f:entry title="${%Build Unstable Message}"
+                         field="buildUnstableMessage"
+                         help="/plugin/gerrit-trigger/trigger/help-BuildUnstableMessage.html">
                    <f:textarea/>
                 </f:entry>
                 <f:entry title="${%Build Not Built Message}"


### PR DESCRIPTION
The order in the global configuration and reporting values is
Started-Successful-Failed-Unstable-Not Built
In Custom Build Messages there is swapped Filed and Unstable