### PR TITLE
WIP: Add option for individual triggers to use Build Only Current Patchsets

### DIFF
--- a/build-config/checkstyle-suppressions.xml
+++ b/build-config/checkstyle-suppressions.xml
@@ -11,4 +11,6 @@
               files="InjectedTest.java"/>
     <suppress checks=".+"
               files="[/\\]generated-sources[/\\]"/>
+    <suppress checks="FileLength"
+            files="GerritTrigger.java"/>
 </suppressions>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
@@ -249,7 +249,12 @@ public final class EventListener implements GerritEventListener {
 
         if (event instanceof ChangeBasedEvent) {
             ChangeBasedEvent changeBasedEvent = (ChangeBasedEvent)event;
-            if (serverConfig != null && serverConfig.isGerritBuildCurrentPatchesOnly()) {
+            if (t.getBuildCancellationPolicy() != null && t.getBuildCancellationPolicy().isEnabled())
+            {
+                t.getRunningJobs().cancelTriggeredJob(changeBasedEvent,
+                        t.getJob().getFullName(), t.getBuildCancellationPolicy());
+            }
+            if (serverConfig != null && (serverConfig.isGerritBuildCurrentPatchesOnly())) {
                 t.getRunningJobs().scheduled(changeBasedEvent);
             }
             if (null != changeBasedEvent.getPatchSet()) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackManager.java
@@ -328,16 +328,6 @@ public class GerritMissedEventsPlaybackManager implements ConnectionListener, Na
         if (event instanceof GerritTriggeredEvent) {
             logger.debug("Recording timestamp due to an event {} for server: {}", event, serverName);
             GerritTriggeredEvent triggeredEvent = (GerritTriggeredEvent)event;
-            Provider provider = triggeredEvent.getProvider();
-
-            if (provider != null) {
-              String eventServer = provider.getName();
-              if (!eventServer.equals(serverName)) {
-                logger.debug("{} Ignoring event since it came from different server {}", serverName, eventServer);
-                return;
-              }
-            }
-
             saveTimestamp(triggeredEvent);
             //add to cache
             if (!playBackComplete) {

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -16,13 +16,42 @@
             <f:entry title="${%Silent Start Mode}"
                      field="silentStartMode"
                      help="/plugin/gerrit-trigger/trigger/help-SilentStartMode.html">
-               <f:checkbox name="silentStartMode"
+               <f:checkbox name="silentStartMode" 
                            checked="${it.silentStartMode}"/>
             </f:entry>
             <f:entry title="${%Escape Quotes in Parameter Values}"  field="escapeQuotes"
                  help="/plugin/gerrit-trigger/trigger/help-EscapeQuotes.html">
                 <f:checkbox name="escapeQuotes" default="true" checked="${it.escapeQuotes}"/>
             </f:entry>
+           <f:optionalBlock name="buildCurrentPatchesOnly"
+                            title="${%Build Current Patches Only}"
+                            inline="true"
+                            help="/plugin/gerrit-trigger/trigger/help-BuildCurrentPatchesOnly.html"
+                            field="buildCurrentPatchesOnly"
+                            checked="${it.buildCurrentPatchesOnly}">
+               <f:entry title="${%Abort new patch sets}"
+                        help="/plugin/gerrit-trigger/help-GerritAbortNewPatchSets.html">
+                   <f:checkbox name="abortNewPatchsets"
+                               field="abortNewPatchsets"
+                               checked="${it.abortNewPatchsets}"
+                               default="false"/>
+               </f:entry>
+               <f:entry title="${%Abort manual patch sets}"
+                        help="/plugin/gerrit-trigger/help-GerritAbortManualPatchSets.html">
+                   <f:checkbox name="abortManualPatchsets"
+                               field="abortManualPatchsets"
+                               checked="${it.abortManualPatchsets}"
+                               />
+               </f:entry>
+               <f:entry title="${%Abort patch sets with same topic}"
+                        help="/plugin/gerrit-trigger/help-GerritAbortPatchSetsWithSameTopic.html">
+                   <f:checkbox name="abortSameTopic"
+                               field="abortSameTopic"
+                               checked="${it.abortSameTopic}"
+                               default="false"/>
+               </f:entry>
+           </f:optionalBlock>
+
             <f:entry title="${%Commit message parameter}" field="commitMessageParameterMode">
                 <ff:enum default="BASE64"> <!-- TODO change to f when core dep >= 1.640 -->
                     ${it.toString()}

--- a/src/main/webapp/trigger/help-BuildCurrentPatchesOnly.html
+++ b/src/main/webapp/trigger/help-BuildCurrentPatchesOnly.html
@@ -1,0 +1,4 @@
+
+<p>
+  If checked, only running jobs will be cancelled if a new patch version is pushed over. 
+</p>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/SpecGerritTriggerHudsonTest.java
@@ -91,6 +91,8 @@ public class SpecGerritTriggerHudsonTest {
     private SshServer sshd;
     private SshdServerMock serverMock;
     private GerritServer gerritServer;
+    private static final int DELAY = 2000;
+    private static final int WAIT = 60000;
 
     /**
      * Runs before test method.
@@ -864,8 +866,8 @@ public class SpecGerritTriggerHudsonTest {
     public void testTriggerOnCommentAdded() throws Exception {
         gerritServer.getConfig().setCategories(Setup.createCodeReviewVerdictCategoryList());
         FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJobForCommentAdded(j, "projectX");
-        project.getBuildersList().add(new SleepBuilder(2000));
-        serverMock.waitForCommand(GERRIT_STREAM_EVENTS, 2000);
+        project.getBuildersList().add(new SleepBuilder(DELAY));
+        serverMock.waitForCommand(GERRIT_STREAM_EVENTS, DELAY);
         CommentAdded firstEvent = Setup.createCommentAdded();
         gerritServer.triggerEvent(firstEvent);
         TestUtils.waitForBuilds(project, 1);
@@ -884,8 +886,8 @@ public class SpecGerritTriggerHudsonTest {
         gerritServer.getConfig().setCategories(Setup.createCodeReviewVerdictCategoryList());
 
         FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJobForCommentAdded(j, "projectX");
-        project.getBuildersList().add(new SleepBuilder(2000));
-        serverMock.waitForCommand(GERRIT_STREAM_EVENTS, 2000);
+        project.getBuildersList().add(new SleepBuilder(DELAY));
+        serverMock.waitForCommand(GERRIT_STREAM_EVENTS, DELAY);
 
         gerritServer.triggerEvent(Setup.createCommentAdded());
         gerritServer.triggerEvent(Setup.createCommentAdded());
@@ -922,17 +924,17 @@ public class SpecGerritTriggerHudsonTest {
     @LocalData
     public void testProjectRename() throws Exception {
         FreeStyleProject project = DuplicatesUtil.createGerritTriggeredJob(j, "projectX");
-        serverMock.waitForCommand(GERRIT_STREAM_EVENTS, 2000);
+        serverMock.waitForCommand(GERRIT_STREAM_EVENTS, DELAY);
 
         gerritServer.triggerEvent(Setup.createPatchsetCreated());
 
-        TestUtils.waitForBuilds(project, 1, 60000);
+        TestUtils.waitForBuilds(project, 1, WAIT);
 
         project.renameTo("anotherName");
         project = j.configRoundtrip(project);
 
         gerritServer.triggerEvent(Setup.createPatchsetCreated());
 
-        TestUtils.waitForBuilds(project, 2, 60000);
+        TestUtils.waitForBuilds(project, 2, WAIT);
     }
 }


### PR DESCRIPTION
This expanded work moves the Build Current Patchset functionality from serverwide to configurable on a trigger by trigger basis. 