### PR TITLE
Warning log in wrong place

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcher.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcher.java
@@ -109,8 +109,9 @@ public class ReplicationQueueTaskDispatcher extends QueueTaskDispatcher implemen
         blockedItems = new ConcurrentHashMap<Long, BlockedItem>();
         this.replicationCache = replicationCache;
         if (gerritHandler != null) {
-            logger.warn("No GerritHandler was specified, won't register as event listener, so no function.");
             gerritHandler.addListener(this);
+        } else {
+            logger.warn("No GerritHandler was specified, won't register as event listener, so no function.");
         }
         this.replicationCache.setCreationTime(new Date().getTime());
         logger.debug("Registered to gerrit events");


### PR DESCRIPTION
In a previous commit that fixed null pointer issues this log was added.
The text refers to the ' == null' case, hence was in the wrong branch.

<!-- Please describe your pull request here. -->

- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
