### PR TITLE
Fix GerritProjectListUpdaterFunctionalTest so that it doesnt time out

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer.java
@@ -690,6 +690,16 @@ public class GerritServer implements Describable<GerritServer>, Action {
     }
 
     /**
+     * Returns the GerritProjectListUpdater of this server so that it can
+     * be configured.
+     *
+     * @return the GerritProjectListUpdater used in this server
+     */
+    public GerritProjectListUpdater getProjectListUpdater() {
+        return projectListUpdater;
+    }
+
+    /**
      * Returns the current Gerrit version.
      *
      * @return the current Gerrit version as a String if connected, or null otherwise.

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdaterFunctionalTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdaterFunctionalTest.java
@@ -56,8 +56,15 @@ public class GerritProjectListUpdaterFunctionalTest {
     public final JenkinsRule j = new JenkinsRule();
 
     private static final int SLEEPTIME = 1;
-    private static final int LONGSLEEPTIME = 320;
-    private static final int TIMEOUT = 370;
+    private static final int TIMEOUT = 500;
+
+    /**
+     * Projects update period used in this test, in minutes
+     * The default value is 5 minutes.
+     * This makes the test not take 5 minutes.
+     */
+    private static final int UPDATE_PERIOD = 1;
+    private static final int SECONDS_IN_A_MINUTE = 60;
 
     private static final long MAXSLEEPTIME = 10;
 
@@ -136,11 +143,13 @@ public class GerritProjectListUpdaterFunctionalTest {
             }
         }
         watch.stop();
+
         assertEquals(1, gerritServer.getGerritProjects().size());
 
+        //Sets the project update period to 1 minute.
+        gerritServer.getProjectListUpdater().setTimerUpdatePeriod(UPDATE_PERIOD);
         server.returnCommandFor("gerrit ls-projects", SshdServerMock.SendTwoProjectsCommand.class);
-
-        TimeUnit.SECONDS.sleep(LONGSLEEPTIME);
+        TimeUnit.SECONDS.sleep((UPDATE_PERIOD * SECONDS_IN_A_MINUTE) + SLEEPTIME);
         assertEquals(2, gerritServer.getGerritProjects().size());
 
     }


### PR DESCRIPTION
GerritProjectListUpdaterFunctionalTest has a timeout of 500 seconds, but the time that it takes to fetch updates about projects in gerrit is 300 seconds, making the timeout time insufficient to run the full test.

My fix was to change the update period in GerritProjectListUpdater so that it can be customizable. I've also changed the update period used in the test to 1 minute, making so the timeout doesn't interfere with the normal course of the test.

This issue was reproduced and fixed with a windows env, but also works with Linux.

bug appearance:
https://github.com/jenkinsci/gerrit-trigger-plugin/pull/437

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
