### PR TITLE
Only store events from configured server

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -328,6 +328,16 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Na
         if (event instanceof GerritTriggeredEvent) {
             logger.debug("Recording timestamp due to an event {} for server: {}", event, serverName);
             GerritTriggeredEvent triggeredEvent = (GerritTriggeredEvent)event;
+            Provider provider = triggeredEvent.getProvider();
+
+            if (provider != null) {
+              String eventServer = provider.getName();
+              if (!eventServer.equals(serverName)) {
+                logger.debug("{} Ignoring event since it came from different server {}", serverName, eventServer);
+                return;
+              }
+            }
+
             saveTimestamp(triggeredEvent);
             //add to cache
             if (!playBackComplete) {


### PR DESCRIPTION
Ran into an issue with missed events and the watchdog timeout when there are multiple gerrit instances defined.  Events were being stored for all defined servers when new events came in which caused the per server data file with the last seen event to have incorrect information for all servers except the one that produced the event.  This patch checks to see if the event is coming from the configured server before processing the event,  I have been running with this change for several weeks now and have not seen any issues.