### PR TITLE
Add rerun-check event

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.18.2</version>
+            <version>2.18.3-SNAPSHOT</version>
             <exclusions>
                 <exclusion>
                     <!-- json-lib-2.4-jenkins-2 is provided by core/stapler -->

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.32</version>
+        <version>4.8</version>
         <relativePath />
     </parent>
 
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.18.3-SNAPSHOT</version>
+	    <version>2.19.0</version>
             <exclusions>
                 <exclusion>
                     <!-- json-lib-2.4-jenkins-2 is provided by core/stapler -->

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRerunCheckEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRerunCheckEvent.java
@@ -36,8 +36,8 @@ import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 
 /**
- * An event configuration that causes the build to be triggered when a change's
- * WIP state changed.
+ * An event configuration that causes the build to be (re-)triggered when the
+ * gerrit checks plugin rerun check is triggered.
  */
 public class PluginRerunCheckEvent extends PluginGerritEvent implements Serializable {
     private static final long serialVersionUID = 5530163420962242330L;
@@ -56,7 +56,7 @@ public class PluginRerunCheckEvent extends PluginGerritEvent implements Serializ
      */
     @Override
     public Descriptor<PluginGerritEvent> getDescriptor() {
-        return Jenkins.getInstance().getDescriptorByType(PluginWorkInProgressStateChangedEventDescriptor.class);
+        return Jenkins.getInstance().getDescriptorByType(PluginRerunCheckEventDescriptor.class);
     }
 
     @Override
@@ -68,8 +68,8 @@ public class PluginRerunCheckEvent extends PluginGerritEvent implements Serializ
      * The descriptor for the PluginRerunCheckEvent.
      */
     @Extension
-    @Symbol("wipStateChanged")
-    public static class PluginWorkInProgressStateChangedEventDescriptor extends PluginGerritEventDescriptor {
+    @Symbol("rerunCheck")
+    public static class PluginRerunCheckEventDescriptor extends PluginGerritEventDescriptor {
 
         @Override
         public String getDisplayName() {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRerunCheckEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRerunCheckEvent.java
@@ -1,0 +1,79 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2021 Intel . All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events;
+
+import java.io.Serializable;
+
+import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.RerunCheck;
+
+import hudson.Extension;
+import hudson.model.Descriptor;
+import jenkins.model.Jenkins;
+
+/**
+ * An event configuration that causes the build to be triggered when a change's
+ * WIP state changed.
+ */
+public class PluginRerunCheckEvent extends PluginGerritEvent implements Serializable {
+    private static final long serialVersionUID = 5530163420962242330L;
+
+    /**
+     * Standard constructor.
+     */
+    @DataBoundConstructor
+    public PluginRerunCheckEvent() {
+    }
+
+    /**
+     * Getter for the Descriptor.
+     *
+     * @return the Descriptor for the PluginRerunCheckEvent.
+     */
+    @Override
+    public Descriptor<PluginGerritEvent> getDescriptor() {
+        return Jenkins.getInstance().getDescriptorByType(PluginWorkInProgressStateChangedEventDescriptor.class);
+    }
+
+    @Override
+    public Class getCorrespondingEventClass() {
+        return RerunCheck.class;
+    }
+
+    /**
+     * The descriptor for the PluginRerunCheckEvent.
+     */
+    @Extension
+    @Symbol("wipStateChanged")
+    public static class PluginWorkInProgressStateChangedEventDescriptor extends PluginGerritEventDescriptor {
+
+        @Override
+        public String getDisplayName() {
+            return Messages.RerunCheckDisplayName();
+        }
+    }
+}

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/version/GerritVersionChecker.java
@@ -67,8 +67,12 @@ public final class GerritVersionChecker {
         /**
          * Gerrit CommentAdded always contains approval information, added in Gerrit 2.13.
          */
-        commentAlwaysApproval("CommentAdded always contains approval", "2.13");
+        commentAlwaysApproval("CommentAdded always contains approval", "2.13"),
 
+        /**
+         * Gerrit rerun-check event, added in checks for gerrit-3.3.
+        */
+        rerunCheck("RerunCheck event", "3.3");
 
         private final String displayName;
         private final String version;

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -86,6 +86,8 @@ PrivateStateChangedDisplayName=\
   Private State Changed
 WorkInProgressStateChangedDisplayName=\
   WIP State Changed
+RerunCheckDisplayName=\
+  Rerun Checks
 CommentAddedDisplayName=\
   Comment Added
 PatchsetCreatedDisplayName=\

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRerunCheck/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRerunCheck/config.jelly
@@ -1,0 +1,26 @@
+<!--
+  ~ The MIT License
+  ~
+  ~ Copyright 2012 Intel, Inc. All rights reserved.
+  ~
+  ~ Permission is hereby granted, free of charge, to any person obtaining a copy
+  ~ of this software and associated documentation files (the "Software"), to deal
+  ~ in the Software without restriction, including without limitation the rights
+  ~ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  ~ copies of the Software, and to permit persons to whom the Software is
+  ~ furnished to do so, subject to the following conditions:
+  ~
+  ~ The above copyright notice and this permission notice shall be included in
+  ~ all copies or substantial portions of the Software.
+  ~
+  ~ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  ~ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  ~ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  ~ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  ~ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  ~ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  ~ THE SOFTWARE.
+  -->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core">
+</j:jelly>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRerunCheck/help.html
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginRerunCheck/help.html
@@ -1,0 +1,1 @@
+<p>This event is emitted by the checks plugin if a user clicks the "re-run check" link in gerrit.<p>


### PR DESCRIPTION
The gerrit checks plugin gets a new event 'rerun-check' [1] to signal a rerun has been requested. Add support for this new event.
The required changes in gerrit-event are here [2]

[1] https://gerrit-review.googlesource.com/c/plugins/checks/+/255373
[2] https://github.com/sonyxperiadev/gerrit-events/pull/107

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue 

<!--
Put an `x` into the [ ] to show you have filled the information
-->
