### PR TITLE
Fix the synchronisation block in gerritEvent()

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -302,7 +302,7 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Na
             //add to cache
             if (!playBackComplete) {
                 boolean receivedEvtFound = false;
-                synchronized (receivedEventCache) {
+                synchronized (this) {
                   Iterator<GerritTriggeredEvent> i = receivedEventCache.iterator(); // Must be in synchronized block
                   while (i.hasNext()) {
                       GerritTriggeredEvent rEvt = i.next();


### PR DESCRIPTION
In GerritMissedEventsPlaybackManager there is gerritEvent method with a block that  synchronizes on the receivedEventCache field. It will get a lock on the referenced object that might be changed in line 322. That means that the lock might not work as expected.

Running SpotBugs on the class reveals this problem.