### PR TITLE
Fixed  adding forbidden paths in dynamic config

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritDynamicUrlProcessor.java
@@ -222,7 +222,7 @@ public final class GerritDynamicUrlProcessor {
           }
           FilePath filePath = new FilePath(type, text);
           forbiddenFilePaths.add(filePath);
-          dynamicGerritProject.setForbiddenFilePaths(filePaths);
+          dynamicGerritProject.setForbiddenFilePaths(forbiddenFilePaths);
         }
       }
 


### PR DESCRIPTION
When using dynamic files forbidden paths were not working properly. Changes in the forbidden paths triggered builds instead of being ignored.