### PR TITLE
Fix problem with static access to SimpleDateFormat

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/BuildMemoryReport.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/BuildMemoryReport.java
@@ -32,6 +32,8 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
 import hudson.model.ModelObject;
 
 import javax.annotation.Nonnull;
+
+import java.text.DateFormat;
 import java.text.SimpleDateFormat;
 import java.util.Collection;
 import java.util.Collections;
@@ -58,8 +60,12 @@ public class BuildMemoryReport implements Map<GerritTriggeredEvent, List<BuildMe
      *
      * A variant of ISO 8601 with the 'T' replaced by a space for simpler ocular parsing.
      */
-    public static final SimpleDateFormat TS_FORMAT = new SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ");
-
+    public static final ThreadLocal<DateFormat> TS_FORMAT = new ThreadLocal<DateFormat>() {
+        @Override
+        public DateFormat get() {
+            return new SimpleDateFormat("yyyy-MM-dd HH:mm:ssZ");
+        }
+      };
 
     /**
      * Default Constructor.
@@ -121,7 +127,7 @@ public class BuildMemoryReport implements Map<GerritTriggeredEvent, List<BuildMe
             display.append(((RefUpdated)event).getRefUpdate().getProject());
         }
         display.append(" @ ");
-        display.append(TS_FORMAT.format(event.getEventCreatedOn()));
+        display.append(TS_FORMAT.get().format(event.getEventCreatedOn()));
         return display.toString();
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/support/BuildMemoryComponent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/support/BuildMemoryComponent.java
@@ -24,6 +24,7 @@
 
 package com.sonyericsson.hudson.plugins.gerrit.trigger.diagnostics.support;
 
+import static com.sonyericsson.hudson.plugins.gerrit.trigger.diagnostics.BuildMemoryReport.TS_FORMAT;
 import com.cloudbees.jenkins.support.api.Component;
 import com.cloudbees.jenkins.support.api.Container;
 import com.cloudbees.jenkins.support.api.PrintedContent;
@@ -41,7 +42,6 @@ import hudson.security.Permission;
 
 import java.io.IOException;
 import java.io.PrintWriter;
-import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -82,7 +82,6 @@ public class BuildMemoryComponent extends Component {
                     //logging is performed by getInstance() above
                     return;
                 }
-                SimpleDateFormat tsFormat = BuildMemoryReport.TS_FORMAT;
                 BuildMemoryReport report = toGerritRunListener.report();
                 out.println("#" + getDisplayName());
                 out.println();
@@ -111,11 +110,11 @@ public class BuildMemoryComponent extends Component {
                         }
                         String startedAt = "";
                         if (en.getStartedTimestamp() != null) {
-                            startedAt = tsFormat.format(new Date(en.getStartedTimestamp()));
+                            startedAt = TS_FORMAT.get().format(new Date(en.getStartedTimestamp()));
                         }
                         String completedAt = "";
                         if (en.getCompletedTimestamp() != null) {
-                            completedAt = tsFormat.format(new Date(en.getCompletedTimestamp()));
+                            completedAt = TS_FORMAT.get().format(new Date(en.getCompletedTimestamp()));
                         }
 
                         out.println(" * Job: " + name);
@@ -123,7 +122,7 @@ public class BuildMemoryComponent extends Component {
                         out.println("    - Completed: " + en.isBuildCompleted());
                         out.println("    - Cancelled: " + en.isCancelled());
                         out.println("    - Result: " + result);
-                        out.println("    - Triggered@ " + tsFormat.format(en.getTriggeredTimestamp()));
+                        out.println("    - Triggered@ " + TS_FORMAT.get().format(en.getTriggeredTimestamp()));
                         out.println("    - Started@ " + startedAt);
                         out.println("    - Completed@ " + completedAt);
                     }


### PR DESCRIPTION
The BuildMemoryReport.TS_FORMAT is a static field of type java.text.DateFormat, which is not thread safe

As the JavaDoc states, DateFormats are inherently unsafe for multithreaded use. More on that plus the fix that I have used can be found here [1]

[1] https://stackoverflow.com/questions/4021151/java-dateformat-is-not-threadsafe-what-does-this-leads-to