### PR TITLE
Check that job is not null before starting to process event

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -937,6 +937,11 @@ public class GerritTrigger extends Trigger<Job> {
      * @return true if we should.
      */
     public boolean isInteresting(GerritTriggeredEvent event) {
+        if (job == null) {
+            logger.trace("Job is not fully initialised.");
+            return false;
+        }
+
         if (!job.isBuildable()) {
             logger.trace("Disabled.");
             return false;


### PR DESCRIPTION
During job creation/update process there is a short window then GerritTrigger
does not have a valid reference to the job it belongs to.