### PR TITLE
Add proxy to avoid too much connections

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/DynamicConfigurationCacheProxy.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/DynamicConfigurationCacheProxy.java
@@ -1,0 +1,78 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject;
+import hudson.util.TimeUnit2;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Keeps map between url and dynamic trigger configuration.
+ * It's used to speed up execution time during updating
+ * trigger jobs and reduce number of connections for the duplicated configs.
+ */
+final class DynamicConfigurationCacheProxy {
+    private static final DynamicConfigurationCacheProxy CACHE_PROXY = new DynamicConfigurationCacheProxy();
+    private final Map<String, List<GerritProject>> cache = new HashMap<String, List<GerritProject>>();
+    private static final Logger logger = LoggerFactory.getLogger(DynamicConfigurationCacheProxy.class);
+    private final Map<String, Long> ttl = new HashMap<String, Long>();
+
+    /**
+     * Private constructor.
+     */
+    private DynamicConfigurationCacheProxy() {
+    }
+
+    /**
+     * Returns dynamic trigger config from the cache if it's available.
+     * Otherwise send query.
+     *
+     * @param url url to dynamic trigger config.
+     * @return list of gerrit projects.
+     * @throws IOException if so.
+     * @throws ParseException if so.
+     */
+    synchronized List<GerritProject> fetchThroughCache(String url) throws IOException, ParseException {
+        if (cache.containsKey(url) && !isExpired(url)) {
+            logger.debug("Get dynamic projects from cache for URL: " + url);
+            return cache.get(url);
+        }
+
+        logger.info("Get dynamic projects directly for URL: {}", url);
+        List<GerritProject> gerritProjects = GerritDynamicUrlProcessor.fetch(url);
+        ttl.put(url, System.currentTimeMillis());
+        cache.put(url, gerritProjects);
+
+        return gerritProjects;
+    }
+
+    /**
+     * Return global cache proxy objects.
+     *
+     * @return cache proxy object.
+     */
+    static DynamicConfigurationCacheProxy getInstance() {
+        return CACHE_PROXY;
+    }
+
+    /**
+     * Check the need to update specified url.
+     *
+     * @param url url.
+     * @return true if cached value is expired.
+     */
+    private boolean isExpired(String url) {
+        Long lastTimeUpdated = ttl.get(url);
+        if (lastTimeUpdated == null) {
+            lastTimeUpdated = System.currentTimeMillis();
+        }
+
+        long updateInterval = GerritTriggerTimer.getInstance().calculateAverageDynamicConfigRefreshInterval();
+        return TimeUnit2.MILLISECONDS.toSeconds(System.currentTimeMillis() - lastTimeUpdated) > updateInterval;
+    }
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/DynamicConfigurationCacheProxy.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/DynamicConfigurationCacheProxy.java
@@ -75,4 +75,12 @@ final class DynamicConfigurationCacheProxy {
         long updateInterval = GerritTriggerTimer.getInstance().calculateAverageDynamicConfigRefreshInterval();
         return TimeUnit2.MILLISECONDS.toSeconds(System.currentTimeMillis() - lastTimeUpdated) > updateInterval;
     }
+
+    /**
+     * Clears the cache.
+     */
+    void clear() {
+        ttl.clear();
+        cache.clear();
+    }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
@@ -30,6 +30,8 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.FilePat
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Topic;
 
+import org.kohsuke.accmod.Restricted;
+import org.kohsuke.accmod.restrictions.NoExternalUse;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +55,7 @@ import java.util.regex.Pattern;
  *
  * @author Fredrik Abrahamson &lt;fredrik.abrahamson@sonymobile.com&gt;
  */
+@Restricted(NoExternalUse.class)
 public final class GerritDynamicUrlProcessor {
 
     private static final Logger logger = LoggerFactory.getLogger(GerritDynamicUrlProcessor.class);
@@ -126,13 +129,12 @@ public final class GerritDynamicUrlProcessor {
      * Read and parse the dynamic trigger configuration.
      *
      * @param reader stream from which to read the config
-     * @param serverName the name of the Gerrit server configured in the project, could be null.
      *
      * @return List of Gerrit projects
      * @throws ParseException when the fetched content couldn't be parsed
      * @throws IOException for all other kinds of fetch errors
      */
-    private static List<GerritProject> readAndParseTriggerConfig(BufferedReader reader, String serverName)
+    private static List<GerritProject> readAndParseTriggerConfig(BufferedReader reader)
             throws IOException, ParseException {
       Pattern linePattern = buildLinePattern();
 
@@ -238,12 +240,11 @@ public final class GerritDynamicUrlProcessor {
      * since the last fetch, it returns null.
      *
      * @param gerritTriggerConfigUrl the URL to fetch
-     * @param serverName name of the Gerrit server.
      * @return a list of GerritProjects if successful, or null if no change
      * @throws ParseException when the fetched content couldn't be parsed
      * @throws IOException for all other kinds of fetch errors
      */
-    public static List<GerritProject> fetch(String gerritTriggerConfigUrl, String serverName)
+    public static List<GerritProject> fetch(String gerritTriggerConfigUrl)
             throws IOException, ParseException {
 
         if (gerritTriggerConfigUrl == null) {
@@ -264,13 +265,17 @@ public final class GerritDynamicUrlProcessor {
         try {
           instream = connection.getInputStream();
           reader = new BufferedReader(new InputStreamReader(instream, Charset.forName("UTF-8")));
-          return readAndParseTriggerConfig(reader, serverName);
+          return readAndParseTriggerConfig(reader);
         } finally {
-          if (reader != null) {
-            reader.close();
-          } else if (instream != null) {
-            instream.close();
-          }
+            try {
+                if (reader != null) {
+                    reader.close();
+                }
+            } finally {
+                if (instream != null) {
+                    instream.close();
+                }
+            }
         }
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1720,17 +1720,11 @@ public class GerritTrigger extends Trigger<Job> {
         }
         triggerInformationAction.setErrorMessage("");
         try {
-            if (isAnyServer()) {
-                triggerInformationAction.setErrorMessage("Dynamic trigger configuration needs "
-                        + "a specific configured server");
-            } else {
-                List<GerritProject> fetchedProjects = GerritDynamicUrlProcessor.fetch(triggerConfigURL, serverName);
-                dynamicGerritProjects = fetchedProjects;
-            }
+            dynamicGerritProjects = DynamicConfigurationCacheProxy.getInstance().fetchThroughCache(triggerConfigURL);
         } catch (ParseException pe) {
             String logErrorMessage = MessageFormat.format(
                     "ParseException for project: {0} and URL: {1} Message: {2}",
-                    new Object[]{job.getName(), triggerConfigURL, pe.getMessage()});
+                    job.getName(), triggerConfigURL, pe.getMessage());
             logger.error(logErrorMessage, pe);
             String triggerInformationMessage = MessageFormat.format(
                     "ParseException when fetching dynamic trigger url: {0}", pe.getMessage());
@@ -1738,7 +1732,7 @@ public class GerritTrigger extends Trigger<Job> {
         } catch (MalformedURLException mue) {
             String logErrorMessage = MessageFormat.format(
                     "MalformedURLException for project: {0} and URL: {1} Message: {2}",
-                    new Object[]{job.getName(), triggerConfigURL, mue.getMessage()});
+                    job.getName(), triggerConfigURL, mue.getMessage());
             logger.error(logErrorMessage, mue);
             String triggerInformationMessage = MessageFormat.format(
                     "MalformedURLException when fetching dynamic trigger url: {0}", mue.getMessage());
@@ -1746,7 +1740,7 @@ public class GerritTrigger extends Trigger<Job> {
         } catch (SocketTimeoutException ste) {
             String logErrorMessage = MessageFormat.format(
                     "SocketTimeoutException for project: {0} and URL: {1} Message: {2}",
-                    new Object[]{job.getName(), triggerConfigURL, ste.getMessage()});
+                    job.getName(), triggerConfigURL, ste.getMessage());
             logger.error(logErrorMessage, ste);
             String triggerInformationMessage = MessageFormat.format(
                     "SocketTimeoutException when fetching dynamic trigger url: {0}", ste.getMessage());
@@ -1755,7 +1749,7 @@ public class GerritTrigger extends Trigger<Job> {
         } catch (IOException ioe) {
             String logErrorMessage = MessageFormat.format(
                     "IOException for project: {0} and URL: {1} Message: {2}",
-                    new Object[]{job.getName(), triggerConfigURL, ioe.getMessage()});
+                    job.getName(), triggerConfigURL, ioe.getMessage());
             logger.error(logErrorMessage, ioe);
             String triggerInformationMessage = MessageFormat.format(
                     "IOException when fetching dynamic trigger url: {0}", ioe.getMessage());

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimer.java
@@ -115,7 +115,7 @@ public final class GerritTriggerTimer {
      *
      * @return the average value.
      */
-    private long calculateAverageDynamicConfigRefreshInterval() {
+    long calculateAverageDynamicConfigRefreshInterval() {
         long total = 0;
         for (GerritServer server : PluginImpl.getServers_()) {
             total += server.getConfig().getDynamicConfigRefreshInterval();
@@ -136,7 +136,6 @@ public final class GerritTriggerTimer {
             logger.debug("Schedule task " + timerTask + " for every " + timerPeriod + "ms");
             jenkins.util.Timer.get().scheduleWithFixedDelay(timerTask, DELAY_MILLISECONDS, timerPeriod,
                                                             TimeUnit.MILLISECONDS);
-
         } catch (IllegalArgumentException iae) {
             logger.error("Attempted use of negative delay", iae);
         } catch (IllegalStateException ise) {

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/DynamicConfigurationCacheProxyTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/DynamicConfigurationCacheProxyTest.java
@@ -1,0 +1,106 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.powermock.api.mockito.PowerMockito.mock;
+import static org.powermock.api.mockito.PowerMockito.when;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+
+/**
+ * Tests for {@link DynamicConfigurationCacheProxy}.
+ */
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ GerritDynamicUrlProcessor.class, GerritTriggerTimer.class })
+public class DynamicConfigurationCacheProxyTest {
+
+    private static final long FORCE_REFRESH_INTERVAL = -1000L;
+
+    /**
+     * Cleans the cache and sets mocks before every test.
+     * @throws Exception if so.
+     */
+    @Before
+    public void setUp() throws Exception {
+        DynamicConfigurationCacheProxy.getInstance().clear();
+        PowerMockito.mockStatic(GerritDynamicUrlProcessor.class);
+    }
+
+    /**
+     * Sets refresh interval.
+     * @param refreshInternal refresh interval for dynamic trigger
+     */
+    private void setRefreshInternal(long refreshInternal) {
+        PowerMockito.mockStatic(GerritTriggerTimer.class);
+        GerritTriggerTimer timer = mock(GerritTriggerTimer.class);
+        when(GerritTriggerTimer.getInstance()).thenReturn(timer);
+        when(timer.calculateAverageDynamicConfigRefreshInterval()).thenReturn(refreshInternal);
+    }
+
+    /**
+     * Tests the case when cache is empty.
+     * @throws Exception if so.
+     */
+    @Test
+    public void fetchDirectlyWithoutCache() throws Exception {
+        List<GerritProject> expected = Collections.singletonList(mock(GerritProject.class));
+        when(GerritDynamicUrlProcessor.fetch(anyString())).thenReturn(expected);
+
+        List<GerritProject> actual = DynamicConfigurationCacheProxy.getInstance().fetchThroughCache("someUrl");
+
+        assertEquals(expected, actual);
+    }
+
+    /**
+     * Tests the case when cache is non-empty, but record is outdated.
+     * @throws Exception if so.
+     */
+    @Test
+    public void fetchDirectlyWithCache() throws Exception {
+        List<GerritProject> gerritProjects1 = Collections.singletonList(mock(GerritProject.class));
+        List<GerritProject> gerritProjects2 = Collections.singletonList(mock(GerritProject.class));
+        when(GerritDynamicUrlProcessor.fetch(anyString())).thenReturn(gerritProjects1).thenReturn(gerritProjects2);
+        setRefreshInternal(FORCE_REFRESH_INTERVAL);
+
+        List<GerritProject> res1 = DynamicConfigurationCacheProxy.getInstance().fetchThroughCache("someUrl");
+        List<GerritProject> res2 = DynamicConfigurationCacheProxy.getInstance().fetchThroughCache("someUrl");
+
+        assertNotEquals(res1, res2);
+        assertEquals(gerritProjects1, res1);
+        assertEquals(gerritProjects2, res2);
+        verifyStatic(times(2));
+    }
+
+    /**
+     * Tests the case then cache is non-empty and record is still valid.
+     * @throws Exception if so.
+     */
+    @Test
+    public void fetchThroughCache() throws Exception {
+        PowerMockito.mockStatic(GerritDynamicUrlProcessor.class);
+        List<GerritProject> gerritProjects1 = Collections.singletonList(mock(GerritProject.class));
+        List<GerritProject> gerritProjects2 = Collections.singletonList(mock(GerritProject.class));
+        when(GerritDynamicUrlProcessor.fetch(anyString())).thenReturn(gerritProjects1).thenReturn(gerritProjects2);
+
+        List<GerritProject> res1 = DynamicConfigurationCacheProxy.getInstance().fetchThroughCache("someUrl");
+        List<GerritProject> res2 = DynamicConfigurationCacheProxy.getInstance().fetchThroughCache("someUrl");
+
+        assertEquals(gerritProjects1, res1);
+        assertEquals(gerritProjects1, res2);
+        assertNotEquals(gerritProjects2, res2);
+
+        verifyStatic();
+    }
+}


### PR DESCRIPTION
In our environment we have several hundreds jobs, but only few unique dynamic trigger options (10 or 20). This PR has two main goals:
- reduce memory consumption for establishing ssl connection / parsing dynamic trigger config list
- speed dynamic config update time for duplicated entities