### PR TITLE
Remove "previous version warnings" from readme

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -16,18 +16,6 @@ This plugin integrates Jenkins to
 http://code.google.com/p/gerrit/[Gerrit code review] for triggering
 builds when a "patch set" is created.
 
-
-[NOTE]
-====
-Older versions of this plugin may not be safe to use. Please review the
-following warnings before using an older version:
-
- * https://jenkins.io/security/advisory/2018-02-26/#SECURITY-402[Unauthorized
-access to some Gerrit Trigger server configuration]
-* https://jenkins.io/security/advisory/2018-02-26/#SECURITY-403[Unauthorized
-users were able to change Gerrit Trigger server configuration]
-====
-
 == Set Up
 
 === Gerrit access rights


### PR DESCRIPTION
This content is displayed on the plugin site in the right column using update center API -- that part will be synchronized with security team's recommendations. It is not necessary to have a duplicate in the readme.