### PR TITLE
[JENKINS-39498] Stop panicking about "eventCreatedOn" and losing my position

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -152,8 +152,13 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Na
     public void checkIfEventsLogPluginSupported() {
         GerritServer server = PluginImpl.getServer_(serverName);
         if (server != null && server.getConfig() != null) {
-            isSupported = GerritPluginChecker.isPluginEnabled(
-                    server.getConfig(), EVENTS_LOG_PLUGIN_NAME, true);
+            Boolean newValue = GerritPluginChecker.isPluginEnabled(server.getConfig(), EVENTS_LOG_PLUGIN_NAME, true);
+            if (newValue == null) {
+                logger.warn("Could not determine plugin support for " + EVENTS_LOG_PLUGIN_NAME
+                    + "; leaving status as " + String.valueOf(isSupported));
+            } else {
+                isSupported = newValue;
+            }
         }
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -451,19 +451,16 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Na
      * @return true if was able to persist event.
      */
     synchronized boolean persist(GerritTriggeredEvent evt) {
-
+        // If there is not timestamp, then ignore this event.
         if (evt == null || evt.getEventCreatedOn() == null) {
-            logger.warn("Event CreatedOn is null...Gerrit Server might not support attribute eventCreatedOn. "
-                    + "Will NOT persist this event and Missed Events will be disabled!");
-            isSupported = false;
+            logger.debug("'eventCreatedOn' is null; skipping event.");
             return false;
         }
 
         long ts = evt.getEventCreatedOn().getTime();
+        // If the timestamp is invalid, then ignore this event.
         if (ts == 0) {
-            logger.warn("Event CreatedOn is 0...Gerrit Server does not support attribute eventCreatedOn. "
-                    + "Will NOT persist this event and Missed Events will be disabled!");
-            isSupported = false;
+            logger.debug("'eventCreatedOn' is 0; skipping event.");
             return false;
         }
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManagerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManagerTest.java
@@ -340,7 +340,6 @@ public class GerritMissedEventsPlaybackManagerTest {
     @Test
     public void testInitialSupportedState() {
        // Option 1a: not supported
-       PowerMockito.mockStatic(GerritPluginChecker.class);
        PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
                , anyString(), anyBoolean())).thenReturn(false);
 
@@ -349,7 +348,6 @@ public class GerritMissedEventsPlaybackManagerTest {
         Assert.assertFalse("isSupported should be false", missingEventsPlaybackManager.isSupported());
 
        // Option 1b: not supported
-       PowerMockito.mockStatic(GerritPluginChecker.class);
        PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
                , anyString(), anyBoolean())).thenReturn(null);
 
@@ -358,7 +356,6 @@ public class GerritMissedEventsPlaybackManagerTest {
         Assert.assertFalse("isSupported should be false", missingEventsPlaybackManager.isSupported());
 
        // Option 2: supported
-       PowerMockito.mockStatic(GerritPluginChecker.class);
        PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
                , anyString(), anyBoolean())).thenReturn(true);
 
@@ -373,7 +370,6 @@ public class GerritMissedEventsPlaybackManagerTest {
      */
     @Test
     public void testStateOnlyChangesWhenValid() {
-       PowerMockito.mockStatic(GerritPluginChecker.class);
        PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
                , anyString(), anyBoolean())).thenReturn(false);
 
@@ -381,14 +377,12 @@ public class GerritMissedEventsPlaybackManagerTest {
                 = new GerritMissedEventsPlaybackManager("defaultServer");
         Assert.assertFalse("isSupported should be false", missingEventsPlaybackManager.isSupported());
 
-        PowerMockito.mockStatic(GerritPluginChecker.class);
         PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
                 , anyString(), anyBoolean())).thenReturn(true);
 
         missingEventsPlaybackManager.checkIfEventsLogPluginSupported();
         Assert.assertTrue("isSupported should be true", missingEventsPlaybackManager.isSupported());
 
-        PowerMockito.mockStatic(GerritPluginChecker.class);
         PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
                 , anyString(), anyBoolean())).thenReturn(null);
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManagerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManagerTest.java
@@ -155,7 +155,6 @@ public class GerritMissedEventsPlaybackManagerTest {
         PowerMockito.mockStatic(GerritPluginChecker.class);
         PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
                 , anyString(), anyBoolean())).thenReturn(true);
