### PR TITLE
Fix retrieving review message.

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -265,7 +265,7 @@ public class ParameterExpander {
         String command = gerritCommand;
         if (r != null && taskListener != null) {
             try {
-                System.out.println("EnvVars: " + r.getEnvironment(taskListener));
+                
                 command = r.getEnvironment(taskListener).expand(command);
             } catch (Exception ex) {
                 logger.error("Failed to expand env vars into gerrit cmd. Gerrit won't be notified!!", ex);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -263,6 +263,7 @@ public class ParameterExpander {
         String command = gerritCommand;
         if (r != null && taskListener != null) {
             try {
+                System.out.println("EnvVars: " + r.getEnvironment(taskListener));
                 command = r.getEnvironment(taskListener).expand(command);
             } catch (Exception ex) {
                 logger.error("Failed to expand env vars into gerrit cmd. Gerrit won't be notified!!", ex);

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -52,6 +52,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static com.sonyericsson.hudson.plugins.gerrit.trigger.utils.Logic.shouldSkip;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Expands a parameterized string to its full potential.
@@ -705,13 +707,14 @@ public class ParameterExpander {
      * @return the message
      */
     protected String findMessage(String completedCommand) {
-        String messageStart = "--message '";
-        String fromMessage = completedCommand.substring(completedCommand.indexOf(messageStart));
-        int endIndex = fromMessage.indexOf("' --");
-        if (endIndex <= -1) {
-            endIndex = fromMessage.length();
+        String message = "";
+        String messageRegex = "(?s)--message\\s+'(.*?)'";
+        Pattern p = Pattern.compile(messageRegex);
+        Matcher m = p.matcher(completedCommand);
+        while (m.find()) {
+          message = m.group(1);
         }
-        return fromMessage.substring(messageStart.length(), endIndex);
+        return message;
     }
 
     /**

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -265,7 +265,6 @@ public class ParameterExpander {
         String command = gerritCommand;
         if (r != null && taskListener != null) {
             try {
-                
                 command = r.getEnvironment(taskListener).expand(command);
             } catch (Exception ex) {
                 logger.error("Failed to expand env vars into gerrit cmd. Gerrit won't be notified!!", ex);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/MockGerritHudsonTriggerConfig.java
@@ -77,7 +77,7 @@ public class MockGerritHudsonTriggerConfig implements
                 + " VERIFIED=<VERIFIED>"
                 + " CODEREVIEW=<CODE_REVIEW>"
                 + " NOTIFICATION_LEVEL=<NOTIFICATION_LEVEL>"
-                + " REFSPEC=<REFSPEC> MSG='Your friendly butler says OK. BS=<BUILDS_STATS>'"
+                + " REFSPEC=<REFSPEC> MSG='Build Successful <BUILDS_STATS>'"
                 + " BUILDURL=<BUILDURL>"
                 + " STARTED_STATS=<STARTED_STATS>"
                 + " ENV_BRANCH=$BRANCH"
@@ -95,7 +95,7 @@ public class MockGerritHudsonTriggerConfig implements
                 + " VERIFIED=-1"
                 + " CODEREVIEW=<CODE_REVIEW>"
                 + " NOTIFICATION_LEVEL=<NOTIFICATION_LEVEL>"
-                + " REFSPEC=<REFSPEC> MSG='A disappointed butler says not OK. BS=<BUILDS_STATS>'"
+                + " REFSPEC=<REFSPEC> MSG='Build Failed <BUILDS_STATS>'"
                 + " BUILDURL=<BUILDURL>"
                 + " STARTED_STATS=<STARTED_STATS>"
                 + " ENV_BRANCH=$BRANCH"
@@ -126,7 +126,14 @@ public class MockGerritHudsonTriggerConfig implements
     @Override
     public String getGerritCmdBuildNotBuilt() {
         // TODO Copy-pasted from getGerritCmdBuildUnstable.
-        return "CHANGE=<CHANGE> PATCHSET=<PATCHSET> VERIFIED=0 MSG=The build is NotBuilt";
+        return "CHANGE=<CHANGE>"
+                + " CHANGE_ID=<CHANGE_ID>"
+                + " PATCHSET=<PATCHSET>"
+                + " VERIFIED=<VERIFIED>"
+                + " CODEREVIEW=<CODE_REVIEW>"
+                + " NOTIFICATION_LEVEL=<NOTIFICATION_LEVEL>"
+                + " REFSPEC=<REFSPEC>"
+                + " MSG='No Builds Executed <BUILDS_STATS>'";
     }
 
     @Override


### PR DESCRIPTION
In case of NOT_BUILT status (for ex. when a build was removed from
the queue before it has been started) we get null in both labels:
Verify and Code-Review.
In this case we remove these labels from result command. After that
assuming the message is located between "--message '" and "'  --"
fails due to we got extra spaces after labels has been removed.
As a result, an option following the message is parsed as a part
of the message.