### PR TITLE
Fix excessive triggers for a change with forbidden files only and strictForbiddenFileVerification enabled

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProject.java
@@ -49,6 +49,12 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.PluginImpl;
  * @author Robert Sandell &lt;robert.sandell@sonyericsson.com&gt;
  */
 public class GerritProject implements Describable<GerritProject> {
+    /** Magical file name which represents the commit message. */
+    private static final String MAGIC_FILE_NAME_COMMIT_MSG = "/COMMIT_MSG";
+    /** Magical file name which represents the merge list of a merge commit. */
+    private static final String MAGIC_FILE_NAME_MERGE_LIST = "/MERGE_LIST";
+    /** Magical file name which doesn't represent a file. Used specifically for patchset-level comments. */
+    private static final String MAGIC_FILE_NAME_PATCHSET_LEVEL = "/PATCHSET_LEVEL";
 
     private CompareType compareType;
     private String pattern;
@@ -217,6 +223,9 @@ public class GerritProject implements Describable<GerritProject> {
     public boolean isInteresting(String project, String branch, String topic, List<String> files) {
         if (compareType.matches(pattern, project)) {
             List<String> tmpFiles = new ArrayList<String>(files);
+            tmpFiles.remove(MAGIC_FILE_NAME_COMMIT_MSG);
+            tmpFiles.remove(MAGIC_FILE_NAME_MERGE_LIST);
+            tmpFiles.remove(MAGIC_FILE_NAME_PATCHSET_LEVEL);
             for (Branch b : branches) {
                 boolean foundInterestingForbidden = false;
                 if (b.isInteresting(branch)) {

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectForbiddenFilesWithMagicalFileNamesTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectForbiddenFilesWithMagicalFileNamesTest.java
@@ -1,0 +1,66 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2021 Liberty Global B.V.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data;
+
+import org.junit.Test;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * Testing if magical file names are ignored with Forbidden File Paths and do not make change interesting.
+ * @author Adam Romanek&lt;romanek.adam@gmail.com&gt;
+ */
+public class GerritProjectForbiddenFilesWithMagicalFileNamesTest {
+
+    /**
+     * Constructor.
+     */
+    public GerritProjectForbiddenFilesWithMagicalFileNamesTest() {
+    }
+
+    /**
+     * Tests.
+     */
+    @Test
+    public void testMagicalFileNamesDoNotMakeChangeInteresting() {
+        List<Branch> branches = new LinkedList<Branch>();
+        branches.add(new Branch(CompareType.PLAIN, "master"));
+        List<Topic> topics = new LinkedList<Topic>();
+        List<FilePath> filePaths = new LinkedList<FilePath>();
+        List<FilePath> forbiddenFilePaths = new LinkedList<FilePath>();
+        forbiddenFilePaths.add(new FilePath(CompareType.ANT, "README.md"));
+        List<String> files = new LinkedList<String>();
+        files.add("/COMMIT_MSG");
+        files.add("/MERGE_LIST");
+        files.add("/PATCHSET_LEVEL");
+        files.add("README.md");
+        GerritProject project = new GerritProject(
+                CompareType.PLAIN, "project1", branches, topics, filePaths, forbiddenFilePaths, true);
+
+        assertEquals(false, project.isInteresting("project1", "master", null, files));
+    }
+}


### PR DESCRIPTION
With strictForbiddenFileVerification enabled, when the list of files in
a change was fully covered by forbidden file paths, the change was still
considered interesting. That's because the list of files always contains
at least one magical file name: "/COMMIT_MSG" [1]. In some cases a change
may also contain some other magical file names: "/MERGE_LIST" and/or
"/PATCHSET_LEVEL" (at least as of Gerrit 3.4). So after all, when the
list of files was checked against forbidden file paths, the resuling
list of files (tmpFiles) was never empty and the associated job was
being triggered, although it shouldn't have been.

[1] https://gerrit.googlesource.com/gerrit/+/refs/tags/v3.4.0/java/com/google/gerrit/entities/Patch.java#33

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
