### PR TITLE
Fixed Enable Code-Review checkbox can not be unchecked

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -351,7 +351,7 @@
                                               with="gerritFrontEndUrl,gerritHttpUserName,gerritHttpPassword"/>
                             <f:entry title="${%Enable Code-Review}">
                                 <f:checkbox name="restCodeReview"
-                                            checked="${is.config.restCodeReview}"
+                                            checked="${it.config.restCodeReview}"
                                             default="true" />
                             </f:entry>
                             <f:entry title="${%Enable Verified}">


### PR DESCRIPTION
fix "Enable Code-Review" checkbox can not be unchecked.
It's a simple typo error in index.jelly

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
