### PR TITLE
Prepare for icon removal from core

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/index.jelly
@@ -36,8 +36,8 @@
         </l:header>
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
-                <l:task icon="images/24x24/new-package.png" href="newServer" title="${%Add New Server}" />
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-new-package icon-md" href="newServer" title="${%Add New Server}" />
                 <l:task icon="icon-folder icon-md" href="diagnostics" title="${%Diagnostics}" />
             </l:tasks>
         </l:side-panel>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/newServer.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritManagement/newServer.jelly
@@ -26,12 +26,12 @@ THE SOFTWARE.
   "New Server" page.
 -->
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:s="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
   <l:layout norefresh="true" permission="${app.ADMINISTER}" title="${%Add New Server}">
     <l:side-panel>
       <l:tasks>
-        <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
-        <l:task icon="images/24x24/up.gif" href="${rootURL}/${it.urlName}/" title="${%Back to Server List}"/>
+        <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
+        <l:task icon="icon-up icon-md" href="${rootURL}/${it.urlName}/" title="${%Back to Server List}"/>
       </l:tasks>
     </l:side-panel>
     <l:main-panel>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -1,12 +1,12 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt" xmlns:p="/lib/gerrit-trigger">
+         xmlns:f="/lib/form" xmlns:p="/lib/gerrit-trigger">
     <l:layout title="${%Gerrit Trigger Plugin Configuration}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/${it.parentUrl}/" title="${%Back to Server List}"/>
-                <l:task icon="images/24x24/edit-delete.png" href="remove" title="Remove Server" />
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/${it.parentUrl}/" title="${%Back to Server List}"/>
+                <l:task icon="icon-edit-delete icon-md" href="remove" title="Remove Server" />
             </l:tasks>
         </l:side-panel>
         <l:main-panel>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/remove.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/remove.jelly
@@ -1,12 +1,11 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:f="/lib/form">
     <l:layout title="${%Remove Server}" norefresh="true" permission="${it.requiredPermission}">
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/${it.parentUrl}/" title="${%Back to Server List}"/>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/${it.url}/" title="${%Back to Server Configuration}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/${it.parentUrl}/" title="${%Back to Server List}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/${it.url}/" title="${%Back to Server Configuration}"/>
             </l:tasks>
         </l:side-panel>
         <l:main-panel>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/BuildMemoryReport/index.groovy
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/BuildMemoryReport/index.groovy
@@ -41,7 +41,7 @@ DateFormat dateFormat = DateFormat.getDateTimeInstance(DateFormat.SHORT, DateFor
 l.layout(title: _("Build Coordination - Gerrit Trigger Diagnostics"), norefresh: false, permission: Diagnostics.requiredPermission) {
     l.'side-panel' {
         l.tasks {
-            l.task(icon: "images/24x24/up.gif", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
+            l.task(icon: "icon-up icon-md", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
             l.task(icon: "icon-folder icon-md", href: "${rootURL}/${GerritManagement.URL_NAME}/diagnostics", title: _("Back to Diagnostics"))
         }
     }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/Diagnostics/index.groovy
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/Diagnostics/index.groovy
@@ -34,7 +34,7 @@ def l = namespace(lib.LayoutTagLib)
 l.layout(title: _("Gerrit Trigger Diagnostics"), norefresh: false, permission: Diagnostics.requiredPermission) {
     l.'side-panel' {
         l.tasks {
-            l.task(icon: "images/24x24/up.gif", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
+            l.task(icon: "icon-up icon-md", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
             l.task(icon: "icon-clipboard icon-md", href: "buildMemory", title: Messages.BuildMemoryReport_DisplayName())
             l.task(icon: "icon-clipboard icon-md", href: "eventListeners", title: Messages.EventListenersReport_DisplayName())
             if (diag.isDebugMode()) {

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/EventListenersReport/index.groovy
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/diagnostics/EventListenersReport/index.groovy
@@ -76,7 +76,7 @@ l.layout(title: _("${report.getDisplayName()} - Gerrit Trigger Diagnostics"), no
 
     l.'side-panel' {
         l.tasks {
-            l.task(icon: "images/24x24/up.gif", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
+            l.task(icon: "icon-up icon-md", href: "${rootURL}/${GerritManagement.URL_NAME}/", title: _("Back to Gerrit Management"))
             l.task(icon: "icon-folder icon-md", href: "${rootURL}/${GerritManagement.URL_NAME}/diagnostics", title: _("Back to Diagnostics"))
         }
     }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/index.jelly
@@ -1,9 +1,8 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout"
-         xmlns:t="/lib/hudson" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:l="/lib/layout" xmlns:f="/lib/form" xmlns:i="jelly:fmt">
     <l:layout title="${%Gerrit Manual trigger}" norefresh="true" permission="${it.requiredPermission}">
         <l:header>
-            <script src="${rootURL}${it.getJsUrl('gerrit-search.js')}" type="text/javascript"></script>
+            <script src="${rootURL}${it.getJsUrl('gerrit-search.js')}" type="text/javascript"/>
             <style type="text/css">
                 tr.disablehover:hover {
                 background-color: white;
@@ -12,7 +11,7 @@
         </l:header>
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.gif" href="${rootURL}/" title="${%Back to Dashboard}"/>
+                <l:task icon="icon-up icon-md" href="${rootURL}/" title="${%Back to Dashboard}"/>
             </l:tasks>
             <j:if test="${!empty(request.session.getAttribute('trigger_monitor'))}">
                 <st:include page="ajaxTriggerMonitor.jelly"/>


### PR DESCRIPTION
Preparation for core sunsetting dated icons: `https://github.com/jenkinsci/jenkins/pull/5778`

@rsandell Would be nice if you can also trigger a release after merging this PR. The core PR is blocked until then.
Thanks in advance!