### PR TITLE
Fix unstable forbidden file trigger

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
@@ -32,6 +32,7 @@ import hudson.model.Descriptor;
 import hudson.model.Hudson;
 import hudson.util.ComboBoxModel;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -219,7 +220,7 @@ public class GerritProject implements Describable<GerritProject> {
                 boolean foundInterestingForbidden = false;
                 if (b.isInteresting(branch)) {
                     if (forbiddenFilePaths != null) {
-                        Iterator<String> i = files.iterator();
+                        Iterator<String> i = new ArrayList<String>(files).iterator();
                         while (i.hasNext()) {
                             String file = i.next();
                             for (FilePath ffp : forbiddenFilePaths) {


### PR DESCRIPTION
Issue: Suppose we have 2 jobs A and B. If A's forbidden file path matches B's normal trigger path, sometimes B doesn't get triggered at all because the list of files associated to the Gerrit change is changed dynamically in line 232 of GerritProject.java

Example: Gerrit change on the file desk/extension/build.gradle. The filelist becomes ["/COMMITMSG", "desk/extension/build.gradle"]. Suppose A's forbidden file path is "desk/extension/" and B's trigger path is "desk/extension/" (the same)

If A is processed first, if we disable strict forbidden file verification, at line 232 of GerritTrigger.java we have:
`i.remove();`
which removes "desk/extension/build.gradle" from the global list of files for those associated 2 triggers. Then, when B is processed, the global file list contains only ["/COMMITMSG"] so it doesn't get triggered.

This change solves the bug by **not modifying the global variable and creating a clone instead**.