### PR TITLE
[JENKINS-49163] Create correct url in Diagnotic Event Listeners report for jobs located in folders

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/EventListenersReport/index.groovy
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/EventListenersReport/index.groovy
@@ -98,7 +98,7 @@ l.layout(title: _("${report.getDisplayName()} - Gerrit Trigger Diagnostics"), no
                 tr {
                     td {
                         if (job != null) {
-                            a(href: "${rootURL}/${job.shortUrl}", job.getFullDisplayName())
+                            a(href: "${rootURL}/${job.url}", job.getFullDisplayName())
                         } else {
                             span(_("_unknown"))
                         }


### PR DESCRIPTION
Fixes [JENKINS-49163](https://issues.jenkins-ci.org/browse/JENKINS-49163)