### PR TITLE
Bom sshd

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.13</version>
+        <version>4.16</version>
         <relativePath />
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -159,7 +159,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-step-api</artifactId>
-            <version>2.17</version>
+            <version>2.22</version>
             <optional>true</optional>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.190.1</jenkins.version>
+        <jenkins.version>2.282</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <findbugs.failOnError>false</findbugs.failOnError>
@@ -61,7 +61,6 @@
         <powermock.version>1.6.2</powermock.version>
         <checkstyle.version>2.16</checkstyle.version>
         <mockito.version>1.10.19</mockito.version>
-        <scm-api.version>2.2.6</scm-api.version>
         <!--<workflow-cps.version>2.61</workflow-cps.version>-->
         <!--<workflow-job.version>2.26</workflow-job.version>-->
         <!--<workflow-step-api.version>2.17</workflow-step-api.version>-->
@@ -85,7 +84,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>git</artifactId>
-            <version>2.4.3</version>
+            <version>4.7.0</version>
             <optional>true</optional>
         </dependency>
         <dependency>
@@ -118,11 +117,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>scm-api</artifactId>
-            <version>${scm-api.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>pipeline-build-step</artifactId>
             <version>2.4</version>
             <!--<scope>test</scope>-->
@@ -146,12 +140,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-job</artifactId>
-            <version>2.26</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-scm-step</artifactId>
             <version>2.4</version>
             <scope>test</scope>
@@ -163,10 +151,15 @@
             <optional>true</optional>
         </dependency>
         <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-support</artifactId>
-            <version>2.21</version>
+            <groupId>org.apache.sshd</groupId>
+            <artifactId>sshd-core</artifactId>
+            <version>1.7.0</version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>matrix-project</artifactId>
+            <version>1.18</version>
         </dependency>
         <dependency>
             <!-- Used for test with matrix permissions -->
@@ -268,16 +261,36 @@
       <dependencies>
         <dependency>
           <groupId>io.jenkins.tools.bom</groupId>
-          <artifactId>bom-2.190.x</artifactId>
-          <version>10</version>
+          <artifactId>bom-2.277.x</artifactId>
+          <version>26</version>
           <type>pom</type>
           <scope>import</scope>
         </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>git-client</artifactId>
-          <version>1.19.6</version>
+          <version>3.7.0</version>
         </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpclient</artifactId>
+          <version>4.5.13</version>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.httpcomponents</groupId>
+          <artifactId>httpcore</artifactId>
+          <version>4.4.14</version>
+        </dependency>
+        <dependency>
+          <groupId>com.google.code.gson</groupId>
+          <artifactId>gson</artifactId>
+          <version>2.8.6</version>
+        </dependency>
+          <dependency>
+              <groupId>org.apache.commons</groupId>
+              <artifactId>commons-lang3</artifactId>
+              <version>3.10</version>
+          </dependency>
       </dependencies>
     </dependencyManagement>
     <repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.32</version>
+        <version>4.13</version>
         <relativePath />
     </parent>
 
@@ -53,7 +53,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.121.1</jenkins.version>
+        <jenkins.version>2.190.1</jenkins.version>
         <java.level>8</java.level>
         <no-test-jar>false</no-test-jar>
         <findbugs.failOnError>false</findbugs.failOnError>
@@ -81,11 +81,6 @@
                 </exclusion>
             </exclusions>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>structs</artifactId>
-            <version>1.17</version>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -123,18 +118,6 @@
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>credentials</artifactId>
-            <version>2.1.10</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
-            <artifactId>junit</artifactId>
-            <version>1.12</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scm-api</artifactId>
             <version>${scm-api.version}</version>
         </dependency>
@@ -143,12 +126,6 @@
             <artifactId>pipeline-build-step</artifactId>
             <version>2.4</version>
             <!--<scope>test</scope>-->
-        </dependency>
-        <dependency>
-            <groupId>org.jenkins-ci.plugins.workflow</groupId>
-            <artifactId>workflow-api</artifactId>
-            <version>2.30</version>
-            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
@@ -203,16 +180,6 @@
             <artifactId>easymock</artifactId>
             <version>3.0</version>
             <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
-            <version>1.7.25</version>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-jdk14</artifactId>
-            <version>1.7.25</version>
         </dependency>
         <!-- https://stackoverflow.com/a/7878281/2091470 -->
         <dependency>
@@ -296,17 +263,20 @@
         </dependency>
 
     </dependencies>
+
     <dependencyManagement>
       <dependencies>
+        <dependency>
+          <groupId>io.jenkins.tools.bom</groupId>
+          <artifactId>bom-2.190.x</artifactId>
+          <version>10</version>
+          <type>pom</type>
+          <scope>import</scope>
+        </dependency>
         <dependency>
           <groupId>org.jenkins-ci.plugins</groupId>
           <artifactId>git-client</artifactId>
           <version>1.19.6</version>
-        </dependency>
-        <dependency>
-          <groupId>org.jenkins-ci.plugins</groupId>
-          <artifactId>script-security</artifactId>
-          <version>1.48</version>
         </dependency>
       </dependencies>
     </dependencyManagement>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerBuildChooser.java
@@ -198,7 +198,7 @@ public class GerritTriggerBuildChooser extends BuildChooser {
             return;
         }
         try {
-            walk.release(); // JGit 3
+            walk.dispose(); // JGit 3
         } catch (NoSuchMethodError noMethod) {
             closeByReflection(walk);
         }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
This PR change to use BOM to manage the dependencies of the plugin and changes to use Apache Mina sshd 1.7.0 directly because is no longer in the Jenkins core after 2.282. This is related to the changes described on [JENKINS-60902](https://issues.jenkins-ci.org/browse/JENKINS-60902) to bump the Apache Mina SSHD library.

related to https://github.com/jenkinsci/sshd-plugin/pull/45 and https://github.com/jenkinsci/gerrit-trigger-plugin/pull/441
see [Jenkins Core BOM](https://www.jenkins.io/doc/developer/plugin-development/dependency-management/)

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue


<!--
Put an `x` into the [ ] to show you have filled the information
-->

cc @rsandell 
