### PR TITLE
Update documentation to link to latest major Gerrit release

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/help-Search.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/help-Search.jelly
@@ -4,7 +4,7 @@
         <j:set var="frontEndUrl" value="${it.getFrontEndUrl(request.session.getAttribute('selectedServer'))}"/>
         <j:choose>
             <j:when test="${empty(frontEndUrl)}">
-                <j:set var="helpUrl" value="https://gerrit-documentation.storage.googleapis.com/Documentation/2.13/user-search.html"/>
+                <j:set var="helpUrl" value="https://gerrit-documentation.storage.googleapis.com/Documentation/2.15/user-search.html"/>
             </j:when>
             <j:otherwise>
                 <j:set var="helpUrl" value="${frontEndUrl + 'Documentation/user-search.html'}"/>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
@@ -32,7 +32,7 @@
                             <j:set var="frontEndUrl" value="${it.getFrontEndUrl(request.session.getAttribute('selectedServer'))}"/>
                             <j:choose>
                                 <j:when test="${empty(frontEndUrl)}">
-                                    <j:set var="helpUrl" value="https://gerrit-documentation.storage.googleapis.com/Documentation/2.13/user-search.html"/>
+                                    <j:set var="helpUrl" value="https://gerrit-documentation.storage.googleapis.com/Documentation/2.15/user-search.html"/>
                                 </j:when>
                                 <j:otherwise>
                                     <j:set var="helpUrl" value="${frontEndUrl + 'Documentation/user-search.html'}"/>


### PR DESCRIPTION
The latest release is 2.15 but the documentation still points to 2.13.
