### PR TITLE
Move to Java 8 & Jenkins 2.60

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,10 @@ Each job can be configured with one Gerrit server.
 
 # Environments
 * `linux`
-    * `java-1.7`
+    * `java-1.8`
         * `maven-3.3.3`
 
-* Java 1.7: minimum development environment.
-* Java 8: Works.
-* Java 6 Runtime compatible
+* Java 8: needed development environment.
 
 You should have no problem running the plugin on a Windows server.
 
@@ -52,7 +50,7 @@ The _(build-config)_ directory contains "special" CheckStyle configurations and 
 fail during the verification phase if you don't follow them.
 
     mvn clean package
-    
+
 Run findbugs for future reference or to make sure you haven't introduced any
 new warnings
 
@@ -68,6 +66,10 @@ To test in a local Jenkins instance
 
     mvn hpi:run
 
+# Clean test environment
+
+    mvn clean
+    rm $TMPDIR/jenkins-testkey* hostkey.ser # Needing when changing SSH components versions
 
 # License
 
@@ -93,4 +95,3 @@ To test in a local Jenkins instance
     LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
     OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
     THE SOFTWARE.
-

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ To test in a local Jenkins instance
 # Clean test environment
 
     mvn clean
-    rm $TMPDIR/jenkins-testkey* hostkey.ser # Needing when changing SSH components versions
+    rm /tmp/jenkins-testkey* hostkey.ser # Needed when changing SSH components versions
 
 # License
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.30</version>
+        <version>3.32</version>
         <relativePath />
     </parent>
 
@@ -54,16 +54,17 @@
 
     <properties>
         <jenkins.version>1.609.3</jenkins.version>
-        <!--<jenkins.version>2.5-SNAPSHOT</jenkins.version>-->
-        <java.level>6</java.level>
+        <!-- <jenkins.version>1.625.1</jenkins.version> First LTS for java 7 and java 8 (remove java 6) / 2015 -->
+        <!-- <jenkins.version>2.60.1</jenkins.version> First LTS for java 8 only / 2017 -->
+        <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <findbugs.failOnError>false</findbugs.failOnError>
         <concurrency>1C</concurrency>
         <powermock.version>1.6.2</powermock.version>
         <checkstyle.version>2.13</checkstyle.version>
         <mockito.version>1.10.19</mockito.version>
-        <workflow.version>1.14</workflow.version>
-        <workflow.version.test>1.14.1-beta-1</workflow.version.test>
+        <workflow.version>1.14.2</workflow.version>
+        <workflow.version.test>1.14.2</workflow.version.test>
     </properties>
 
     <dependencies>
@@ -88,13 +89,12 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.3</version>
+            <version>2.4.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git-client</artifactId>
-            <version>1.11.1</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -106,7 +106,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>rabbitmq-consumer</artifactId>
-            <version>2.2</version>
+            <version>2.8</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -118,7 +118,7 @@
         <dependency>
             <groupId>commons-net</groupId>
             <artifactId>commons-net</artifactId>
-            <version>2.0</version>
+            <version>3.6</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -147,17 +147,17 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-jdk14</artifactId>
-            <version>1.6.1</version>
+            <version>1.7.25</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -187,7 +187,7 @@
         <dependency>
             <groupId>org.apache.sshd</groupId>
             <artifactId>sshd-core</artifactId>
-            <version>0.13.0</version>
+            <version>0.14.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -208,6 +208,20 @@
             <scope>provided</scope>
         </dependency>
     </dependencies>
+    <dependencyManagement>
+      <dependencies>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>git-client</artifactId>
+          <version>1.19.6</version>
+        </dependency>
+        <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>script-security</artifactId>
+          <version>1.16</version>
+        </dependency>
+      </dependencies>
+    </dependencyManagement>
     <repositories>
         <repository>
             <id>repo.jenkins-ci.org</id>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,8 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.14</jenkins.version> <!-- First version with auto-closeable ACLs / 2016 -->
