### PR TITLE
[JENKINS-65481] Add choosing strategy with newrev support

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -355,6 +355,62 @@ node {
 Note though that with this approach the changelog will not show
 correctly.
 
+== Declarative Pipeline Jobs
+
+You can configure the pipeline checkout in the job configuration to use the
+"Gerrit Trigger with merge commit support" choosing strategy. This strategy
+behaves similar to the original "Gerrit Trigger" strategy with the exception
+that for change-merged events where Gerrit automatically creates a merge commit,
+it will select the revision for the merge commit rather than the revision for
+the patchset that was submitted. This ensures that the Jenkinsfile is checked
+out correctly in the event the Gerrit resolved a merge for that file. See
+https://issues.jenkins.io/browse/JENKINS-65481 for all the details.
+
+Configure your job as normal for patchset-created and change-merged event triggers then use
+the following settings in the Pipeline section of your job configuration
+(you can use a similar setup for freestyle jobs):
+
+Definition: Pipeline script from SCM
+ - SCM: Git
+   - Repositories
+     - Set your repository URL and credentials
+     - Name: origin
+     - Click the "Advanced" button
+     - Refspec: $GERRIT_REFSPEC +refs/heads/$GERRIT_BRANCH:refs/remotes/origin/$GERRIT_BRANCH
+   - Branches to build
+     - Branch specifier: refs/heads/$GERRIT_BRANCH
+   - Additional Behaviours
+     - Strategy for choosing what to build: Gerrit Trigger with merge commit support
+
+then in your Jenkinsfile pipeline code rely on the automatic checkout or disable the automatic checkout and use
+"scm checkout" as shown below:
+
+[source,syntaxhighlighter-pre]
+----
+pipeline {
+  options {
+      skipDefaultCheckout true
+      // ...
+  }
+  stages {
+    stage('checkout') {
+      checkout scm
+    }
+    //...
+  }
+}
+----
+
+This method of skipping the default checkout is useful if you want to checkout into a subdirectory of your
+workspace by wrapping the checkout in a dir directive, for example:
+
+[source,syntaxhighlighter-pre]
+----
+dir("${env.WORKSPACE}/scm") {
+  checkout scm
+}
+----
+
 == Tips & Tricks
 
 This section contains some useful tips and tricks that users has come up

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooserWithMergeCommitSupport.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooserWithMergeCommitSupport.java
@@ -1,0 +1,327 @@
+/*
+ * The MIT License
+ *
+ * Copyright 2010 Andrew Bayer. All rights reserved.
+ * Copyright 2013 Sony Mobile Communications AB. All rights reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
+
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeMerged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
+
+import hudson.Extension;
+import hudson.model.Run;
+import hudson.model.TaskListener;
+import hudson.model.Result;
+import hudson.plugins.git.GitException;
+import hudson.plugins.git.Revision;
+import hudson.plugins.git.Branch;
+import hudson.plugins.git.util.Build;
+import hudson.plugins.git.util.BuildChooser;
+import hudson.plugins.git.util.BuildChooserContext;
+import hudson.plugins.git.util.BuildChooserDescriptor;
+import hudson.plugins.git.util.BuildData;
+import hudson.remoting.VirtualChannel;
+
+import org.eclipse.jgit.lib.Repository;
+import org.eclipse.jgit.revwalk.RevCommit;
+import org.eclipse.jgit.revwalk.RevWalk;
+import org.jenkinsci.plugins.gitclient.GitClient;
+import org.jenkinsci.plugins.gitclient.RepositoryCallback;
+import org.kohsuke.stapler.DataBoundConstructor;
+import org.eclipse.jgit.lib.ObjectId;
+
+import edu.umd.cs.findbugs.annotations.NonNull;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
+
+/**
+ * Used by the git plugin to determine the revision to build. This forks off
+ * the original build chooser to add support for handling automatic merge commits.
+ * It was necessary to add an additional chooser as the change could not be made
+ * in a backward compatible way.
+ */
+public class GerritTriggerBuildChooserWithMergeCommitSupport extends BuildChooser {
+    private static final long serialVersionUID = 2003462680723330645L;
+
+    /**
+     * Used by XStream for something.
+     */
+    @SuppressWarnings("unused")
+    private final String separator = "#";
+
+    /**
+     * Default constructor.
+     */
+    @DataBoundConstructor
+    public GerritTriggerBuildChooserWithMergeCommitSupport() {
+    }
+
+    //CS IGNORE RedundantThrows FOR NEXT 30 LINES. REASON: Informative, and could happen.
+
+    /**
+     * Determines which Revisions to build.
+     *
+     * Doesn't care about branches.
+     *
+     * @param isPollCall   whether this is being called from Git polling
+     * @param singleBranch The branch
+     * @param git          The GitClient API object
+     * @param listener     TaskListener for logging, etc
+     * @param data         the historical BuildData object
+     * @param context      the remote context
+     * @return A Collection containing the new revision.
+     *
+     * @throws GitException in case of error
+     * @throws IOException  In case of error
+     * @throws InterruptedException  In case of error
+     */
+    @Override
+    public Collection<Revision> getCandidateRevisions(boolean isPollCall, String singleBranch,
+                                                      GitClient git, TaskListener listener,
+                                                      BuildData data, BuildChooserContext context)
+            throws GitException, IOException, InterruptedException {
+
+        try {
+            String rev = context.actOnBuild(new GetGerritEventRevision());
+            if (rev == null) {
+                rev = "FETCH_HEAD";
+            }
+
+            String refspec = context.actOnBuild(new GetGerritEventRefspec());
+            if (refspec == null) {
+                refspec = singleBranch;
+            }
+
+            ObjectId sha1 = git.revParse(rev);
+
+            Revision revision = new Revision(sha1);
+            revision.getBranches().add(new Branch(refspec, sha1));
+
+            return Collections.singletonList(revision);
+        } catch (GitException e) {
+            // branch does not exist, there is nothing to build
+            return Collections.<Revision>emptyList();
+        }
+    }
+
+    @Override
+    public Build prevBuildForChangelog(String singleBranch, BuildData data, GitClient git,
+                                       BuildChooserContext context) throws InterruptedException, IOException {
+        if (data != null) {
+            ObjectId sha1 = git.revParse("FETCH_HEAD");
+
+            // Now we cheat and add the parent as the last build on the branch, so we can
+            // get the changelog working properly-ish.
+            ObjectId parentSha1 = getFirstParent(sha1, git);
+            Revision parentRev = new Revision(parentSha1);
+            parentRev.getBranches().add(new Branch(singleBranch, parentSha1));
+
+            int prevBuildNum = 0;
+            Result r = null;
+
+            Build lastBuild = data.getLastBuildOfBranch(singleBranch);
+            if (lastBuild != null) {
+                prevBuildNum = lastBuild.getBuildNumber();
+                r = lastBuild.getBuildResult();
+            }
+
+            return new Build(parentRev, prevBuildNum, r);
+        } else {
+            //Hmm no sure what to do here, but the git plugin can handle us returning null here
+            return null;
+        }
+    }
+
+    /**
+     * Close walk through method name found by reflection.
+     * @param walk the RevWalk object to be closed
+     */
+    private static void closeByReflection(@NonNull RevWalk walk) {
+        java.lang.reflect.Method closeMethod;
+        try {
+            closeMethod = walk.getClass().getDeclaredMethod("close");
+        } catch (NoSuchMethodException ex) {
+            LOGGER.log(Level.SEVERE, "Exception finding walker close method: {0}", ex);
+            return;
+        } catch (SecurityException ex) {
+            LOGGER.log(Level.SEVERE, "Exception finding walker close method: {0}", ex);
+            return;
+        }
+        try {
+            closeMethod.invoke(walk);
+        } catch (IllegalAccessException ex) {
+            LOGGER.log(Level.SEVERE, "Exception calling walker close method: {0}", ex);
+        } catch (IllegalArgumentException ex) {
+            LOGGER.log(Level.SEVERE, "Exception calling walker close method: {0}", ex);
+        } catch (InvocationTargetException ex) {
+            LOGGER.log(Level.SEVERE, "Exception calling walker close method: {0}", ex);
+        }
+    }
+
+    /**
+     * Call release method on walk.  JGit 3 uses release(), JGit 4 uses close() to
+     * release resources.
+     *
+     * This method should be removed once the code depends on git client 2.0.0.
+     * @param walk object whose close or release method will be called
+     * @throws IOException on IO error
+     */
+    private static void releaseOrClose(RevWalk walk) throws IOException {
+        if (walk == null) {
+            return;
+        }
+        try {
+            walk.release(); // JGit 3
+        } catch (NoSuchMethodError noMethod) {
+            closeByReflection(walk);
+        }
+    }
+
+    //CS IGNORE RedundantThrows FOR NEXT 30 LINES. REASON: Informative, and could happen.
+    /**
+     * Gets the top parent of the given revision.
+     *
+     * @param id Revision
+     * @param git GitClient API object
+     * @return object id of Revision's parent, or of Revision itself if there is no parent
+     * @throws GitException In case of error in git call
+     * @throws InterruptedException if the repository handling gets interrupted
+     * @throws IOException in case of communication errors.
+     */
+    @SuppressWarnings("serial")
+    private ObjectId getFirstParent(final ObjectId id, GitClient git)
+            throws GitException, IOException, InterruptedException {
+        return git.withRepository(new RepositoryCallback<ObjectId>() {
+            @Override
+            public ObjectId invoke(Repository repository, VirtualChannel virtualChannel)
+                    throws IOException, InterruptedException {
+                RevWalk walk = null;
+                ObjectId result = null;
+                try {
+                    walk = new RevWalk(repository);
+                    RevCommit commit = walk.parseCommit(id);
+                    if (commit.getParentCount() > 0) {
+                        result = commit.getParent(0);
+                    } else {
+                        // If this is the first commit in the git, there is no parent.
+                        result = id;
+                    }
+                } catch (Exception e) {
+                    throw new GitException("Failed to find parent id. ", e);
+                } finally {
+                    releaseOrClose(walk);
+                }
+                return result;
+            }
+        });
+    }
+
+    /**
+     * Descriptor for GerritTriggerBuildChooserWithMergeCommitSupport.
+     */
+    @Extension(optional = true)
+    public static final class DescriptorImpl extends BuildChooserDescriptor {
+        @Override
+        public String getDisplayName() {
+            return Messages.GerritTriggerBuildChooserWithMergeCommitSupport_DisplayName();
+        }
+
+        @Override
+        public String getLegacyId() {
+            return Messages.GerritTriggerBuildChooserWithMergeCommitSupport_DisplayName();
+        }
+    }
+
+    /**
+     * Retrieve the Gerrit event revision
+     */
+    private static class GetGerritEventRevision
+            implements BuildChooserContext.ContextCallable<Run<?, ?>, String> {
+        static final long serialVersionUID = 0L;
+        @Override
+        public String invoke(Run<?, ?> build, VirtualChannel channel) {
+            GerritCause cause = build.getCause(GerritCause.class);
+            if (cause != null) {
+                GerritTriggeredEvent event = cause.getEvent();
+                if (event instanceof ChangeMerged) {
+                    // when gerrit creates a merge commit for some submit types, we need the newrev or we get the
+                    // changes from the patchset before the merge and build the wrong source, in the case that
+                    // there is no merge commit, the newrev will match the patchset revision
+                    String newRev = ((ChangeMerged)event).getNewRev();
+                    if (newRev != null) {
+                        return newRev;
+                    }
+                    // else we are on an old version of gerrit that is not reporting newrev
+                    // so fall through to the old behavior
+                }
+                if (event instanceof ChangeBasedEvent) {
+                    return ((ChangeBasedEvent)event).getPatchSet().getRevision();
+                }
+                if (event instanceof RefUpdated) {
+                    return ((RefUpdated)event).getRefUpdate().getNewRev();
+                }
+            }
+            return null;
+        }
+    }
+
+    /**
+     * Retrieve the Gerrit refspec
+     */
+    private static class GetGerritEventRefspec
+            implements BuildChooserContext.ContextCallable<Run<?, ?>, String> {
+        static final long serialVersionUID = 0L;
+        @Override
+        public String invoke(Run<?, ?> build, VirtualChannel channel) {
+            GerritCause cause = build.getCause(GerritCause.class);
+            if (cause != null) {
+                GerritTriggeredEvent event = cause.getEvent();
+                // For change-merged we need the project refname which is the ref for the branch we merged onto in
+                // case Gerrit created an automatic merge commit. The project object from the event stream is not
+                // available in the DTO objects so use the next best thing which is the branch name from the Change.
+                if (event instanceof ChangeMerged) {
+                    return "refs/heads/" + ((ChangeMerged)event).getChange().getBranch();
+                }
+                if (event instanceof ChangeBasedEvent) {
+                    return ((ChangeBasedEvent)event).getPatchSet().getRef();
+                }
+                if (event instanceof RefUpdated) {
+                    return ((RefUpdated)event).getRefUpdate().getRefName();
+                }
+            }
+            return null;
+        }
+    }
+
+    private static final Logger LOGGER = Logger.getLogger(GerritTriggerBuildChooser.class.getName());
+}

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/Messages.properties
@@ -198,3 +198,4 @@ GerritProjectListUpdater.For=GerritProjectListUpdater for server: {0}
 GerritMissedEventsPlaybackManager.For=GerritMissedEventsPlaybackManager for server: {0}
 NotANumber=Not a number
 NoSuchJobExists=No such job \u2018{0}\u2019 exists. Perhaps you meant \u2018{1}\u2019?
+GerritTriggerBuildChooserWithMergeCommitSupport.DisplayName=Gerrit Trigger with merge commit support

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooserWithMergeCommitSupportTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooserWithMergeCommitSupportTest.java
@@ -1,0 +1,198 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
+
+import hudson.plugins.git.util.BuildChooserContext;
+import hudson.plugins.git.Revision;
+import static org.junit.Assert.assertEquals;
+import org.junit.Test;
+import java.util.Collection;
+import hudson.model.Job;
+import hudson.model.Run;
+import hudson.model.FreeStyleProject;
+import hudson.model.FreeStyleBuild;
+import hudson.EnvVars;
+import java.io.IOException;
+import java.io.Serializable;
+import hudson.model.Hudson;
+import org.jenkinsci.plugins.gitclient.GitClient;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeMerged;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.Setup;
+import org.eclipse.jgit.lib.ObjectId;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tests for {@link GerritTriggerBuildChooser}.
+ * @author Jacob Keller
+ */
+public class GerritTriggerBuildChooserWithMergeCommitSupportTest {
+    /**
+     * Copied from the Git plugin because the real implementation is private.
+     *
+     * Ideally we can find a way to have this work somehow without needing to have this copy...
+     */
+    static class BuildChooserContextImpl implements BuildChooserContext, Serializable {
+        private static final long serialVersionUID = 1L;
+
+        final Job project;
+        final Run build;
+        final EnvVars environment;
+
+        /**
+         * Provides context for running closures while determining what to build
+         * @param project the Jenkins project
+         * @param build the Jenkins build
+         * @param environment the environment
+         */
+        BuildChooserContextImpl(Job project, Run build, EnvVars environment) {
+            this.project = project;
+            this.build = build;
+            this.environment = environment;
+        }
+
+        /**
+         * Perform some closure, executing on the build
+         * @param <T> The return type from the closure
+         * @param callable the closure to run
+         * @throws IOException if IO cannot be performed
+         * @throws InterruptedException if the process is interrupted
+         * @return closure return value
+         */
+        public <T> T actOnBuild(ContextCallable<Run<?, ?>, T> callable)
+            throws IOException, InterruptedException {
+            return callable.invoke(build, Hudson.MasterComputer.localChannel);
+        }
+
+        /**
+         * Perform some closure, executing on the project
+         * @param <T> The return type from the closure
+         * @param callable the closure to run
+         * @throws IOException if IO cannot be performed
+         * @throws InterruptedException if the process is interrupted
+         * @return closure return value
+         */
+        public <T> T actOnProject(ContextCallable<Job<?, ?>, T> callable)
+            throws IOException, InterruptedException {
+            return callable.invoke(project, Hudson.MasterComputer.localChannel);
+        }
+
+        /**
+         * Get the build
+         * @return Jenkins build
+         */
+        public Run<?, ?> getBuild() {
+            return build;
+        }
+
+        /**
+         * Get the project
+         * @return environment variables
+         */
+        public EnvVars getEnvironment() {
+            return environment;
+        }
+    }
+
+    /**
+     * Tests {@link GerritTriggerBuildChooser} if it correctly determines revision.
+     *
+     * @throws Exception if so.
+     */
+    @Test
+    public void testGerritTriggerBuildChooser() throws Exception {
+        GerritTriggerBuildChooserWithMergeCommitSupport chooser = new GerritTriggerBuildChooserWithMergeCommitSupport();
+        final ObjectId fetchHead = ObjectId.fromString("7f3547c6d55946e25e99a847b5160d69e59994ba");
+        final ObjectId patchsetRevision = ObjectId.fromString("38b0940738376ee1b66c332a2cb6d4d37bafa4e4");
+        // newRev here does not match patchsetRevision to simulate gerrit automatically creating a merge commit
+        final ObjectId newRev = ObjectId.fromString("14332a762fa01cfcb65e637ecce3bc621b44a381");
+        final String singleBranch = "origin/master";
+        final String changeBranch = "master";
+        final String patchsetRefspec = "refs/changes/98/99498/2";
+        final String changeMergedRefspec = "refs/heads/master";
+
+        // Mock the necessary objects we will need to make this work
+        FreeStyleProject p = mock(FreeStyleProject.class);
+        FreeStyleBuild b = mock(FreeStyleBuild.class);
+        GitClient git = mock(GitClient.class);
+        when(git.revParse("FETCH_HEAD")).thenReturn(fetchHead);
+
+        BuildChooserContextImpl context = new BuildChooserContextImpl(p, b, null);
+
+        // get the candidate revision(s)
+        Collection<Revision> revs = chooser.getCandidateRevisions(true, singleBranch, git, null, null, context);
+
+        // Check that we correctly use branch when no gerrit revision is used
+        assertEquals(1, revs.size());
+        assertEquals(1, revs.iterator().next().getBranches().size());
+        assertEquals(singleBranch, revs.iterator().next().getBranches().iterator().next().getName());
+        assertEquals(fetchHead, revs.iterator().next().getBranches().iterator().next().getSHA1());
+
+        // Mock the objects to report a gerrit revision was built
+        // build.getCause returns some object which reports the event correctly
+        PatchsetCreated patchsetCreated = Setup.createPatchsetCreated();
+        patchsetCreated.getPatchSet().setRef(patchsetRefspec);
+        patchsetCreated.getPatchSet().setRevision(patchsetRevision.toString());
+
+        GerritCause gerritCause = new GerritCause();
+        gerritCause.setEvent(patchsetCreated);
+        when(b.getCause(GerritCause.class)).thenReturn(gerritCause);
+        when(git.revParse(patchsetRefspec)).thenReturn(patchsetRevision);
+        when(git.revParse(patchsetRevision.toString())).thenReturn(patchsetRevision);
+
+        // get the candidate revision(s)
+        revs = chooser.getCandidateRevisions(true, singleBranch, git, null, null, context);
+
+        // Check that we correctly use branch when a gerrit revision is used
+        assertEquals(1, revs.size());
+        assertEquals(1, revs.iterator().next().getBranches().size());
+        assertEquals(patchsetRefspec, revs.iterator().next().getBranches().iterator().next().getName());
+        assertEquals(patchsetRevision, revs.iterator().next().getBranches().iterator().next().getSHA1());
+
+        // Mock the objects to report a gerrit revision was built
+        // build.getCause returns a change-merged event without a newrev to test old gerrit versions
+        ChangeMerged changeMerged = Setup.createChangeMerged();
+        changeMerged.getPatchSet().setRef(patchsetRefspec);
+        changeMerged.getPatchSet().setRevision(patchsetRevision.toString());
+        changeMerged.getChange().setBranch(changeBranch);
+
+        gerritCause = new GerritCause();
+        gerritCause.setEvent(changeMerged);
+        when(b.getCause(GerritCause.class)).thenReturn(gerritCause);
+        when(git.revParse(changeMergedRefspec)).thenReturn(patchsetRevision);
+        when(git.revParse(patchsetRevision.toString())).thenReturn(patchsetRevision);
+
+        // get the candidate revision(s)
+        revs = chooser.getCandidateRevisions(true, singleBranch, git, null, null, context);
+
+        // Check that we correctly use branch when a gerrit revision is used
+        assertEquals(1, revs.size());
+        assertEquals(1, revs.iterator().next().getBranches().size());
+        assertEquals(changeMergedRefspec, revs.iterator().next().getBranches().iterator().next().getName());
+        assertEquals(patchsetRevision, revs.iterator().next().getBranches().iterator().next().getSHA1());
+
+        // Mock the objects to report a gerrit revision was built
+        // build.getCause returns a change-merged event with a newrev value to test current gerrit versions
+        changeMerged = Setup.createChangeMerged();
+        changeMerged.getPatchSet().setRef(patchsetRefspec);
+        changeMerged.getPatchSet().setRevision(patchsetRevision.toString());
+        changeMerged.getChange().setBranch(changeBranch);
+        changeMerged.setNewRev(newRev.toString());
+
+        gerritCause = new GerritCause();
+        gerritCause.setEvent(changeMerged);
+        when(b.getCause(GerritCause.class)).thenReturn(gerritCause);
+        when(git.revParse(changeMergedRefspec)).thenReturn(newRev);
+        when(git.revParse(newRev.toString())).thenReturn(newRev);
+
+        // get the candidate revision(s)
+        revs = chooser.getCandidateRevisions(true, singleBranch, git, null, null, context);
+
+        // Check that we correctly use branch when a gerrit revision is used
+        assertEquals(1, revs.size());
+        assertEquals(1, revs.iterator().next().getBranches().size());
+        assertEquals(changeMergedRefspec, revs.iterator().next().getBranches().iterator().next().getName());
+        assertEquals(newRev, revs.iterator().next().getBranches().iterator().next().getSHA1());
+    }
+}


### PR DESCRIPTION
When gerrit automatically generates a merge commit, we should be building
the merge commit when the change is merged, not the patchset commit.

Added a new choosing strategy that honors newrev and updated README.adoc with instructions on how to use the new strategy.

I originally attempted modifying the original strategy here: https://github.com/eric-isakson/gerrit-trigger-plugin/tree/choose-newrev-for-change-merged

But that attempt caused build failures for existing jobs when an automatic merge commit is created so I decided to add a new strategy rather than trying to adapt the old one so as not to break existing behavior.

Details here: https://issues.jenkins.io/browse/JENKINS-65481

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [x ] Link to relevant issues in GitHub or Jira
- [x ] Link to relevant pull requests, esp. upstream and downstream changes
- [x ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