-
     }
 
     /**
@@ -335,4 +334,65 @@ public class GerritMissedEventsPlaybackManagerTest {
 
     }
 
+    /**
+     * This tests that the initial `isSupported` state is false.
+     */
+    @Test
+    public void testInitialSupportedState() {
+       // Option 1a: not supported
+       PowerMockito.mockStatic(GerritPluginChecker.class);
+       PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
+               , anyString(), anyBoolean())).thenReturn(false);
+
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        Assert.assertFalse("isSupported should be false", missingEventsPlaybackManager.isSupported());
+
+       // Option 1b: not supported
+       PowerMockito.mockStatic(GerritPluginChecker.class);
+       PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
+               , anyString(), anyBoolean())).thenReturn(null);
+
+        missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        Assert.assertFalse("isSupported should be false", missingEventsPlaybackManager.isSupported());
+
+       // Option 2: supported
+       PowerMockito.mockStatic(GerritPluginChecker.class);
+       PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
+               , anyString(), anyBoolean())).thenReturn(true);
+
+        missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        Assert.assertTrue("isSupported should be true", missingEventsPlaybackManager.isSupported());
+    }
+
+    /**
+     * This tests that the supported state does not change if GerritPluginChecker
+     * cannot determine the state successfully.
+     */
+    @Test
+    public void testStateOnlyChangesWhenValid() {
+       PowerMockito.mockStatic(GerritPluginChecker.class);
+       PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
+               , anyString(), anyBoolean())).thenReturn(false);
+
+        GerritMissedEventsPlaybackManager missingEventsPlaybackManager
+                = new GerritMissedEventsPlaybackManager("defaultServer");
+        Assert.assertFalse("isSupported should be false", missingEventsPlaybackManager.isSupported());
+
+        PowerMockito.mockStatic(GerritPluginChecker.class);
+        PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
+                , anyString(), anyBoolean())).thenReturn(true);
+
+        missingEventsPlaybackManager.checkIfEventsLogPluginSupported();
+        Assert.assertTrue("isSupported should be true", missingEventsPlaybackManager.isSupported());
+
+        PowerMockito.mockStatic(GerritPluginChecker.class);
+        PowerMockito.when(GerritPluginChecker.isPluginEnabled((IGerritHudsonTriggerConfig)anyObject()
+                , anyString(), anyBoolean())).thenReturn(null);
+
+        missingEventsPlaybackManager.checkIfEventsLogPluginSupported();
+        Assert.assertTrue("isSupported should be true", missingEventsPlaybackManager.isSupported());
+    }
 }


### PR DESCRIPTION
Premise:

When a lot of changes come in within a few seconds of each other, our Jenkins instance would "miss" some of those events.  As far as I can tell, Jenkins somehow received an event with no "eventCreatedOn" timestamp (which is strange because Gerrit never sent such an event, but which may be caused if the event processor receives a null event), which then caused this plugin to switch to "unsupported" mode, deleting the XML flatfile where it tracks which events have been handled.  Almost immediately afterward, the plugin would surprisingly determine that "eventCreatedOn" was being sent, switch to "supported" mode, and be on its merry way.  However, those few events in that window were lost, and my people would send me messages about their change requests not being verified.

This patch:

As far as I can tell, the original code was overly concerned with ever possibly processing an event without "eventCreatedOn", so much so that the _event processing code_ would switch the plugin to "unsupported" mode and then reject the event.

These changes simply remove mode-change ability from the event processing code.  That code should process events, not make configuration changes to the plugin's state.  If an event happens to be received that is missing "eventCreatedOn" (or if an event is passed in that's null for whatever reason), then that event is simply skipped.

In addition, I updated the function that checks for the "events-log" plugin in Gerrit.  Instead of returning true or false, it can now return null when it doesn't know.  This is helpful for situations where Jenkins loses connectivity to Gerrit.  Instead of changing the state of the plugin, this will now merely persist the existing state if a new state cannot be determined.

Edit:
Here's the Jira ticket that was referenced: https://issues.jenkins-ci.org/browse/JENKINS-39498