### PR TITLE
Added Uploader Name RegEx filter for patchsetCreatedEvent

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -54,8 +54,10 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
     private boolean excludePrivateState = false;
     private boolean excludeWipState = false;
     private String commitMessageContainsRegEx = "";
+    private String uploaderNameContainsRegEx = "";
 
     private transient Pattern commitMessagePattern = null;
+    private transient Pattern uploaderNamePattern = null;
 
 
     /**
@@ -69,6 +71,7 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
         this.excludePrivateState = false;
         this.excludeWipState = false;
         this.commitMessageContainsRegEx = "";
+        this.uploaderNameContainsRegEx = "";
     }
 
     /**
@@ -149,6 +152,17 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
     }
 
     /**
+     * Setter for uploaderNameContainsRegEx.
+     *
+     * @param uploaderNameContainsRegEx Trigger if uploader name is validated against this RegEx.
+     */
+    @DataBoundSetter
+    public void setUploaderNameContainsRegEx(String uploaderNameContainsRegEx) {
+        this.uploaderNameContainsRegEx = uploaderNameContainsRegEx;
+        this.uploaderNamePattern = null;
+    }
+
+    /**
      * Getter for the Descriptor.
      *
      * @return the Descriptor for the PluginPatchsetCreatedEvent.
@@ -217,6 +231,15 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
         return commitMessageContainsRegEx;
     }
 
+    /**
+     * Getter for uploaderNameContainsRegEx field.
+     *
+     * @return uploaderNameContainsRegEx
+     */
+    public String getUploaderNameContainsRegEx() {
+        return uploaderNameContainsRegEx;
+    }
+
     @Override
     public boolean shouldTriggerOn(GerritTriggeredEvent event) {
         if (!super.shouldTriggerOn(event)) {
@@ -250,6 +273,14 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
             }
             String commitMessage = ((PatchsetCreated)event).getChange().getCommitMessage();
             return commitMessagePattern.matcher(commitMessage).find();
+        }
+        if (StringUtils.isNotEmpty(uploaderNameContainsRegEx)) {
+            if (uploaderNamePattern == null) {
+                uploaderNamePattern = Pattern.compile(
+                        this.uploaderNameContainsRegEx, Pattern.DOTALL);
+            }
+            String uploaderName = ((PatchsetCreated)event).getPatchSet().getUploader().getName();
+            return uploaderNamePattern.matcher(uploaderName).find();
         }
         return true;
     }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent/config.jelly
@@ -50,4 +50,9 @@
              help="/plugin/gerrit-trigger/trigger/help-CommitMessageContains.html">
         <f:textbox/>
     </f:entry>
+    <f:entry title="${%Uploader Name Contains Regular Expression}"
+             field="uploaderNameContainsRegEx"
+             help="/plugin/gerrit-trigger/trigger/help-UploaderNameContains.html">
+        <f:textbox/>
+    </f:entry>
 </j:jelly>

--- a/src/main/webapp/trigger/help-UploaderNameContains.html
+++ b/src/main/webapp/trigger/help-UploaderNameContains.html
@@ -1,0 +1,9 @@
+<p>
+	Trigger Build if uploader name matches a regular expression.
+</p>
+<p>
+	If not empty, trigger if the uploader name matches the regular expression.
+	The regular expression must be in the format that can be parsed by
+	<a href="https://docs.oracle.com/javase/8/docs/api/java/util/regex/Pattern.html#sum">Java
+	Regular Expression.</a>.
+</p>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
@@ -7,6 +7,7 @@ import org.junit.Test;
 
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginPatchsetCreatedEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeKind;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Account;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.PatchsetCreated;
@@ -129,6 +130,46 @@ public class PluginPatchsetCreatedEventTest {
 
         // Commit message Regular expression does not match
         pluginPatchsetCreatedEvent.setCommitMessageContainsRegEx("MY_THING");
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+    }
+
+    /**
+     * Test that it should, or should not, fire if the uploader name matches a regular expression.
+     */
+    @Test
+    public void uploaderNameRegExCheck() {
+        PluginPatchsetCreatedEvent pluginPatchsetCreatedEvent =
+                new PluginPatchsetCreatedEvent();
+        PatchsetCreated patchsetCreated = new PatchsetCreated();
+        PatchSet patchSet = new PatchSet();
+        patchSet.setUploader(new Account("test-uploader-name", "test@test.com"));
+        patchsetCreated.setPatchset(patchSet);
+        Change change = new Change();
+        change.setCommitMessage("new commit");
+        patchsetCreated.setChange(change);
+
+        // Uploader name regular expression set to null
+        pluginPatchsetCreatedEvent.setUploaderNameContainsRegEx(null);
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Uploader name Regular expression is an empty string
+        pluginPatchsetCreatedEvent.setUploaderNameContainsRegEx("");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Uploader name Regular expression matches
+        pluginPatchsetCreatedEvent.setUploaderNameContainsRegEx("test");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Uploader name Regular expression matches
+        pluginPatchsetCreatedEvent.setUploaderNameContainsRegEx(".*uploader.*");
+        assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Uploader name Regular expression does not match
+        pluginPatchsetCreatedEvent.setUploaderNameContainsRegEx(".*MY_THING.*");
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+
+        // Uploader name Regular expression does not match
+        pluginPatchsetCreatedEvent.setUploaderNameContainsRegEx("MY_THING");
         assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
     }
 }


### PR DESCRIPTION
Added ability to filter patchset created events by uploader name using regex.

Added additional field to the patchset created event with required logic. Now if regex is added to this field it will validate uploader name against regex.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

