### PR TITLE
Check that server is not null before doing the check

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackEnabledChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackEnabledChecker.java
@@ -67,8 +67,12 @@ public class GerritMissedEventsPlaybackEnabledChecker extends AsyncPeriodicWork 
     protected void execute(TaskListener listener) throws IOException, InterruptedException {
         List<GerritServer> servers = PluginImpl.getServers_();
         for (GerritServer gs: servers) {
-            logger.debug("Performing plugin check for server: {0}", gs.getName());
-            gs.getMissedEventsPlaybackManager().performCheck();
+            if (gs != null && gs.getMissedEventsPlaybackManager() != null) {
+                logger.debug("Performing plugin check for server: {0}", gs.getName());
+                gs.getMissedEventsPlaybackManager().performCheck();
+            } else {
+                logger.debug("Skip plugin check, because server is not completely initialised");
+            }
         }
     }
 


### PR DESCRIPTION
During Jenkins initialization it's possible to hit the case when GerritMissedEventsPlaybackEnabledChecker is already ready and scheduled, but GerritServer construction is not finished yet.

It leads to something really scare:
```java
Jan 09, 2018 6:57:24 AM hudson.model.AsyncPeriodicWork$1 run
INFO: Started GerritMissedEventsPlaybackEnabledChecker
Jan 09, 2018 6:57:24 AM hudson.init.impl.InstallUncaughtExceptionHandler$DefaultUncaughtExceptionHandler uncaughtException
SEVERE: A thread (GerritMissedEventsPlaybackEnabledChecker thread/201) died unexpectedly due to an uncaught exception, this may leave your Jenkins in a bad way and is usually indicative of a bug in the code.
java.lang.NullPointerException at com.sonyericsson.hudson.plugins.gerrit.trigger.playback.GerritMissedEventsPlaybackEnabledChecker.execute(GerritMissedEventsPlaybackEnabledChecker.java:71)
                at hudson.model.AsyncPeriodicWork$1.run(AsyncPeriodicWork.java:101)
                at java.lang.Thread.run(Thread.java:748)
```


p.s. Happy New Year @rsandell! And thank you for maintaining this plugin and your help with getting things done :)