### PR TITLE
Follow general contract of comparison method

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -743,6 +743,10 @@ public class ParameterExpander {
                 } else {
                     return o1 - o2;
                 }
+            } else if (b1 != null) {
+                return 1;
+            } else if (b2 != null) {
+                return -1;
             }
             return 0;
         }


### PR DESCRIPTION
Old implemenation did not respect transitive requirement of comparison
method. I.e.:
  If A == B and B == C, then A must be equal to C.

So, in old implementation if B is null, first two checks return true, but it does not gurantee that A == C.

That leads to:

```java
Jan 22, 2018 11:04:58 AM com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.GerritNotifier buildCompleted
SEVERE: Could not complete BuildCompleted notification!
java.lang.IllegalArgumentException: Comparison method violates its general contract!
        at java.util.TimSort.mergeHi(TimSort.java:899)
        at java.util.TimSort.mergeAt(TimSort.java:516)
        at java.util.TimSort.mergeForceCollapse(TimSort.java:457)
        at java.util.TimSort.sort(TimSort.java:254)
        at java.util.Arrays.sort(Arrays.java:1438)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ParameterExpander.createBuildsStats(ParameterExpander.java:798)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ParameterExpander.getBuildCompletedCommand(ParameterExpander.java:768)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ParameterExpander.fillOnCompletedParams(ParameterExpander.java:704)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.ParameterExpander.getBuildCompletedCommands(ParameterExpander.java:670)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.GerritNotifier.buildCompleted(GerritNotifier.java:121)
        at com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.ssh.BuildCompletedCommandJob.run(BuildCompletedCommandJob.java:71)
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
        at java.util.concurrent.FutureTask.run(FutureTask.java:266)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
```