### PR TITLE
Fix bug in abort build configuration

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -2303,7 +2303,7 @@ public class GerritTrigger extends Trigger<Job> {
                                 && buildCurrentPatchesOnly.isAbortManualPatchsets()
                                 || !(runningChangeBasedEvent instanceof ManualPatchsetCreated));
 
-                        if (!shouldCancelManual) {
+                        if (!abortBecauseOfTopic && !shouldCancelManual) {
                             continue;
                         }
 


### PR DESCRIPTION
When using the Build Current Patches Only / Abort Patch sets with same topic feature I found that there is a small problem there: 'Abort manual patch sets' needs to be enabled for 'Abort patch sets with same topic' to work

This change should fix this issue by adding abortBecauseOfTopic into the if-clause