### PR TITLE
Do not use synchronised checks during event processing

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ToGerritRunListener.java
@@ -206,7 +206,11 @@ public final class ToGerritRunListener extends RunListener<Run> {
      * @param event   the Gerrit Event which is being checked.
      * @param p   the Gerrit project being checked.
      * @return true if so.
+     *
+     * @deprecated Use {@link #isTriggered(Job, GerritTriggeredEvent)} and
+     *                 {@link #isBuilding(Job, GerritTriggeredEvent)}} instead
      */
+    @Deprecated
     public synchronized boolean isProjectTriggeredAndIncomplete(Job p, GerritTriggeredEvent event) {
         if (!memory.isTriggered(event, p)) {
             return false;

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -949,14 +949,9 @@ public class GerritTrigger extends Trigger<Job> {
         }
 
         ToGerritRunListener listener = ToGerritRunListener.getInstance();
-        if (listener != null) {
-            if (listener.isProjectTriggeredAndIncomplete(job, event)) {
-                logger.trace("Already triggered and incomplete.");
-                return false;
-            } else if (listener.isTriggered(job, event)) {
-                logger.trace("Already triggered.");
-                return false;
-            }
+        if (listener != null && listener.isTriggered(job, event)) {
+            logger.trace("{} is already triggered for the event {}.", job, event);
+            return false;
         }
 
         if (!shouldTriggerOnEventType(event)) {


### PR DESCRIPTION
Using synchronised checks during event processing leads to contention on
GerritWorker threads. Especially if lock is done on ToGerritRunListener.
So, to speed up the processing we need to get rid of
`isProjectTriggeredAndIncomplete`.

`isProjectTriggeredAndIncomplete` can be replaced by `isTriggered` and `isBuilding`.
That transforms the previos version of check to `(isTriggered && isBuilding) || isTriggered`.
So, it's absolutely safe to keep `isTriggered` only.

After that plugin itself does not use `isProjectTriggeredAndIncomplete`.