### PR TITLE
Query the documentation to check if plugin is enabled

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/GerritPluginChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/GerritPluginChecker.java
@@ -161,7 +161,8 @@ public final class GerritPluginChecker {
 
         CloseableHttpResponse execute = null;
         try {
-            execute = HttpUtils.performHTTPGet(config, restUrl + "plugins/" + pluginName + "/");
+            execute = HttpUtils.performHTTPGet(config, 
+                    restUrl + "plugins/" + pluginName + "/Documentation/index.html");
             int statusCode = execute.getStatusLine().getStatusCode();
             logger.debug("status code: {}", statusCode);
             return decodeStatus(statusCode, pluginName, quiet);


### PR DESCRIPTION
Instead of querying the plugin (which may give a redirect), query the plugin's Documentation (which does not require authentication).