### PR TITLE
Connection is not established on startup

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -487,6 +487,10 @@ public class GerritServer implements Describable<GerritServer>, Action {
         missedEventsPlaybackManager.checkIfEventsLogPluginSupported();
         addListener((GerritEventListener)missedEventsPlaybackManager);
 
+        if (!this.isNoConnectionOnStartup()) {
+            this.startConnection();
+        }
+
         logger.info(name + " started");
         started = true;
     }


### PR DESCRIPTION
The connection is established in the ItemListener.onLoad() handler.
onLoad is not called in case of a Jenkins soft restart[1].

This happens for example when using the Jenkins Kubernetes operator
which loads configuration after Jenkins startup and then issues a soft
restart.

[1] https://github.com/jenkinsci/jenkins/blob/c9eaf345d845ec8b433120479a718a7f33e5850d/core/src/main/java/jenkins/model/Jenkins.java#L4282

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
