### PR TITLE
Specify a prefix for limiting the list of Gerrit Projects

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdater.java
@@ -54,8 +54,9 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
     /**
      * The command for fetching projects.
      */
-    public static final String GERRIT_LS_PROJECTS = "gerrit ls-projects";
+    public static final String GERRIT_LS_PROJECTS = "gerrit ls-projects --prefix ";
     private static final int MAX_WAIT_TIME = 64;
+    private final String projectPrefix;
 
     private AtomicBoolean connected = new AtomicBoolean(false);
     private boolean shutdown = false;
@@ -66,11 +67,13 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
     /**
      * Default constructor.
      * @param serverName the name of the Gerrit server.
+     * @param projectPrefix of the projects to list from the Gerrit server.
      */
-    public GerritProjectListUpdater(String serverName) {
+    public GerritProjectListUpdater(String serverName, String projectPrefix) {
         this.setName(this.getClass().getName() + " for " + serverName + " Thread");
         this.setDaemon(true);
         this.serverName = serverName;
+        this.projectPrefix = projectPrefix;
         addThisAsListener();
     }
 
@@ -239,7 +242,8 @@ public class GerritProjectListUpdater extends Thread implements ConnectionListen
                         activeConfig.getGerritProxy(),
                         activeConfig.getGerritAuthentication()
                 );
-                List<String> projects = readProjects(sshConnection.executeCommandReader(GERRIT_LS_PROJECTS));
+                List<String> projects = readProjects(sshConnection
+                        .executeCommandReader(GERRIT_LS_PROJECTS + projectPrefix));
                 if (projects.size() > 0) {
                     setGerritProjects(projects);
                     logger.info("Project list from {} contains {} entries", serverName, projects.size());

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -143,6 +143,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
     private static final int RESPONSE_INTERVAL_MS = 1000;
     private static final int RESPONSE_TIMEOUT_S = 10;
     private String name;
+    private String projectPrefix;
     @Deprecated
     private transient boolean pseudoMode;
     private boolean noConnectionOnStartup;
@@ -249,6 +250,26 @@ public class GerritServer implements Describable<GerritServer>, Action {
     @Exported
     public String getName() {
         return name;
+    }
+
+    /**
+     * Get the prefix for fetching all project names.
+     *
+     * @return projects prefix.
+     */
+    @Exported
+    public String getProjectPrefix() {
+        return projectPrefix;
+    }
+
+    /**
+     * Set the prefix for fetching all project names.
+     *
+     * @param projectPrefix prefix of the projects to list from the Gerrit Server.
+     */
+    @Exported
+    public void setProjectPrefix(String projectPrefix) {
+        this.projectPrefix = projectPrefix;
     }
 
     /**
@@ -445,7 +466,7 @@ public class GerritServer implements Describable<GerritServer>, Action {
         initializeConnectionListener();
 
         projectListUpdater =
-                new GerritProjectListUpdater(name);
+                new GerritProjectListUpdater(name, projectPrefix);
         projectListUpdater.start();
 
         missedEventsPlaybackManager.checkIfEventsLogPluginSupported();


### PR DESCRIPTION
The GerritServer thread executes an unlimited gerrit ls-projects
at startup which has two major issues:

1. May take a very long time, because the list of projects could
   be huge, even hundreds of thousands of repositories.

2. May cause trouble to the Gerrit Server that has to load *ALL*
   projects in memory to access their configuration and evaluate
   the ACLs.

By introducing a projects prefix pattern, the GerritServer startup
speed could be increased by 20x or even 100x, depending on the
Gerrit server that is connecting to.