### PR TITLE
JENKINS-65075 Update PluginPatchsetCreatedEvent shouldTriggerOn

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -225,6 +225,14 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
         if (excludeDrafts && ((PatchsetCreated)event).getPatchSet().isDraft()) {
             return false;
         }
+        if (StringUtils.isNotEmpty(commitMessageContainsRegEx)) {
+            if (commitMessagePattern == null) {
+                commitMessagePattern = Pattern.compile(
+                        this.commitMessageContainsRegEx, Pattern.DOTALL | Pattern.MULTILINE);
+            }
+            String commitMessage = ((PatchsetCreated)event).getChange().getCommitMessage();
+            return commitMessagePattern.matcher(commitMessage).find();
+        }
         if (event instanceof ManualPatchsetCreated) {
             // always trigger build when the build is triggered manually
             return true;
@@ -242,14 +250,6 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
         }
         if (excludeWipState && ((PatchsetCreated)event).getChange().isWip()) {
             return false;
-        }
-        if (StringUtils.isNotEmpty(commitMessageContainsRegEx)) {
-            if (commitMessagePattern == null) {
-                commitMessagePattern = Pattern.compile(
-                        this.commitMessageContainsRegEx, Pattern.DOTALL | Pattern.MULTILINE);
-            }
-            String commitMessage = ((PatchsetCreated)event).getChange().getCommitMessage();
-            return commitMessagePattern.matcher(commitMessage).find();
         }
         return true;
     }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
@@ -1,15 +1,15 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.event;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import org.junit.Test;
-
+import com.sonyericsson.hudson.plugins.gerrit.trigger.events.ManualPatchsetCreated;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 /**
  * Tests for {@link PluginPatchsetCreatedEvent}.
@@ -131,4 +131,49 @@ public class PluginPatchsetCreatedEventTest {
         pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("MY_THING");
         assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
     }
+    /**
+     * Test that it should, or should not, fire if the commit message matches a regular expression.
+     */
+    @Test
+    public void commitMessageRegExCheckManualPatchSetCreated() {
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent =
+                new PluginPatchsetCreatedEvent();
+        ManualPatchsetCreated patchsetCreated = new ManualPatchsetCreated();
+        patchsetCreated.setPatchset(new PatchSet());
+        StringBuilder commitMessage = new StringBuilder();
+        commitMessage.append("This is a summary\n");
+        commitMessage.append("\n");
+        commitMessage.append("This is my description.\n");
+        commitMessage.append("\n");
+        commitMessage.append("Issue: JENKINS-64091\n");
+        Change change = new Change();
+        change.setCommitMessage(commitMessage.toString());
+        patchsetCreated.setChange(change);
+
+        // Commit Message regular expression set to null
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx(null);
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Commit message Regular expression is an empty string
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Commit message Regular expression matches
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("JENKINS");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Commit message Regular expression matches
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("Issue:.*JENKINS.*");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Commit message Regular expression does not match
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("Issue:.*MY_THING.*");
+        boolean result = pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated);
+        assertFalse(result);
+
+        // Commit message Regular expression does not match
+        pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("MY_THING");
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+    }
+
 }


### PR DESCRIPTION
When a Jenkins job is configured with a PatchSet Created, and the
"commit message contains regular expression" is populated, using the
"Query and Trigger Gerrit Patches" link found at
 <jenkins_url>/gerrit_manual_trigger/ will incorrectly trigger the job.

Update the PatchSetCreatedEvent shouldTriggerOn function to check for
the commit message before inspecting if it's a ManualPatchSetCreated
event.

Issue: JENKINS-65075

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