-        <!-- <jenkins.version>2.60.1</jenkins.version> First LTS for java 8 only / 2017 -->
+        <!-- <jenkins.version>2.14</jenkins.version>  First version with auto-closeable ACLs / 2016 -->
+        <jenkins.version>2.60.1</jenkins.version> <!-- First LTS for java 8 only / 2017 -->
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <findbugs.failOnError>false</findbugs.failOnError>
@@ -163,7 +163,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,8 +53,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>1.609.3</jenkins.version>
-        <!-- <jenkins.version>1.625.1</jenkins.version> First LTS for java 7 and java 8 (remove java 6) / 2015 -->
+        <jenkins.version>2.14</jenkins.version> <!-- First version with auto-closeable ACLs / 2016 -->
         <!-- <jenkins.version>2.60.1</jenkins.version> First LTS for java 8 only / 2017 -->
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
@@ -136,6 +135,13 @@
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
             <version>${workflow.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <!-- Used for test with matrix permissions -->
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-auth</artifactId>
+            <version>2.3</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -319,8 +325,8 @@
                 <configuration>
                     <signature>
                         <groupId>org.codehaus.mojo.signature</groupId>
-                        <artifactId>java16</artifactId>
-                        <version>1.1</version>
+                        <artifactId>java18</artifactId>
+                        <version>1.0</version>
                     </signature>
                 </configuration>
                 <executions>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -1329,7 +1329,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
             Integer.parseInt(value);
             return FormValidation.ok();
         } catch (NumberFormatException e) {
-            return FormValidation.error(hudson.model.Messages.Hudson_NotANumber());
+            return FormValidation.error(Messages.NotANumber());
         }
     }
 
@@ -1349,7 +1349,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
                 Integer.parseInt(value);
                 return FormValidation.ok();
             } catch (NumberFormatException e) {
-                return FormValidation.error(hudson.model.Messages.Hudson_NotANumber());
+                return FormValidation.error(Messages.NotANumber());
             }
         }
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/JenkinsAwareGerritHandler.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/JenkinsAwareGerritHandler.java
@@ -23,6 +23,8 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger;
 
+import hudson.security.ACL;
+import hudson.security.ACLContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -73,8 +75,10 @@ public class JenkinsAwareGerritHandler extends GerritHandler {
             }
         }
 
-        // The read deal
-        super.notifyListeners(event);
+        try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
+            // The read deal
+            super.notifyListeners(event);
+        }
 
         // //Notify lifecycle listeners.
         if (event instanceof GerritEventLifecycle) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/SystemEventThread.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/SystemEventThread.java
@@ -23,10 +23,8 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger;
 
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
-
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 
 import com.sonymobile.tools.gerrit.gerritevents.workers.Coordinator;
 import com.sonymobile.tools.gerrit.gerritevents.workers.EventThread;
