### PR TITLE
Demonstrating #jenkinsci/plugin-pom#236

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.32</version>
+        <version>3.51-SNAPSHOT</version>
         <relativePath />
     </parent>
 
@@ -57,6 +57,7 @@
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <findbugs.failOnError>false</findbugs.failOnError>
+        <violations.maxViolations>0</violations.maxViolations>
         <concurrency>1C</concurrency>
         <powermock.version>1.6.2</powermock.version>
         <checkstyle.version>2.13</checkstyle.version>
@@ -328,6 +329,7 @@
                     <suppressionsFileExpression>checkstyle.suppressions.file</suppressionsFileExpression>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <consoleOutput>true</consoleOutput>
+                    <failsOnError>false</failsOnError>
                 </configuration>
                 <executions>
                     <execution>
@@ -336,15 +338,8 @@
                             <goal>checkstyle</goal>
                         </goals>
                         <phase>compile</phase>
-                    </execution>
-                    <execution>
-                        <id>test-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <phase>test</phase>
                         <configuration>
-                            <violationSeverity>warning</violationSeverity>
+                            <failsOnError>false</failsOnError>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/PluginImpl.java
@@ -74,7 +74,14 @@ public class PluginImpl extends Plugin {
     /**
      * What to call this plug-in to humans.
      */
-    public static final String DISPLAY_NAME = "Gerrit Trigger";
+    public static final String DISPLAY_NAME = "Gerrit Trigger";  
+
+
+//This should give a warning
+
+    public static final String dISPLAY_NAME = "Gerrit Trigger";  
+
+
 
     /**
      * Any special permissions needed by this plugin are grouped into this.


### PR DESCRIPTION
This is just a demonstration of #jenkinsci/plugin-pom#236

Feel free to just close the PR whenever you want. I just need it for demonstration purpose!

Check the build log:
```bash
...
[2019-10-05T15:46:04.333Z] com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
[2019-10-05T15:46:04.333Z] |          |          |          |      |                                                 |
[2019-10-05T15:46:04.333Z] | Reporter | Rule     | Severity | Line | Message                                         |
[2019-10-05T15:46:04.333Z] |          |          |          |      |                                                 |
[2019-10-05T15:46:04.333Z] +----------+----------+----------+------+-------------------------------------------------+
[2019-10-05T15:46:04.333Z] |          |          |          |      |                                                 |
[2019-10-05T15:46:04.333Z] | Spotbugs | IS2_INCO | INFO     | 599  | Inconsistent synchronization <p> The fields  of |
[2019-10-05T15:46:04.333Z] |          | NSISTENT |          |      | this class appear to be accessed inconsistently |
[2019-10-05T15:46:04.333Z] |          | _SYNC    |          |      | with respect to synchronization.&nbsp; This bug |
[2019-10-05T15:46:04.333Z] |          |          |          |      | report indicates that the bug pattern  detector |
[2019-10-05T15:46:04.333Z] |          |          |          |      | judged that </p> <ul> <li> The class contains a |
[2019-10-05T15:46:04.333Z] |          |          |          |      | mix of locked and unlocked accesses,</li>  <li> |
[2019-10-05T15:46:04.333Z] |          |          |          |      | The   class   is   <b>not</b>   annotated    as |
[2019-10-05T15:46:04.333Z] |          |          |          |      | javax.annotation.concurrent.NotThreadSafe,</li> |
[2019-10-05T15:46:04.333Z] |          |          |          |      | <li> At least one locked access  was  performed |
[2019-10-05T15:46:04.333Z] |          |          |          |      | by one of the  class's  own  methods,  and</li> |
[2019-10-05T15:46:04.333Z] |          |          |          |      | <li>  The  number   of   unsynchronized   field |
[2019-10-05T15:46:04.333Z] |          |          |          |      | accesses (reads and writes) was  no  more  than |
[2019-10-05T15:46:04.333Z] |          |          |          |      | one third of all accesses,  with  writes  being |
[2019-10-05T15:46:04.333Z] |          |          |          |      | weighed twice as high as reads</li> </ul> <p> A |
[2019-10-05T15:46:04.333Z] |          |          |          |      | typical  bug  matching  this  bug  pattern   is |
[2019-10-05T15:46:04.333Z] |          |          |          |      | forgetting to synchronize one of the methods in |
[2019-10-05T15:46:04.333Z] |          |          |          |      | a class that is intended to be thread-safe.</p> |
[2019-10-05T15:46:04.333Z] |          |          |          |      | <p>  You   can   select   the   nodes   labeled |
[2019-10-05T15:46:04.333Z] |          |          |          |      | "Unsynchronized  access"  to  show   the   code |
[2019-10-05T15:46:04.333Z] |          |          |          |      | locations where the detector  believed  that  a |
[2019-10-05T15:46:04.333Z] |          |          |          |      | field was accessed without synchronization.</p> |
[2019-10-05T15:46:04.333Z] |          |          |          |      | <p> Note that  there  are  various  sources  of |
[2019-10-05T15:46:04.333Z] |          |          |          |      | inaccuracy in this detector; for  example,  the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | detector   cannot   statically    detect    all |
[2019-10-05T15:46:04.333Z] |          |          |          |      | situations in which a lock is held.&nbsp; Also, |
[2019-10-05T15:46:04.333Z] |          |          |          |      | even  when  the   detector   is   accurate   in |
[2019-10-05T15:46:04.333Z] |          |          |          |      | distinguishing locked  vs.  unlocked  accesses, |
[2019-10-05T15:46:04.333Z] |          |          |          |      | the code in question may still be correct.</p>  |
[2019-10-05T15:46:04.333Z] |          |          |          |      |                                                 |
[2019-10-05T15:46:04.333Z] +----------+----------+----------+------+-------------------------------------------------+
[2019-10-05T15:46:04.333Z] |          |          |          |      |                                                 |
[2019-10-05T15:46:04.333Z] | Spotbugs | RV_RETUR | INFO     | 566  | Method ignores  exceptional  return  value  <p> |
[2019-10-05T15:46:04.333Z] |          | N_VALUE_ |          |      | This  method  returns  a  value  that  is   not |
[2019-10-05T15:46:04.333Z] |          | IGNORED_ |          |      | checked. The return  value  should  be  checked |
[2019-10-05T15:46:04.333Z] |          | BAD_PRAC |          |      | since it can indicate an unusual or  unexpected |
[2019-10-05T15:46:04.333Z] |          | TICE     |          |      | function   execution.    For    example,    the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | <code>File.delete()</code> method returns false |
[2019-10-05T15:46:04.333Z] |          |          |          |      | if the file could not be  successfully  deleted |
[2019-10-05T15:46:04.333Z] |          |          |          |      | (rather than throwing  an  Exception).  If  you |
[2019-10-05T15:46:04.333Z] |          |          |          |      | don't check the result, you won't notice if the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | method invocation signals  unexpected  behavior |
[2019-10-05T15:46:04.333Z] |          |          |          |      | by returning an atypical return value. </p>     |
[2019-10-05T15:46:04.333Z] |          |          |          |      |                                                 |
[2019-10-05T15:46:04.333Z] +----------+----------+----------+------+-------------------------------------------------+
[2019-10-05T15:46:04.333Z] Summary of com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
[2019-10-05T15:46:04.333Z] |          |      |      |       |       |
[2019-10-05T15:46:04.333Z] | Reporter | INFO | WARN | ERROR | Total |
[2019-10-05T15:46:04.333Z] |          |      |      |       |       |
[2019-10-05T15:46:04.333Z] +----------+------+------+-------+-------+
[2019-10-05T15:46:04.333Z] |          |      |      |       |       |
[2019-10-05T15:46:04.333Z] | Spotbugs | 2    | 0    | 0     | 2     |
[2019-10-05T15:46:04.333Z] |          |      |      |       |       |
[2019-10-05T15:46:04.333Z] +----------+------+------+-------+-------+
[2019-10-05T15:46:04.333Z] |          |      |      |       |       |
[2019-10-05T15:46:04.333Z] |          | 2    | 0    | 0     | 2     |
[2019-10-05T15:46:04.333Z] |          |      |      |       |       |
[2019-10-05T15:46:04.333Z] +----------+------+------+-------+-------+
[2019-10-05T15:46:04.333Z] 
[2019-10-05T15:46:04.333Z] 
[2019-10-05T15:46:04.333Z] hudson/util/VersionNumber.java
[2019-10-05T15:46:04.333Z] |          |          |          |      |                  |
[2019-10-05T15:46:04.333Z] | Reporter | Rule     | Severity | Line | Message          |
[2019-10-05T15:46:04.333Z] |          |          |          |      |                  |
[2019-10-05T15:46:04.333Z] +----------+----------+----------+------+------------------+
[2019-10-05T15:46:04.333Z] |          |          |          |      |                  |
[2019-10-05T15:46:04.333Z] | Spotbugs | EQ_DOESN | INFO     | 487  | Class    doesn't |
[2019-10-05T15:46:04.333Z] |          | T_OVERRI |          |      | override  equals |
[2019-10-05T15:46:04.333Z] |          | DE_EQUAL |          |      | in    superclass |
[2019-10-05T15:46:04.333Z] |          | S        |          |      | <p>  This  class |
[2019-10-05T15:46:04.333Z] |          |          |          |      | extends a  class |
[2019-10-05T15:46:04.333Z] |          |          |          |      | that defines  an |
[2019-10-05T15:46:04.333Z] |          |          |          |      | equals    method |
[2019-10-05T15:46:04.333Z] |          |          |          |      | and adds fields, |
[2019-10-05T15:46:04.333Z] |          |          |          |      | but      doesn't |
[2019-10-05T15:46:04.333Z] |          |          |          |      | define an equals |
[2019-10-05T15:46:04.333Z] |          |          |          |      | method   itself. |
[2019-10-05T15:46:04.333Z] |          |          |          |      | Thus,   equality |
[2019-10-05T15:46:04.333Z] |          |          |          |      | on instances  of |
[2019-10-05T15:46:04.333Z] |          |          |          |      | this class  will |
[2019-10-05T15:46:04.333Z] |          |          |          |      | ignore       the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | identity of  the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | subclass and the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | added fields. Be |
[2019-10-05T15:46:04.333Z] |          |          |          |      | sure   this   is |
[2019-10-05T15:46:04.333Z] |          |          |          |      | what          is |
[2019-10-05T15:46:04.333Z] |          |          |          |      | intended,    and |
[2019-10-05T15:46:04.333Z] |          |          |          |      | that  you  don't |
[2019-10-05T15:46:04.333Z] |          |          |          |      | need to override |
[2019-10-05T15:46:04.333Z] |          |          |          |      | the       equals |
[2019-10-05T15:46:04.333Z] |          |          |          |      | method. Even  if |
[2019-10-05T15:46:04.333Z] |          |          |          |      | you  don't  need |
[2019-10-05T15:46:04.333Z] |          |          |          |      | to override  the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | equals   method, |
[2019-10-05T15:46:04.333Z] |          |          |          |      | consider         |
[2019-10-05T15:46:04.333Z] |          |          |          |      | overriding    it |
[2019-10-05T15:46:04.333Z] |          |          |          |      | anyway        to |
[2019-10-05T15:46:04.333Z] |          |          |          |      | document     the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | fact  that   the |
[2019-10-05T15:46:04.333Z] |          |          |          |      | equals    method |
[2019-10-05T15:46:04.334Z] |          |          |          |      | for the subclass |
[2019-10-05T15:46:04.334Z] |          |          |          |      | just return  the |
[2019-10-05T15:46:04.334Z] |          |          |          |      | result        of |
[2019-10-05T15:46:04.334Z] |          |          |          |      | invoking         |
[2019-10-05T15:46:04.334Z] |          |          |          |      | super.equals(o). |
[2019-10-05T15:46:04.334Z] |          |          |          |      | </p>             |
[2019-10-05T15:46:04.334Z] |          |          |          |      |                  |
[2019-10-05T15:46:04.334Z] +----------+----------+----------+------+------------------+
[2019-10-05T15:46:04.334Z] Summary of hudson/util/VersionNumber.java
[2019-10-05T15:46:04.334Z] |          |      |      |       |       |
[2019-10-05T15:46:04.334Z] | Reporter | INFO | WARN | ERROR | Total |
[2019-10-05T15:46:04.334Z] |          |      |      |       |       |
[2019-10-05T15:46:04.334Z] +----------+------+------+-------+-------+
[2019-10-05T15:46:04.334Z] |          |      |      |       |       |
[2019-10-05T15:46:04.334Z] | Spotbugs | 1    | 0    | 0     | 1     |
[2019-10-05T15:46:04.334Z] |          |      |      |       |       |
[2019-10-05T15:46:04.334Z] +----------+------+------+-------+-------+
[2019-10-05T15:46:04.334Z] |          |      |      |       |       |
[2019-10-05T15:46:04.334Z] |          | 1    | 0    | 0     | 1     |
[2019-10-05T15:46:04.334Z] |          |      |      |       |       |
[2019-10-05T15:46:04.334Z] +----------+------+------+-------+-------+
[2019-10-05T15:46:04.334Z] 
[2019-10-05T15:46:04.334Z] 
[2019-10-05T15:46:04.334Z] Summary
[2019-10-05T15:46:04.334Z] |            |      |      |       |       |
[2019-10-05T15:46:04.334Z] | Reporter   | INFO | WARN | ERROR | Total |
[2019-10-05T15:46:04.334Z] |            |      |      |       |       |
[2019-10-05T15:46:04.334Z] +------------+------+------+-------+-------+
[2019-10-05T15:46:04.334Z] |            |      |      |       |       |
[2019-10-05T15:46:04.334Z] | Checkstyle | 0    | 0    | 3     | 3     |
[2019-10-05T15:46:04.334Z] |            |      |      |       |       |
[2019-10-05T15:46:04.334Z] +------------+------+------+-------+-------+
[2019-10-05T15:46:04.334Z] |            |      |      |       |       |
[2019-10-05T15:46:04.334Z] | Spotbugs   | 18   | 7    | 10    | 35    |
[2019-10-05T15:46:04.334Z] |            |      |      |       |       |
[2019-10-05T15:46:04.334Z] +------------+------+------+-------+-------+
[2019-10-05T15:46:04.334Z] |            |      |      |       |       |
[2019-10-05T15:46:04.334Z] |            | 18   | 7    | 13    | 38    |
[2019-10-05T15:46:04.334Z] |            |      |      |       |       |
[2019-10-05T15:46:04.334Z] +------------+------+------+-------+-------+
```