### PR TITLE
Check that job is not null before starting to process event

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -937,6 +937,11 @@ public class GerritTrigger extends Trigger<Job> {
      * @return true if we should.
      */
     public boolean isInteresting(GerritTriggeredEvent event) {
+        if (job == null) {
+            logger.trace("Job is not fully initialised.");
+            return false;
+        }
+
         if (!job.isBuildable()) {
             logger.trace("Disabled.");
             return false;


### PR DESCRIPTION
During job creation process there is a short window then GerritTrigger
does not have valid refecence to job it belongs to.

```java
Jan 22, 2018 10:09:45 AM com.sonymobile.tools.gerrit.gerritevents.GerritHandler notifyListeners
SEVERE: When notifying listener: com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.EventListener@a63d3ad0 about event: RefReplicated [project=XXX, ref=refs/heads/master, status=succeeded, targetNode=YYY]
Jan 22, 2018 10:09:45 AM com.sonymobile.tools.gerrit.gerritevents.GerritHandler notifyListeners
SEVERE: Notify-error: 
java.lang.NullPointerException
        at com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger.isInteresting(GerritTrigger.java:939)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.EventListener.gerritEvent(EventListener.java:114)
        at com.sonymobile.tools.gerrit.gerritevents.GerritHandler.notifyListener(GerritHandler.java:328)
        at com.sonymobile.tools.gerrit.gerritevents.GerritHandler.notifyListeners(GerritHandler.java:296)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.JenkinsAwareGerritHandler.notifyListeners(JenkinsAwareGerritHandler.java:77)
        at com.sonymobile.tools.gerrit.gerritevents.workers.AbstractGerritEventWork.perform(AbstractGerritEventWork.java:46)
        at com.sonymobile.tools.gerrit.gerritevents.workers.AbstractJsonObjectWork.perform(AbstractJsonObjectWork.java:77)
        at com.sonymobile.tools.gerrit.gerritevents.workers.StreamEventsStringWork.perform(StreamEventsStringWork.java:67)
        at com.sonymobile.tools.gerrit.gerritevents.workers.EventThread.run(EventThread.java:66)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.SystemEventThread.run(SystemEventThread.java:66)
```