### PR TITLE
Some controls ignore current state

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -333,7 +333,7 @@
                                               with="gerritFrontEndUrl,gerritHttpUserName,gerritHttpPassword"/>
                             <f:entry title="${%Enable Code-Review}">
                                 <f:checkbox name="restCodeReview"
-                                            checked="${is.config.restCodeReview}"
+                                            checked="${it.config.restCodeReview}"
                                             default="true" />
                             </f:entry>
                             <f:entry title="${%Enable Verified}">
@@ -459,7 +459,7 @@
                     </f:section>
                 </f:advanced>
                 <f:entry title="${%EnablePluginMessages}">
-                    <f:checkbox name="enablePluginMessages" checked="${it.enablePluginMessages}" default="true"/>
+                    <f:checkbox name="enablePluginMessages" checked="${it.config.enablePluginMessages}" default="true"/>
                 </f:entry>
                 <f:block>
                     <f:submit value="${%Save}"/>


### PR DESCRIPTION
'Enable Code-Review' and 'Allow Other Plugins to Contribute Messages' are always selected despite other state in gerrit-trigger.xml. Cause is rather trivial - typos. This is troublesome since any modification must be done with caution otherwise user can override state unconsciously (especially when field is hidden). This patch should fix the issue.