### PR TITLE
[JENKINS-63000] Bypass dynamic trigger fetch after timeout

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/DynamicConfigurationCacheProxy.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/DynamicConfigurationCacheProxy.java
@@ -40,6 +40,15 @@ final class DynamicConfigurationCacheProxy {
     synchronized List<GerritProject> fetchThroughCache(String url) throws IOException, ParseException {
         if (cache.containsKey(url) && !isExpired(url)) {
             logger.debug("Get dynamic projects from cache for URL: " + url);
+            // Maintain cache while not fetching from URL
+            for (String keyUrl : ttl.keySet()) {
+               if (isExpired(keyUrl)) {
+                   ttl.remove(keyUrl);
+                   cache.remove(keyUrl);
+                   logger.trace("Removing {} from cache", keyUrl);
+               }
+            }
+
             return cache.get(url);
         }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimer.java
@@ -31,7 +31,10 @@ import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nonnull;
 import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.ScheduledFuture;
 
 /**
  * Manages the timer that is used for each GerritTrigger TimerTask that
@@ -52,12 +55,16 @@ public final class GerritTriggerTimer {
      */
     private static GerritTriggerTimer instance = null;
 
+    /**
+     * The timer handler
+     */
+    private Map<String, ScheduledFuture> scheduledTasks;
 
     /**
      * The private constructor (this is a singleton class).
      */
     private GerritTriggerTimer() {
-
+        scheduledTasks = new HashMap<String, ScheduledFuture>();
     }
 
     /**
@@ -132,13 +139,30 @@ public final class GerritTriggerTimer {
     public void schedule(GerritTriggerTimerTask timerTask, @Nonnull GerritTrigger trigger) {
         long timerPeriod = TimeUnit.SECONDS.toMillis(calculateDynamicConfigRefreshInterval(trigger));
         try {
+            cancel(timerTask);
             logger.debug("Schedule task " + timerTask + " for every " + timerPeriod + "ms");
-            jenkins.util.Timer.get().scheduleWithFixedDelay(timerTask, DELAY_MILLISECONDS, timerPeriod,
-                                                            TimeUnit.MILLISECONDS);
+            scheduledTasks.put(timerTask.toString(),
+                               jenkins.util.Timer.get().scheduleWithFixedDelay(
+                                                  timerTask, DELAY_MILLISECONDS, timerPeriod,
+                                                            TimeUnit.MILLISECONDS));
         } catch (IllegalArgumentException iae) {
             logger.error("Attempted use of negative delay", iae);
         } catch (IllegalStateException ise) {
             logger.error("Attempted re-use of TimerTask", ise);
+        }
+    }
+
+    /**
+     * Cancel a TimerTask.
+     *
+     * @param timerTask the TimerTask to cancel
+     */
+    public void cancel(GerritTriggerTimerTask timerTask) {
+        if (scheduledTasks.get(timerTask.toString()) != null) {
+           boolean mayNotInterruptIfRunning = true;
+           scheduledTasks.get(timerTask.toString()).cancel(!mayNotInterruptIfRunning);
+           scheduledTasks.remove(timerTask.toString());
+           logger.debug("Canceling and removing timer for " + timerTask);
         }
     }
 }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
@@ -64,6 +64,13 @@ public class GerritTriggerTimerTask extends TimerTask {
     }
 
     @Override
+    public boolean cancel() {
+        boolean retVal = super.cancel();
+        GerritTriggerTimer.getInstance().cancel(this);
+        return retVal;
+    }
+
+    @Override
     public String toString() {
         return "GerritTriggerTimerTask{job='" + job + '\'' + '}';
     }


### PR DESCRIPTION
The root cause of not opened latch was not found so proposed timeout is only workaround to be able to process events without building up the queue. 

Together with the workaround a modification of dynamic configuration timer handling is proposed to avoid scheduling growing number of timer task every time user apply job config with dynamic trigger enabled.

