### PR TITLE
Add support private state changed gerrit event

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -53,6 +53,7 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.Plugi
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginDraftPublishedEvent;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginGerritEvent;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPrivateStateChangedEvent;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.version.GerritVersionChecker;
 
 import static com.sonymobile.tools.gerrit.gerritevents.GerritDefaultValues.DEFAULT_BUILD_SCHEDULE_DELAY;
@@ -1386,6 +1387,9 @@ public class GerritTrigger extends Trigger<Job> {
             if (isTriggerOnDraftPublishedEnabled()) {
                 triggerOnEvents.add(new PluginDraftPublishedEvent());
             }
+            if (isTriggerOnPrivateStateChangedEnabled()) {
+                triggerOnEvents.add(new PluginPrivateStateChangedEvent());
+            }
         }
     }
 
@@ -1791,6 +1795,15 @@ public class GerritTrigger extends Trigger<Job> {
     public boolean isTriggerOnDraftPublishedEnabled() {
         return GerritVersionChecker
                 .isCorrectVersion(GerritVersionChecker.Feature.triggerOnDraftPublished, serverName);
+    }
+
+    /**
+     * Convenience method for finding it out if triggering on private changed is enabled in the Gerrit version.
+     * @return true if triggering on private state changed is enabled in the Gerrit version.
+     */
+    public boolean isTriggerOnPrivateStateChangedEnabled() {
+        return GerritVersionChecker
+                .isCorrectVersion(GerritVersionChecker.Feature.triggerOnPrivateStateChanged, serverName);
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPrivateStateChangedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPrivateStateChangedEvent.java
@@ -1,0 +1,77 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2018 Sony Mobile Communications AB. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import hudson.model.Hudson;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import java.io.Serializable;
+
+/**
+ * An event configuration that causes the build to be triggered when a private change is publiced.
+ */
+public class PluginPrivateStateChangedEvent extends PluginGerritEvent implements Serializable {
+
+
+    /**
+     * Standard DataBoundConstructor.
+     */
+    @DataBoundConstructor
+    public PluginPrivateStateChangedEvent() {
+    }
+
+    /**
+     * Getter for the Descriptor.
+     * @return the Descriptor for the PluginPrivateStateChangedEvent.
+     */
+    @Override
+    public Descriptor<PluginGerritEvent> getDescriptor() {
+        return Hudson.getInstance().getDescriptorByType(PluginPrivateStateChangedEventDescriptor.class);
+    }
+
+    @Override
+    public Class getCorrespondingEventClass() {
+        return PrivateStateChanged.class;
+    }
+
+    /**
+     * The Descriptor for the PluginPrivateStateChangedEvent.
+     */
+    @Extension
+    @Symbol("privateStateChanged")
+    public static class PluginPrivateStateChangedEventDescriptor extends PluginGerritEventDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.PrivateStateChangedDisplayName();
+        }
+    }
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
@@ -48,6 +48,11 @@ public final class GerritVersionChecker {
         fileTrigger("Trigger on files", "2.3"),
 
         /**
+         * Triggering on private state changed, added in Gerrit 2.15.
+         */
+        triggerOnPrivateStateChanged("Trigger on private state changed", "2.15"),
+
+        /**
          * Triggering on draft change published, added in Gerrit 2.5.
          */
         triggerOnDraftPublished("Trigger on draft published", "2.5"),

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -90,6 +90,8 @@ CommentAddedContainsDisplayName=\
   Comment Added Contains Regular Expression
 DraftPublishedDisplayName=\
   Draft Published
+PrivateStateChangedDisplayName=\
+  Private State Changed
 RefUpdatedDisplayName=\
   Ref Updated
 ChangeAbandonedDisplayName=\

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages_ja.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages_ja.properties
@@ -90,6 +90,8 @@ CommentAddedContainsDisplayName=\
   \u6b63\u898f\u8868\u73fe\u30d1\u30bf\u30fc\u30f3\u3092\u542b\u3080Comment Added
 DraftPublishedDisplayName=\
   Draft Published
+PrivateStateChangedDisplayName=\
+  Private State Changed
 RefUpdatedDisplayName=\
   Ref Updated
 ChangeAbandonedDisplayName=\

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPrivateStateChangedEvent/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPrivateStateChangedEvent/config.jelly
@@ -1,0 +1,37 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright 2012 Sony Mobile Communications AB. All rights reserved.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
+   <j:choose>
+        <j:when test="${descriptor.isReplicationPrivateEnabled()}">
+            <f:entry
+                title=""
+                help="/plugin/gerrit-trigger/trigger/help-PrivateStateChanged.html">
+                <div class="warning">Please see important note in Help on Replication</div>
+            </f:entry>
+        </j:when>
+        <j:otherwise>
+        </j:otherwise>
+    </j:choose>
+</j:jelly>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
@@ -313,6 +313,29 @@ public class GerritTriggerTest {
     }
 
     /**
+     * Tests that testInitializeTriggerOnPrivateStateChangedEvents is run correctly by the start method.
+     */
+    @Test
+    public void testInitializeTriggerOnPrivateStateChangedEvents() {
+        mockPluginConfig(0);
+        AbstractProject project = mockProject();
+        boolean silentStartMode = false;
+        GerritTrigger trigger = new GerritTrigger(null, null, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                true, silentStartMode, true, false, false, "", "", "", "", "", "", "", null, null, null,
+                null, false,  "", null);
+        trigger = spy(trigger);
+        Object triggerOnEvents = Whitebox.getInternalState(trigger, "triggerOnEvents");
+
+        assertNull(triggerOnEvents);
+        doReturn(true).when(trigger).isTriggerOnPrivateStateChangedEnabled();
+        trigger.start(project, true);
+        triggerOnEvents = Whitebox.getInternalState(trigger, "triggerOnEvents");
+        assertNotNull(triggerOnEvents);
+        List<PluginGerritEvent> events = (List<PluginGerritEvent>)triggerOnEvents;
+        assertEquals(events.size(), 2);
+    }
+
+    /**
      * Tests the schedule method of GerritTrigger.
      * It verifies that {@link AbstractProject#scheduleBuild2(int, hudson.model.Cause, hudson.model.Action...)}
      * gets called with an negative buildScheduleDelay -20.

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
@@ -52,6 +52,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefReplicated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.TopicChanged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
 import hudson.EnvVars;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractProject;
@@ -270,6 +271,34 @@ public final class Setup {
     }
 
     /**
+     * Gives you a PrivateStateChanged mock.
+     * @return PrivateStateChanged mock.
+     */
+    public static PrivateStateChanged createPrivateStateChanged() {
+        PrivateStateChanged event = new PrivateStateChanged();
+        Change change = new Change();
+        change.setBranch("branch");
+        change.setId("Iddaaddaa123456789");
+        change.setNumber("1000");
+        Account account = new Account();
+        account.setEmail("email@domain.com");
+        account.setName("Name");
+        change.setOwner(account);
+        change.setProject("project");
+        change.setSubject("subject");
+        change.setUrl("http://gerrit/1000");
+        event.setChange(change);
+        PatchSet patch = new PatchSet();
+        patch.setNumber("1");
+        patch.setRevision("9999");
+        event.setPatchset(patch);
+        patch.setRef("ref");
+        event.setProvider(new Provider(PluginImpl.DEFAULT_SERVER_NAME, "gerrit", "29418", "ssh", "http://gerrit/", "1"));
+        event.setEventCreatedOn("1418133772");
+        return event;
+    }
+
+    /**
      * Gives you a ChangeAbandoned mock.
      * @return ChangeAbandoned mock.
      */
@@ -348,6 +377,17 @@ public final class Setup {
     }
 
     /**
+     * Gives you a PrivateStateChanged mock.
+     * @param serverName The server name
+     * @param project The project
+     * @param ref The ref
+     * @return PrivateStateChanged mock.
+     */
+    public static PrivateStateChanged createPrivateStateChanged(String serverName, String project, String ref) {
+        return createPrivateStateChangedWithPatchSetDate(serverName, project, ref, new Date());
+    }
+
+    /**
      * Gives you a ChangeMerged mock.
      * @return ChangeMerged mock.
      */
@@ -418,6 +458,40 @@ public final class Setup {
     public static DraftPublished createDraftPublishedWithPatchSetDate(String serverName, String project,
             String ref, Date date) {
         DraftPublished event = new DraftPublished();
+        Change change = new Change();
+        change.setBranch("branch");
+        change.setId("Iddaaddaa123456789");
+        change.setNumber("1000");
+        Account account = new Account();
+        account.setEmail("email@domain.com");
+        account.setName("Name");
+        change.setOwner(account);
+        change.setProject(project);
+        change.setSubject("subject");
+        change.setUrl("http://gerrit/1000");
+        event.setChange(change);
+        PatchSet patch = new PatchSet();
+        patch.setNumber("1");
+        patch.setRevision("9999");
+        event.setPatchset(patch);
+        patch.setRef(ref);
+        patch.setCreatedOn(date);
+        event.setProvider(new Provider(serverName, "gerrit", "29418", "ssh", "http://gerrit/", "1"));
+        event.setEventCreatedOn("1418133772");
+        return event;
+    }
+
+    /**
+     * Gives you a PrivateStateChanged mock.
+     * @param serverName The server name
+     * @param project The project
+     * @param ref The ref
+     * @param date The patchset's createdOn date
+     * @return PrivateStateChanged mock.
+     */
+    public static PrivateStateChanged createPrivateStateChangedWithPatchSetDate(String serverName, String project,
+            String ref, Date date) {
+        PrivateStateChanged event = new PrivateStateChanged();
         Change change = new Change();
         change.setBranch("branch");
         change.setId("Iddaaddaa123456789");

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat252HudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat252HudsonTest.java
@@ -38,6 +38,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.GerritEventType;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.DraftPublished;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PrivateStateChanged;
 import com.sonymobile.tools.gerrit.gerritevents.mock.SshdServerMock;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
@@ -78,6 +79,10 @@ public class BackCompat252HudsonTest {
      * The stream-events command.
      */
     protected static final String GERRIT_STREAM_EVENTS = "gerrit stream-events";
+    /**
+     * The assert that trigger.
+     */
+    public static final int ASSERT_THAT_TRIGGER = 3;
     /**
      * An instance of Jenkins Rule.
      */
@@ -145,9 +150,10 @@ public class BackCompat252HudsonTest {
         Branch branch = branches.get(0);
         assertThat(branch.getPattern(), equalTo("bra.*"));
         List<PluginGerritEvent> triggerOnEvents = trigger.getTriggerOnEvents();
-        assertThat(triggerOnEvents.size(), equalTo(2));
+        assertThat(triggerOnEvents.size(), equalTo(ASSERT_THAT_TRIGGER));
         assertSame(triggerOnEvents.get(0).getCorrespondingEventClass(), PatchsetCreated.class);
         assertSame(triggerOnEvents.get(1).getCorrespondingEventClass(), DraftPublished.class);
+        assertSame(triggerOnEvents.get(2).getCorrespondingEventClass(), PrivateStateChanged.class);
     }
 
     /**
@@ -172,9 +178,10 @@ public class BackCompat252HudsonTest {
         Branch branch = branches.get(0);
         assertThat(branch.getPattern(), equalTo(".*er"));
         List<PluginGerritEvent> triggerOnEvents = trigger.getTriggerOnEvents();
-        assertThat(triggerOnEvents.size(), equalTo(2));
+        assertThat(triggerOnEvents.size(), equalTo(ASSERT_THAT_TRIGGER));
         assertSame(triggerOnEvents.get(0).getCorrespondingEventClass(), PatchsetCreated.class);
         assertSame(triggerOnEvents.get(1).getCorrespondingEventClass(), DraftPublished.class);
+        assertSame(triggerOnEvents.get(2).getCorrespondingEventClass(), PrivateStateChanged.class);
     }
 
     /**


### PR DESCRIPTION
Drafts have been removed in 2.15 and instead changes can be private.
When private changed is marked public, CI trigger a build on it.
This submit will fail, because private state changed need to be support on gerrit event. The first, pull request below need to be merged:
https://github.com/sonyxperiadev/gerrit-events/pull/73
