### PR TITLE
[JENKINS-64091] Inspect commit message in PatchSetCreated trigger

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -247,7 +247,6 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
             if (commitMessagePattern == null) {
                 commitMessagePattern = Pattern.compile(
                         this.commitMessageContainsRegEx, Pattern.DOTALL | Pattern.MULTILINE);
-                forceUpdatePattern = false;
             }
             String commitMessage = ((PatchsetCreated)event).getChange().getCommitMessage();
             return commitMessagePattern.matcher(commitMessage).find();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -56,7 +56,7 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
     private String commitMessageContainsRegEx = "";
 
     private transient Pattern commitMessagePattern = null;
-    private boolean forceUpdatePattern = true;
+    
 
     /**
      * Default constructor.
@@ -145,7 +145,7 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
     @DataBoundSetter
     public void setCommitMessageContainsRegEx(String commitMessageContainsRegEx) {
         this.commitMessageContainsRegEx = commitMessageContainsRegEx;
-        this.forceUpdatePattern = true;
+        this.commitMessagePattern = null;
     }
 
     /**
@@ -244,7 +244,7 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
             return false;
         }
         if (StringUtils.isNotEmpty(commitMessageContainsRegEx)) {
-            if (null == commitMessagePattern || forceUpdatePattern) {
+            if (commitMessagePattern == null) {
                 commitMessagePattern = Pattern.compile(
                         this.commitMessageContainsRegEx, Pattern.DOTALL | Pattern.MULTILINE);
                 forceUpdatePattern = false;

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -423,13 +423,13 @@
                             </f:repeatable>
                             </td>
                         </tr>
-                       <tr>
+                        <tr>
                             <td colspan="4" valign="top" style="border-left: 1px solid black; border-right: 1px solid black; border-bottom: 1px solid black;">
                                     <label>Disable Strict Forbidden File Verification</label>
                                     <f:checkbox name="disableStrictForbiddenFileVerification"
                                      checked="${loop.isDisableStrictForbiddenFileVerification()}"/>
                             </td>
-                      </tr>
+                        </tr>
                     </j:if>
                 </table>
             </f:repeatable>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
@@ -45,4 +45,9 @@
              field="excludeWipState">
         <f:checkbox/>
     </f:entry>
+    <f:entry title="${%Commit Message Contains Regular Expression}"
+             field="commitMessageContainsRegEx"
+             help="/plugin/gerrit-trigger/trigger/help-CommitMessageContains.html">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/webapp/trigger/help-CommitMessageContains.html
+++ b/src/main/webapp/trigger/help-CommitMessageContains.html
@@ -1,0 +1,9 @@
+<p>
+	Trigger Build if commit message matches a regular expression.
+</p>
+<p>
+	If not empty, trigger if the commit message matches the regular expression.
+	The regular expression must be in the format that can be parsed by
+	<a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#sum">Java
+	Regular Expression.</a>.
+</p>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
 
@@ -83,6 +84,51 @@ public class PluginPatchsetCreatedEventTest {
         //should fire only on regular patchset (no drafts)
         assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
         patchsetCreated.getPatchSet().setKind(GerritChangeKind.NO_CODE_CHANGE);
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+    }
+
+    /**
+     * Test that it should, or should not, fire if the commit message matches a regular expression.
+     */
+    @Test
+    public void commitMessageRegExCheck() {
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent =
+                new PluginPatchsetCreatedEvent();
+        PatchsetCreated patchsetCreated = new PatchsetCreated();
+        patchsetCreated.setPatchset(new PatchSet());
+        StringBuilder commitMessage = new StringBuilder();
+        commitMessage.append("This is a summary\n");
+        commitMessage.append("\n");
+        commitMessage.append("This is my description.\n");
+        commitMessage.append("\n");
+        commitMessage.append("Issue: JENKINS-64091\n");
+        Change change = new Change();
+        change.setCommitMessage(commitMessage.toString());
+        patchsetCreated.setChange(change);
+
+        // Commit Message regular expression set to null
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx(null);
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Commit message Regular expression is an empty string
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Commit message Regular expression matches
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("JENKINS");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Commit message Regular expression matches
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("Issue:.*JENKINS.*");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Commit message Regular expression does not match
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("Issue:.*MY_THING.*");
+        boolean result = pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated);
+        assertFalse(result);
+
+        // Commit message Regular expression does not match
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("MY_THING");
         assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
     }
 }


### PR DESCRIPTION
* Add support for "Commit message contains regular expression" in the
  Patch Set Created trigger
* Commit message ignored is the textbox is empty

Issue JENKINS-64091