@@ -61,11 +59,8 @@ public class SystemEventThread extends EventThread {
      */
     @Override
     public void run() {
-        SecurityContext old = ACL.impersonate(ACL.SYSTEM);
-        try {
+        try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
             super.run();
-        } finally {
-            SecurityContextHolder.setContext(old);
         }
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJob.java
@@ -38,13 +38,11 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ReviewLabel;
 
 import hudson.model.TaskListener;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
 
 /**
 * A job for the {@link com.sonymobile.tools.gerrit.gerritevents.GerritSendCommandQueue} that
@@ -79,8 +77,7 @@ public class BuildCompletedRestCommandJob extends AbstractRestCommandJob {
 
     @Override
     protected ReviewInput createReview() {
-        SecurityContext old = ACL.impersonate(ACL.SYSTEM);
-        try {
+        try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
             String message = parameterExpander.getBuildCompletedMessage(memoryImprint, listener);
             Collection<ReviewLabel> scoredLabels = new ArrayList<ReviewLabel>();
             if (memoryImprint.getEvent().isScorable()) {
@@ -119,8 +116,6 @@ public class BuildCompletedRestCommandJob extends AbstractRestCommandJob {
 
             return new ReviewInput(message, scoredLabels, commentedFiles).setNotify(notificationLevel)
                 .setTag(Constants.TAG_VALUE);
-        } finally {
-            SecurityContextHolder.setContext(old);
         }
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/ssh/BuildCompletedCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/ssh/BuildCompletedCommandJob.java
@@ -25,9 +25,6 @@
 
 package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.ssh;
 
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
-
 import com.sonymobile.tools.gerrit.gerritevents.workers.cmd.AbstractSendCommandJob;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.config.IGerritHudsonTriggerConfig;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.GerritNotifier;
@@ -36,6 +33,7 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.Build
 
 import hudson.model.TaskListener;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 
 /**
  * A send-command-job that calculates and sends the builds completed command.
@@ -64,13 +62,10 @@ public class BuildCompletedCommandJob extends AbstractSendCommandJob {
 
     @Override
     public void run() {
-        SecurityContext old = ACL.impersonate(ACL.SYSTEM);
-        try {
+        try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
             GerritNotifier notifier = NotificationFactory.getInstance()
                 .createGerritNotifier((IGerritHudsonTriggerConfig)getConfig(), this);
             notifier.buildCompleted(memoryImprint, listener);
-        } finally {
-            SecurityContextHolder.setContext(old);
         }
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/ssh/BuildStartedCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/ssh/BuildStartedCommandJob.java
@@ -26,8 +26,6 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.job.ssh;
 
 import hudson.model.Run;
-import org.acegisecurity.context.SecurityContext;
-import org.acegisecurity.context.SecurityContextHolder;
 
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.workers.cmd.AbstractSendCommandJob;
@@ -38,6 +36,7 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.Build
 
 import hudson.model.TaskListener;
 import hudson.security.ACL;
+import hudson.security.ACLContext;
 
 /**
  * A send-command-job that calculates and sends the build started command.
@@ -73,13 +72,10 @@ public class BuildStartedCommandJob extends AbstractSendCommandJob {
 
     @Override
     public void run() {
-        SecurityContext old = ACL.impersonate(ACL.SYSTEM);
-        try {
+        try (ACLContext ctx = ACL.as(ACL.SYSTEM)) {
             GerritNotifier notifier = NotificationFactory.getInstance()
                 .createGerritNotifier((IGerritHudsonTriggerConfig)getConfig(), this);
             notifier.buildStarted(build, taskListener, event, stats);
-        } finally {
-            SecurityContextHolder.setContext(old);
         }
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -81,7 +81,6 @@ import hudson.model.Executor;
 import hudson.model.Hudson;
 import hudson.model.Item;
 import hudson.model.ItemGroup;
-import hudson.model.Items;
 import hudson.model.Job;
 import hudson.model.ParametersAction;
 import hudson.model.Queue;
@@ -1958,13 +1957,10 @@ public class GerritTrigger extends Trigger<Job> {
                     assert jenkins != null;
                     Item item = jenkins.getItem(projectName, project, Item.class);
                     if ((item == null) || !(item instanceof Job)) {
-                        Job nearest = Items.findNearest(Job.class,
-                                projectName,
-                                project.getParent()
-                        );
+                        AbstractProject nearest = AbstractProject.findNearest(projectName);
                         String path = "<null>";
                         if (nearest != null) {
-                            path = nearest.getRelativeNameFrom(project);
+                            path = nearest.getFullName();
                         }
                         return FormValidation.error(
                                 Messages.NoSuchJobExists(

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1932,7 +1932,7 @@ public class GerritTrigger extends Trigger<Job> {
                     Integer.parseInt(value);
                     return FormValidation.ok();
                 } catch (NumberFormatException e) {
-                    return FormValidation.error(hudson.model.Messages.Hudson_NotANumber());
+                    return FormValidation.error(Messages.NotANumber());
                 }
             }
         }
@@ -1976,7 +1976,7 @@ public class GerritTrigger extends Trigger<Job> {
                             path = nearest.getRelativeNameFrom(project);
                         }
                         return FormValidation.error(
-                                hudson.model.Messages.AbstractItem_NoSuchJobExists(
+                                Messages.NoSuchJobExists(
                                         projectName,
                                         path));
                     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -114,6 +114,7 @@ import java.util.StringTokenizer;
 import java.util.regex.PatternSyntaxException;
 
 import jenkins.model.Jenkins;
+import jenkins.model.ParameterizedJobMixIn;
 
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.AncestorInPath;
@@ -534,17 +535,7 @@ public class GerritTrigger extends Trigger<Job> {
             return null;
         }
 
-        if (project instanceof ParameterizedJob) {
-            // TODO: After 1.621, use ParameterizedJobMixIn.getTrigger
-            ParameterizedJob parameterizedJob = (ParameterizedJob)project;
-            for (Trigger p : parameterizedJob.getTriggers().values()) {
-                if (GerritTrigger.class.isInstance(p)) {
-                    return GerritTrigger.class.cast(p);
-                }
-            }
-        }
-
-        return null;
+        return ParameterizedJobMixIn.getTrigger(project, GerritTrigger.class);
     }
 
     /**

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -192,3 +192,5 @@ BuildMemoryReport.DisplayName=Build Coordination Report
 EventListenersReport.DisplayName=Event Listeners
 GerritProjectListUpdater.For=GerritProjectListUpdater for server: {0}
 GerritMissedEventsPlaybackManager.For=GerritMissedEventsPlaybackManager for server: {0}
+NotANumber=Not a number
+NoSuchJobExists=No such job ‘{0}’ exists. Perhaps you meant ‘{1}’?

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -193,4 +193,4 @@ EventListenersReport.DisplayName=Event Listeners
 GerritProjectListUpdater.For=GerritProjectListUpdater for server: {0}
 GerritMissedEventsPlaybackManager.For=GerritMissedEventsPlaybackManager for server: {0}
 NotANumber=Not a number
-NoSuchJobExists=No such job ‘{0}’ exists. Perhaps you meant ‘{1}’?
+NoSuchJobExists=No such job \u2018{0}\u2019 exists. Perhaps you meant \u2018{1}\u2019?

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServerHudsonTest.java
@@ -254,7 +254,7 @@ public class GerritServerHudsonTest {
         HtmlPage removalPage = j.createWebClient().getPage(url);
 
         HtmlForm form = removalPage.getFormByName(removalFormName);
-        List<HtmlElement> buttons = form.getHtmlElementsByTagName("button");
+        List<HtmlElement> buttons = form.getElementsByTagName("button");
         textContent = form.getTextContent();
         if (buttons.size() >= 1) {
             j.submit(form);

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
@@ -345,7 +345,7 @@ public class SshdServerMock implements CommandFactory {
     public static SshServer startServer(SshdServerMock server) throws IOException {
         SshServer sshd = SshServer.setUpDefaultServer();
         sshd.setPort(0);
-        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("hostkey.ser"));
+        sshd.setKeyPairProvider(new SimpleGeneratorHostKeyProvider("hostkey.ser", "RSA"));
         List<NamedFactory<UserAuth>>userAuthFactories = new ArrayList<NamedFactory<UserAuth>>();
         userAuthFactories.add(new UserAuthNone.Factory());
         sshd.setUserAuthFactories(userAuthFactories);

--- a/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
+++ b/src/test/java/com/sonymobile/tools/gerrit/gerritevents/mock/SshdServerMock.java
@@ -445,7 +445,11 @@ public class SshdServerMock implements CommandFactory {
      * @throws JSchException        if creation of the keys goes wrong.
      */
     public static KeyPairFiles generateKeyPair() throws IOException, InterruptedException, JSchException {
-        File tmp = new File(System.getProperty("java.io.tmpdir"));
+        // Can't use java.io.tmp: '/tmp' is explicitely set in some XML config files.`
+        File tmp = new File("/tmp");
+        if (!tmp.exists()) {
+            tmp.mkdirs();
+        }
         File priv = new File(tmp, "jenkins-testkey");
         File pub = new File(tmp, "jenkins-testkey.pub");
         final KeyPairFiles sshKey;


### PR DESCRIPTION
This change allow use of Java 8 enhancements and  remove compatibility with Java 6 & 7.
Upgrade to Jenkins core 2.60 is needed to expose Java 8 requirement.

Some dependencies are updated to match new jenkins core and jenkins plugin POM parent changes, but many dependencies are still old: we could choose to upgrade them, too.

Dependencies update discussed in PR 383