### PR TITLE
[JENKINS-68181]-FIX: Use SafeTimerTask instead of TimerTask for DynamicTriggerConfigU…

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTimerTask.java
@@ -24,7 +24,7 @@
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger;
 
 import hudson.model.Job;
-import java.util.TimerTask;
+import hudson.triggers.SafeTimerTask;
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
 
@@ -36,7 +36,7 @@ import jenkins.model.Jenkins;
  *
  * @author Fredrik Abrahamson &lt;fredrik.abrahamson@sonymobile.com&gt;
  */
-public class GerritTriggerTimerTask extends TimerTask {
+public class GerritTriggerTimerTask extends SafeTimerTask {
     //TODO possible need to handle renames
     private String job;
 
@@ -53,8 +53,7 @@ public class GerritTriggerTimerTask extends TimerTask {
     /**
      * Called periodically by the GerritTriggerTimer according to its schedule.
      */
-    @Override
-    public void run() {
+    public void doRun() {
         GerritTrigger trigger = getGerritTrigger();
         if (trigger == null) {
             return;
@@ -62,6 +61,7 @@ public class GerritTriggerTimerTask extends TimerTask {
         // Do not skip updates since tasks might wait for the update
         trigger.updateTriggerConfigURL();
     }
+
 
     @Override
     public boolean cancel() {


### PR DESCRIPTION
…RL update

I have created an issue on jenkins jira and describes what problem that we met, and provide some useful logging  information. For periodical Dynamic Trigger Configure URL updating, it's better use the wrapped SafeTImerTask instead TimerTask.

More detail please refers to jira: [https://issues.jenkins.io/browse/JENKINS-68181](https://issues.jenkins.io/browse/JENKINS-68181)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
