### PR TITLE
Add option to include matrix results in message

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -37,6 +37,8 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Notify;
 
 import edu.umd.cs.findbugs.annotations.CheckForNull;
+import hudson.matrix.MatrixBuild;
+import hudson.matrix.MatrixRun;
 import hudson.model.Result;
 import hudson.model.Run;
 import hudson.model.TaskListener;
@@ -642,6 +644,22 @@ public class ParameterExpander {
                             if (extensionMessage != null) {
                                 str.append("\n\n").append(extensionMessage);
                             }
+                        }
+                    }
+
+                    if (build instanceof MatrixBuild && trigger.getIncludeMatrixResults()) {
+                        for (MatrixRun childBuild : ((MatrixBuild)build).getRuns()) {
+                            Result childResult = childBuild.getResult();
+
+                            if (childResult == null) {
+                                childResult = Result.NOT_BUILT;
+                            }
+
+                            str.append("\n\n");
+                            str.append("\\__ ");
+                            str.append(rootUrl).append(childBuild.getUrl());
+                            str.append(MESSAGE_DELIMITER);
+                            str.append(childResult.toString());
                         }
                     }
                 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -71,6 +71,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Notify;
 import hudson.Extension;
 import hudson.ExtensionList;
 import hudson.Util;
+import hudson.matrix.MatrixProject;
 import hudson.model.AbstractProject;
 import hudson.model.Action;
 import hudson.model.AutoCompletionCandidates;
@@ -173,6 +174,7 @@ public class GerritTrigger extends Trigger<Job> {
     private String buildUnstableMessage;
     private String buildNotBuiltMessage;
     private String buildUnsuccessfulFilepath;
+    private boolean includeMatrixResults;
     private String customUrl;
     private String serverName;
     private String gerritSlaveId;
@@ -1333,6 +1335,26 @@ public class GerritTrigger extends Trigger<Job> {
     }
 
     /**
+     * Whether the build results of MatrixBuild children will be included in the results posted to Gerrit.
+     *
+     * @return whether matrix results are included or not
+     */
+    public boolean getIncludeMatrixResults() {
+        return includeMatrixResults;
+    }
+
+    /**
+     * Sets whether the build results of MatrixBuild children should be included in the results posted to Gerrit.
+     *
+     * @param includeMatrixResults
+     *         whether matrix results should be included or not
+     */
+    @DataBoundSetter
+    public void setIncludeMatrixResults(boolean includeMatrixResults) {
+        this.includeMatrixResults = includeMatrixResults;
+    }
+
+    /**
      * Getter for the triggerOnEvents list.
      * @return the list.
      */
@@ -1898,6 +1920,16 @@ public class GerritTrigger extends Trigger<Job> {
          */
         public boolean isUnsuccessfulMessageFileSupported(Job job) {
             return job instanceof AbstractProject;
+        }
+
+        /**
+         * Checks if the provided job is a {@link MatrixProject}.
+         *
+         * @param job the job to check.
+         * @return true if so.
+         */
+        public boolean isMatrixProject(Job job) {
+            return job instanceof MatrixProject;
         }
 
         /**

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -188,6 +188,14 @@
                         <f:textbox/>
                     </f:entry>
                 </j:if>
+                <j:if test="${descriptor.isMatrixProject(it)}">
+                    <f:entry title="${%Include Matrix Results}"
+                             field="includeMatrixResults"
+                             help="/plugin/gerrit-trigger/trigger/help-IncludeMatrixResults.html">
+                        <f:checkbox name="includeMatrixResults"
+                                    checked="${it.includeMatrixResults}"/>
+                    </f:entry>
+                </j:if>
             </f:section>
         </f:advanced>
 

--- a/src/main/webapp/trigger/help-IncludeMatrixResults.html
+++ b/src/main/webapp/trigger/help-IncludeMatrixResults.html
@@ -1,0 +1,17 @@
+Controls whether the results of individual child builds from matrix jobs
+get included in the build message that is sent back to Gerrit.<br/>
+<br/>
+<b>Example message:</b>
+<pre>
+Build Successful
+
+http://jenkins/job/MyJob/1/ : SUCCESS
+
+\__ http://jenkins/job/MyJob/Axis1=one,Axis2=A/1/ : SUCCESS
+
+\__ http://jenkins/job/MyJob/Axis1=one,Axis2=B/1/ : SUCCESS
+
+\__ http://jenkins/job/MyJob/Axis1=two,Axis2=A/1/ : SUCCESS
+
+\__ http://jenkins/job/MyJob/Axis1=two,Axis2=B/1/ : SUCCESS
+<pre>


### PR DESCRIPTION
Add an option to matrix jobs that will include the build results of all
child builds in the final build result message that is sent to Gerrit.
The option can be found in Matrix Job -> Gerrit Trigger -> Advanced ->
Include Matrix Results. This option will probably produce too much
output with large matrices, but can be very useful with smaller ones.