### PR TITLE
skip updating the dynamic configuration if jobs are disabled

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
@@ -63,6 +63,9 @@ public class GerritTriggerTimerTask extends TimerTask {
         if (StringUtils.isEmpty(trigger.getTriggerConfigURL())) {
             return;
         }
+        if (!trigger.getJob().isBuildable()) {
+        	return;
+        }
         trigger.updateTriggerConfigURL();
     }
 


### PR DESCRIPTION
There's no need to continuously inquire the dynamic config if job is disabled