### PR TITLE
[JENKINS-49813] RunningJobs: Remove extra shouldCancelPatchsetNumber check

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -2277,11 +2277,6 @@ public class GerritTrigger extends Trigger<Job> {
                             continue;
                         }
 
-
-                        if (!shouldCancelPatchsetNumber) {
-                            continue;
-                        }
-
                         outdatedEvents.add(runningChangeBasedEvent);
                         it.remove();
                     }


### PR DESCRIPTION
An extra check for !shouldCancelPatchsetNumber after the check for
(!abortBecauseOfTopic && !shouldCancelpatchsetNumber) breaks the "Abort
patch sets with same topic" feature.
It appears that these lines were added inadvertently during
merge conflict resolution in 7455d86c5d0eaf72743094d64e5faa23b1a5bf82.

Removing this extra if block allows for cancelling running jobs when
a new patchset arrives on the same topic.

Signed-off-by: Allen Wild <allenwild93@gmail.com>