### PR TITLE
Remove GerritMissedEventsPlaybackManager.getServerTimestamp method

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -517,14 +517,6 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Na
     }
 
     /**
-     * Return server timestamp.
-     * @return timestamp.
-     */
-    public EventTimeSlice getServerTimestamp() {
-        return serverTimestamp;
-    }
-
-    /**
      * @param serverName The Name of the Gerrit Server to load config for.
      * @return XmlFile corresponding to gerrit-trigger-server-timestamps.xml.
      * @throws IOException if it occurs.

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsFunctionalTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsFunctionalTest.java
@@ -199,7 +199,7 @@ public class GerritMissedEventsFunctionalTest {
         createAndWaitforPatchset(gerritServer, project, ++buildNum);
         createAndWaitforPatchset(gerritServer, project, ++buildNum);
 
-        EventTimeSlice lastTimeStamp = gerritServer.getMissedEventsPlaybackManager().getServerTimestamp();
+        EventTimeSlice lastTimeStamp = gerritServer.getMissedEventsPlaybackManager().serverTimestamp;
 
         // now we force the plugin is supported to false...
         stubFor(get(urlEqualTo("/plugins/" + GerritMissedEventsPlaybackManager.EVENTS_LOG_PLUGIN_NAME + "/"))
@@ -331,7 +331,7 @@ public class GerritMissedEventsFunctionalTest {
         FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJob(j, projectName, gServer.getName());
         createAndWaitforPatchset(gServer, project, 1);
 
-        assertNotNull(gServer.getMissedEventsPlaybackManager().getServerTimestamp());
+        assertNotNull(gServer.getMissedEventsPlaybackManager().serverTimestamp);
         FreeStyleBuild buildOne = project.getLastCompletedBuild();
         assertSame(Result.SUCCESS, buildOne.getResult());
         assertEquals(1, project.getLastCompletedBuild().getNumber());


### PR DESCRIPTION
This getter for serverTimestamp variable was only used in the unit tests
and the variable is already accessed directly in other tests.