### PR TITLE
[JENKINS-55262] Missing content-type on serverStatuses REST API

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/serverStatuses.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/serverStatuses.jelly
@@ -1,5 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
          xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<st:contentType value="application/json" />
 ${it.serverStatuses}
 </j:jelly>


### PR DESCRIPTION
Add Jelly tag to set content-type HTTP header on JSON response.

Fix issue with some reverse proxy/browser combinaison (See [JENKINS-55262](https://issues.jenkins-ci.org/browse/JENKINS-55262))