### PR TITLE
feat: use BOM for manage the dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.13</version>
+        <version>4.16</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.17</version>
+            <version>2.22</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.32</version>
+        <version>4.13</version>
         <relativePath />
     </parent>
 
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <findbugs.failOnError>false</findbugs.failOnError>
@@ -81,11 +81,6 @@
                 </exclusion>
             </exclusions>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -123,18 +118,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
-            <version>2.1.10</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-            <version>1.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <version>${scm-api.version}</version>
         </dependency>
@@ -143,12 +126,6 @@
             <artifactId>pipeline-build-step</artifactId>
             <version>2.4</version>
             <!--<scope>test</scope>-->
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <version>2.30</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -203,16 +180,6 @@
             <artifactId>easymock</artifactId>
             <version>3.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
         </dependency>
         <!-- https://stackoverflow.com/a/7878281/2091470 -->
         <dependency>
@@ -296,17 +263,20 @@
         </dependency>
 
     </dependencies>
+
     <dependencyManagement>
       <dependencies>
+        <dependency>
+          <groupId>io.jenkins.tools.bom</groupId>
+          <artifactId>bom-2.190.x</artifactId>
+          <version>10</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>git-client</artifactId>
           <version>1.19.6</version>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>script-security</artifactId>
-          <version>1.48</version>
         </dependency>
       </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR change to use BOM to manage the dependencies of the plugin. This is need to work in the changes described on [JENKINS-60902](https://issues.jenkins-ci.org/browse/JENKINS-60902) to bump the Apache Mina SSHD library.

*NOTE* I have tried to not bump the Jenkins Core requires but finally I have had to do it, version 2.190.1 was the smaller one I could find that works.

related to https://github.com/jenkinsci/sshd-plugin/pull/46 and https://github.com/jenkinsci/gerrit-trigger-plugin/pull/441
see [Jenkins Core BOM](https://www.jenkins.io/doc/developer/plugin-development/dependency-management/)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue


<!--
Put an `x` into the [ ] to show you have filled the information
-->

cc @rsandell 
