### PR TITLE
Print the list of triggered builds in user-friendly order

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContext.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContext.java
@@ -265,4 +265,36 @@ public class TriggerContext {
         }
         return list;
     }
+
+    /**
+     * Gets all the other entities in the most user friendly order.
+     *      on-going builds
+     *      already finished builds
+     *      builds without build number
+     *
+     * @return a sorted list of entities from this context.
+     */
+    public synchronized List<TriggeredItemEntity> getSortedOthers() {
+        int lastBuilding = 0;
+        LinkedList<TriggeredItemEntity> result = new LinkedList<TriggeredItemEntity>();
+        if (others != null) {
+            for (TriggeredItemEntity entity : others) {
+                Run build = entity.getBuild();
+                if (build != null) {
+                    if (build.isBuilding()) {
+                        result.addFirst(entity);
+                        lastBuilding++;
+                    } else {
+                        result.add(lastBuilding, entity);
+                    }
+                } else {
+                    if (entity.getProject() != null) {
+                        result.addLast(entity);
+                    }
+                }
+            }
+        }
+
+        return result;
+    }
 }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.jelly
@@ -39,7 +39,7 @@
                     ${%OtherTriggeredBuilds}
                 </th>
             </tr>
-            <j:forEach items="${it.context.others}" var="other">
+            <j:forEach items="${it.context.getSortedOthers()}" var="other">
                 <tr>
                     <j:choose>
                         <j:when test="${other.hasBuild()}">

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextTest.java
@@ -322,4 +322,39 @@ public class TriggerContextTest {
         assertEquals(3, others.get(0).getNumber());
     }
 
+    /**
+     * Test of getSortedOthers method with no others, of class TriggerContext.
+     * With a list of "others" containing several builds in different stage.
+     */
+    @Test
+    public void testGetSortedOthers() {
+        AbstractBuild buildInProgress0 = mockBuild("p0", 1);
+        when(buildInProgress0.isBuilding()).thenReturn(true);
+
+        AbstractBuild buildInProgress1 = mockBuild("p1", 1);
+        when(buildInProgress1.isBuilding()).thenReturn(true);
+
+        AbstractProject project = mockProject("p7");
+        when(project.getBuildByNumber(777)).thenReturn(null);
+        TriggeredItemEntity itemWithNullBuild = new TriggeredItemEntity(project);
+        itemWithNullBuild.setBuildNumber(777);
+
+        List<TriggeredItemEntity> bah = new LinkedList<TriggeredItemEntity>();
+        bah.add(new TriggeredItemEntity(mockBuild("p4", 1)));
+        bah.add(new TriggeredItemEntity(mockProject("p5")));
+        bah.add(new TriggeredItemEntity(buildInProgress1));
+        bah.add(new TriggeredItemEntity(mockBuild("p3", 1)));
+        bah.add(new TriggeredItemEntity(mockProject("p6")));
+        bah.add(new TriggeredItemEntity(mockBuild("p2", 1)));
+        bah.add(itemWithNullBuild);
+        bah.add(new TriggeredItemEntity(buildInProgress0));
+
+        TriggerContext context = new TriggerContext(mockBuild("p", 1), null, bah);
+        List<TriggeredItemEntity> others = context.getSortedOthers();
+        assertNotNull(others);
+        assertEquals(8, others.size());
+        for (int i = 0; i < others.size(); i++) {
+            assertEquals("p" + i, others.get(i).getProjectId());
+        }
+    }
 }


### PR DESCRIPTION
Previous implementation showed list in same order as elements were added
to context. But in case of many jobs it makes harder for user to find
the actual ongoing build.