### PR TITLE
Modify the "filtered in" and "filtered out" order in Gerrit Trigger menu

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/index.jelly
@@ -74,8 +74,8 @@
                         <f:entry title="${%Event List}" help="/plugin/gerrit-trigger/help-EventsFilter.html">
                             <div style="display:flex">
                                 <div style="display: inline; width: 45%;">
-                                    <span><b>Filtered In</b></span>
-                                    <select id="filterInSelect" class="setting-input" multiple="multiple" size="${it.pluginConfig.eventTypesSize}">
+                                    <span><b>Filtered Out</b></span>
+                                    <select id="filterOutSelect" class="setting-input" multiple="multiple" size="${it.pluginConfig.eventTypesSize}">
                                     </select>
                                 </div>
                                 <div style="margin: auto; display:flex; flex-direction: column;">
@@ -83,8 +83,8 @@
                                     <button id="reset" type="button" title="Reset" style="font-size: large; padding: 5px 10px 5px 10px;">&#8630;</button>
                                 </div>
                                 <div style="display: inline; width: 45%;">
-                                    <span><b>Filtered Out</b></span>
-                                    <select id="filterOutSelect" class="setting-input" multiple="multiple" size="${it.pluginConfig.eventTypesSize}">
+                                    <span><b>Filtered In</b></span>
+                                    <select id="filterInSelect" class="setting-input" multiple="multiple" size="${it.pluginConfig.eventTypesSize}">
                                     </select>
                                 </div>
                             </div>

--- a/src/main/webapp/js/events-filter.js
+++ b/src/main/webapp/js/events-filter.js
@@ -24,7 +24,7 @@
 
 document.addEventListener('DOMContentLoaded', function () {
     'use strict';
-    var defaultFilterList = document.getElementById("defaultFilter").value.slice(1, -1).split(", ");
+    var defaultFilterList = document.getElementById("defaultFilter").value.slice(-1, 1).split(", ");
     var filterInList = document.getElementById("filterInForm").value.slice(1, -1).split(", ");
     var filterInForm = document.getElementById("filterInForm");
     var filterInSelect = document.getElementById("filterInSelect");


### PR DESCRIPTION
Modify the order of "filtered in" and "filtered out" event list of received events type in Gerrit Trigger menu, 
moving "filtered in" to the right and "filtered out" to the left, making the filtered in events easier to identify.
