### PR TITLE
Improve Patchset trigger options

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
@@ -23,9 +23,13 @@
   -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="${%Exclude Drafts}"
-             field="excludeDrafts">
-        <f:checkbox/>
+    <f:entry title="${%Trigger For Published Patchsets}"
+             field="triggerForPublishedPatchsets">
+        <f:checkbox name="triggerForPublishedPatchsets" default="true" checked="${it.triggerForPublishedPatchsets}"/>
+    </f:entry>
+    <f:entry title="${%Trigger For Drafts}"
+             field="triggerForDrafts">
+        <f:checkbox name="triggerForDrafts" default="true" checked="${it.triggerForDrafts}"/>
     </f:entry>
     <f:entry title="${%Exclude Trivial Rebase}"
              field="excludeTrivialRebase"

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
@@ -23,13 +23,8 @@
   -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <f:entry title="${%Trigger For Published Patchsets}"
-             field="triggerForPublishedPatchsets">
-        <f:checkbox name="triggerForPublishedPatchsets" default="true" checked="${it.triggerForPublishedPatchsets}"/>
-    </f:entry>
-    <f:entry title="${%Trigger For Drafts}"
-             field="triggerForDrafts">
-        <f:checkbox name="triggerForDrafts" default="true" checked="${it.triggerForDrafts}"/>
+    <f:entry title="${%Trigger For}" field="triggerFor">
+        <f:select />
     </f:entry>
     <f:entry title="${%Exclude Trivial Rebase}"
              field="excludeTrivialRebase"

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
@@ -22,7 +22,8 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldFireOnAllTypeOfPatchset() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false, false, false);
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, true, false, false
+        );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
 
@@ -37,7 +38,8 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldNotFireOnDraftPatchsetWhenExcluded() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, false, false);
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, false, false, false
+        );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
 
@@ -48,12 +50,30 @@ public class PluginPatchsetCreatedEventTest {
     }
 
     /**
+     * Tests that it should fire on draft patchset when triggerForDrafts is true.
+     */
+    @Test
+    public void shouldFireOnDraftPatchsetWhenChecked() {
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false, true, false, false
+        );
+        PatchsetCreated patchsetCreated = new PatchsetCreated();
+        patchsetCreated.setPatchset(new PatchSet());
+
+        //should fire only on draft patchset
+        patchsetCreated.getPatchSet().setDraft(true);
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+        //should not not fire for regular patchsets
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+    }
+
+    /**
      * Tests that it should not fire on trivial rebase when they are excluded.
      * @author Doug Kelly &lt;dougk.ff7@gmail.com&gt;
      */
     @Test
     public void shouldNotFireOnTrivialRebaseWhenExcluded() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false, true, false);
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, true, true, false
+        );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
 
@@ -69,7 +89,8 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldNotFireOnNoCodeChangeWhenExcluded() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false, false, true);
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, true, false, true
+        );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
@@ -22,7 +22,8 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldFireOnAllTypeOfPatchset() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, true, false, false
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(
+                PluginPatchsetCreatedEvent.TRIGGER_FOR_ALL, false, false
         );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
@@ -38,7 +39,8 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldNotFireOnDraftPatchsetWhenExcluded() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, false, false, false
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(
+                PluginPatchsetCreatedEvent.TRIGGER_FOR_PUBLISHED, false, false
         );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
@@ -54,7 +56,8 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldFireOnDraftPatchsetWhenChecked() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(false, true, false, false
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(
+                PluginPatchsetCreatedEvent.TRIGGER_FOR_DRAFT, false, false
         );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
@@ -72,7 +75,8 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldNotFireOnTrivialRebaseWhenExcluded() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, true, true, false
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(
+                PluginPatchsetCreatedEvent.TRIGGER_FOR_ALL, true, false
         );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());
@@ -89,7 +93,8 @@ public class PluginPatchsetCreatedEventTest {
      */
     @Test
     public void shouldNotFireOnNoCodeChangeWhenExcluded() {
-        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(true, true, false, true
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent = new PluginPatchsetCreatedEvent(
+                PluginPatchsetCreatedEvent.TRIGGER_FOR_ALL, false, true
         );
         PatchsetCreated patchsetCreated = new PatchsetCreated();
         patchsetCreated.setPatchset(new PatchSet());

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java
@@ -128,8 +128,7 @@ public class BackCompat2173JenkinsTest {
         assertThat(trigger.getTriggerOnEvents(), hasItem(
                 allOf(
                         isA(PluginPatchsetCreatedEvent.class),
-                        hasProperty("triggerForDrafts", is(true)),
-                        hasProperty("triggerForPublishedPatchsets", is(true)),
+                        hasProperty("triggerFor", equalTo(PluginPatchsetCreatedEvent.TRIGGER_FOR_ALL)),
                         hasProperty("excludeTrivialRebase", is(false)),
                         hasProperty("excludeNoCodeChange", is(false))
                 )
@@ -201,8 +200,7 @@ public class BackCompat2173JenkinsTest {
         assertThat(trigger.getTriggerOnEvents(), hasItem(
                 allOf(
                         isA(PluginPatchsetCreatedEvent.class),
-                        hasProperty("triggerForDrafts", is(true)),
-                        hasProperty("triggerForPublishedPatchsets", is(true)),
+                        hasProperty("triggerFor", equalTo(PluginPatchsetCreatedEvent.TRIGGER_FOR_ALL)),
                         hasProperty("excludeTrivialRebase", is(true)),
                         hasProperty("excludeNoCodeChange", is(false))
                 )

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java
@@ -128,7 +128,8 @@ public class BackCompat2173JenkinsTest {
         assertThat(trigger.getTriggerOnEvents(), hasItem(
                 allOf(
                         isA(PluginPatchsetCreatedEvent.class),
-                        hasProperty("excludeDrafts", is(false)),
+                        hasProperty("triggerForDrafts", is(true)),
+                        hasProperty("triggerForPublishedPatchsets", is(true)),
                         hasProperty("excludeTrivialRebase", is(false)),
                         hasProperty("excludeNoCodeChange", is(false))
                 )
@@ -200,7 +201,8 @@ public class BackCompat2173JenkinsTest {
         assertThat(trigger.getTriggerOnEvents(), hasItem(
                 allOf(
                         isA(PluginPatchsetCreatedEvent.class),
-                        hasProperty("excludeDrafts", is(false)),
+                        hasProperty("triggerForDrafts", is(true)),
+                        hasProperty("triggerForPublishedPatchsets", is(true)),
                         hasProperty("excludeTrivialRebase", is(true)),
                         hasProperty("excludeNoCodeChange", is(false))
                 )


### PR DESCRIPTION
This pull request adds the possibility to trigger a job when a draft patchset is created and to ignore otherwise.

To make the configuration a bit clear I removed the exclude drafts option and set the TriggerForPublishedPatchsets and TriggerForDrafts variables enabled by default, keeping the same behavior as before.

There are two things that I didn't manage to do:
1 - This pull request brakes backward compatibility with previous versions of the plugin.

 **Does Jenkins has some kind of migration API?**

2 - I couldn't make the tests in src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java green. 

 **Could someone point me to where are the test setup for the two blocks of tests listed below?**

- https://github.com/jenkinsci/gerrit-trigger-plugin/blob/master/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java#L200

- https://github.com/jenkinsci/gerrit-trigger-plugin/blob/master/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java#L128