### PR TITLE
Add missing metadata on the maven-surefire-plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,6 +227,7 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemProperties>

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
                 <configuration>
                     <systemProperties>
                         <property>


### PR DESCRIPTION
The configuration for the maven-surefire-plugin was missing the groupId and version values.
