### PR TITLE
Add listener for cleaning up removed triggers

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritSaveableListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritSaveableListener.java
@@ -1,0 +1,33 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
+import com.sonymobile.tools.gerrit.gerritevents.GerritHandler;
+import hudson.Extension;
+import hudson.XmlFile;
+import hudson.model.Job;
+import hudson.model.Saveable;
+import hudson.model.listeners.SaveableListener;
+
+/**
+ * Listens for updated job configurations. If a trigger is removed from the job
+ * configuration, then we need to remove the associated listener
+ */
+@Extension
+public class GerritSaveableListener extends SaveableListener {
+    @Override
+    public void onChange(Saveable o, XmlFile file) {
+        if (o instanceof Job<?, ?>) {
+            Job<?, ?> project = (Job<?, ?>)o;
+            GerritTrigger gerritTrigger = GerritTrigger.getTrigger(project);
+            if (gerritTrigger == null) {
+                PluginImpl plugin = PluginImpl.getInstance();
+                if (plugin != null) {
+                    GerritHandler handler = plugin.getHandler();
+                    if (handler != null) {
+                        handler.removeListener(new EventListener(project));
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
If a gerrit trigger is removed from a job, then the listener won't be removed. This caused loads of log entires to be written to the Jenkins system log, warning that the trigger couldn't be found. E.g.:

> Couldn't find a configured trigger for Some/Job

This change fixes this issue by listening for save events on jobs and removing listeners if there is no gerrit trigger configured on the newly updated job.