### PR TITLE
JENKINS-53250: Fix warnings what configuration-as-code is not installed

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/GerritJcascConfigurator.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/GerritJcascConfigurator.java
@@ -117,7 +117,7 @@ public class GerritJcascConfigurator extends BaseConfigurator<PluginImpl> {
      * Inject `config` field explicitly as BaseConfigurator cannot detect this ("type is abstract but not Describable").
      * The methods are using interface, but we have to point the `config` property to concrete class.
      */
-    @Extension
+    @Extension(optional = true)
     public static final class ServerConfigurator extends BaseConfigurator<GerritServer> {
 
         @Override
@@ -141,7 +141,7 @@ public class GerritJcascConfigurator extends BaseConfigurator<PluginImpl> {
     /**
      * Cannot use BaseConfigurator as {@link WatchTimeExceptionData} is immutable.
      */
-    @Extension
+    @Extension(optional = true)
     public static final class WatchTimeExceptionDataConfigurator implements Configurator<WatchTimeExceptionData> {
 
         private static final String DAYS_OF_WEEK = "daysOfWeek";
@@ -262,7 +262,7 @@ public class GerritJcascConfigurator extends BaseConfigurator<PluginImpl> {
     /**
      * Configure {@link com.sonymobile.tools.gerrit.gerritevents.watchdog.WatchTimeExceptionData.TimeSpan}.
      */
-    @Extension
+    @Extension(optional = true)
     public static final class TimeSpanConfigurator implements Configurator<WatchTimeExceptionData.TimeSpan> {
 
         @Override


### PR DESCRIPTION
Declare all `Configuration` `@Extension`s as `optional`.

https://issues.jenkins.io/browse/JENKINS-53250?focusedCommentId=408991&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-408991

Amending https://github.com/jenkinsci/gerrit-trigger-plugin/pull/426

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [n/a] Ensure you have provided tests - that demonstrates feature works or fixes the issue

@rsandell PTAL