### PR TITLE
Prevent forbiddenFilePaths from corrupting following filePath matches

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
@@ -32,6 +32,7 @@ import hudson.model.Descriptor;
 import hudson.model.Hudson;
 import hudson.util.ComboBoxModel;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -215,11 +216,12 @@ public class GerritProject implements Describable<GerritProject> {
      */
     public boolean isInteresting(String project, String branch, String topic, List<String> files) {
         if (compareType.matches(pattern, project)) {
+            List<String> tmpFiles = new ArrayList<String>(files);
             for (Branch b : branches) {
                 boolean foundInterestingForbidden = false;
                 if (b.isInteresting(branch)) {
                     if (forbiddenFilePaths != null) {
-                        Iterator<String> i = files.iterator();
+                        Iterator<String> i = tmpFiles.iterator();
                         while (i.hasNext()) {
                             String file = i.next();
                             for (FilePath ffp : forbiddenFilePaths) {
@@ -235,11 +237,11 @@ public class GerritProject implements Describable<GerritProject> {
                             }
                         }
                     }
-                    if (foundInterestingForbidden && files.isEmpty()) {
+                    if (foundInterestingForbidden && tmpFiles.isEmpty()) {
                         // All changed files are forbidden, so this is not interesting
                         return false;
                     }
-                    return isInterestingTopic(topic) && isInterestingFile(files);
+                    return isInterestingTopic(topic) && isInterestingFile(tmpFiles);
                 }
             }
         }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectForbiddenFilesTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectForbiddenFilesTest.java
@@ -1,0 +1,68 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2012 Sony Ericsson Mobile Communications.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data;
+
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Testing if Forbidden File Paths usage corrupts the list of files checked.
+ * @author Peter Walls &lt;peter.walls@se.bosch.com&gt;
+ */
+public class GerritProjectForbiddenFilesTest {
+
+    /**
+     * Constructor.
+     */
+    public GerritProjectForbiddenFilesTest() {
+    }
+
+    /**
+     * Tests.
+     */
+    @Test
+    public void testFileRemoved() {
+        List<Branch> branches = new LinkedList<Branch>();
+        branches.add(new Branch(CompareType.PLAIN, "master"));
+        List<Topic> topics = new LinkedList<Topic>();
+        List<FilePath> filePaths = new LinkedList<FilePath>();
+        List<FilePath> forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePaths.add(new FilePath(CompareType.ANT, "t*.txt"));
+        List<String> files = new LinkedList<String>();
+        files.add("test.txt");
+        files.add("hide.txt");
+        GerritProject config = new GerritProject(
+                CompareType.PLAIN, "project1", branches, topics, filePaths, forbiddenFilePaths, true);
+        config.isInteresting("project1", "master", null, files);
+        filePaths.add(new FilePath(CompareType.PLAIN, "test.txt"));
+        config = new GerritProject(
+                CompareType.PLAIN, "project2", branches, topics, filePaths, null, false);
+
+        assertEquals(true, config.isInteresting("project2", "master", null, files));
+    }
+}


### PR DESCRIPTION
When iterating over multiple jobs set to listen to Gerrit events
a job using forbiddenFilePaths will remove files from the filePaths
that will be checked for jobs that are checked later on. This has
been fixed by changing the file list object to a local copy in the
method doing the check instead of a reference to the object used
later on