### PR TITLE
Migrate from deprecated `org.junit.Assert.assertThat` to non-deprecated `org.hamcrest.MatcherAssert.assertThat`

### DIFF
--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/LockedDownGerritEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/LockedDownGerritEventTest.java
@@ -29,7 +29,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcherTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/dependency/DependencyQueueTaskDispatcherTest.java
@@ -25,7 +25,7 @@ package com.sonyericsson.hudson.plugins.gerrit.trigger.dependency;
 
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.any;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
@@ -61,7 +61,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritQueueListenerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritQueueListenerTest.java
@@ -26,7 +26,7 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
 
 import static org.hamcrest.Matchers.equalTo;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import hudson.model.FreeStyleBuild;
 import hudson.model.FreeStyleProject;
 import hudson.model.Queue;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/WorkflowTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/WorkflowTest.java
@@ -61,7 +61,7 @@ import static org.hamcrest.core.IsEqual.equalTo;
 import static org.hamcrest.core.StringContains.containsString;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author <a href="mailto:tom.fennelly@gmail.com">tom.fennelly@gmail.com</a>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionApprovalTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionApprovalTest.java
@@ -43,7 +43,7 @@ import org.jvnet.hudson.test.JenkinsRule;
 
 import static org.hamcrest.core.IsInstanceOf.instanceOf;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * @author Jiri Engelthaler &lt;EngyCZ@gmail.com&gt;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextConverterTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggerContextConverterTest.java
@@ -61,7 +61,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyCollection;

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/project/GerritTriggerProjectHudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/project/GerritTriggerProjectHudsonTest.java
@@ -47,7 +47,7 @@ import java.util.Iterator;
 import java.util.List;
 
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 /**
  * Tests for the project setup for a Gerrit triggered project.

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat2173JenkinsTest.java
@@ -48,7 +48,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat252HudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat252HudsonTest.java
@@ -64,7 +64,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersHudsonTestCase.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersHudsonTestCase.java
@@ -58,7 +58,7 @@ import static com.sonyericsson.hudson.plugins.gerrit.trigger.mock.DuplicatesUtil
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 
 //CS IGNORE MagicNumber FOR NEXT 200 LINES. REASON: Test data.

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersPreloadedProjectHudsonTestCase.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/DuplicateGerritListenersPreloadedProjectHudsonTestCase.java
@@ -86,7 +86,7 @@ import static org.hamcrest.Matchers.iterableWithSize;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertTrue;
 
 //CS IGNORE MagicNumber FOR NEXT 400 LINES. REASON: testdata.


### PR DESCRIPTION
CC @rsandell