### PR TITLE
[JENKINS-56528] Always unblock executors waiting for dynamic trigger configuration

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
@@ -29,7 +29,6 @@ import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * TimerTasks that are created from a GerritTrigger and periodically calls
@@ -60,12 +59,7 @@ public class GerritTriggerTimerTask extends TimerTask {
         if (trigger == null) {
             return;
         }
-        if (StringUtils.isEmpty(trigger.getTriggerConfigURL())) {
-            return;
-        }
-        if (trigger.getJob() != null && !trigger.getJob().isBuildable()) {
-            return;
-        }
+        // Do not skip updates since tasks might wait for the update
         trigger.updateTriggerConfigURL();
     }
 


### PR DESCRIPTION
Executors are waiting for the project to be ready. This is done so the
list of dynamic trigger projects has finished loading. To ensure the
tasks are not waiting forever, the list must always be set and the latch
released, even when the job is disabled or the trigger was disabled,
fetching of the trigger list failed or similar.

This fixes https://issues.jenkins-ci.org/browse/JENKINS-56528