### PR TITLE
[JENKINS-47420] Set review labels when RestAPI is enabled

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -155,7 +155,7 @@ public class ParameterExpander {
      * @param r the build.
      * @return the value.
      */
-    private Integer getBuildStartedVerifiedValue(Run r) {
+    public Integer getBuildStartedVerifiedValue(Run r) {
         GerritTrigger trigger = GerritTrigger.getTrigger(r.getParent());
         if (trigger == null) {
             logger.warn("Unable to get trigger config for build {} will use global value.");
@@ -179,7 +179,7 @@ public class ParameterExpander {
      * @param r the build.
      * @return the value.
      */
-    private Integer getBuildStartedCodeReviewValue(Run r) {
+    public Integer getBuildStartedCodeReviewValue(Run r) {
         GerritTrigger trigger = GerritTrigger.getTrigger(r.getParent());
         if (trigger == null) {
             logger.warn("Unable to get trigger config for build {} will use global value.");

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildStartedRestCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildStartedRestCommandJob.java
@@ -85,7 +85,7 @@ public class BuildStartedRestCommandJob extends AbstractRestCommandJob {
     protected ReviewInput createReview() {
         String message = parameterExpander.getBuildStartedMessage(build, listener, event, stats);
 
-	Collection<ReviewLabel> scoredLabels = new ArrayList<ReviewLabel>();
+        Collection<ReviewLabel> scoredLabels = new ArrayList<ReviewLabel>();
 
         if (event.isScorable()) {
             if (config.isRestCodeReview()) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildStartedRestCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildStartedRestCommandJob.java
@@ -33,8 +33,12 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.Build
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.Notify;
 import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ReviewInput;
+import com.sonymobile.tools.gerrit.gerritevents.dto.rest.ReviewLabel;
 import hudson.model.Run;
 import hudson.model.TaskListener;
+
+import java.util.ArrayList;
+import java.util.Collection;
 
 /**
  * A job for the {@link com.sonymobile.tools.gerrit.gerritevents.GerritSendCommandQueue} that
@@ -42,10 +46,15 @@ import hudson.model.TaskListener;
  */
 public class BuildStartedRestCommandJob extends AbstractRestCommandJob {
 
+
+    private static final String LABEL_CODEREVIEW = "Code-Review";
+    private static final String LABEL_VERIFIED   = "Verified";
+
     private final Run build;
     private final BuildsStartedStats stats;
     private final TaskListener listener;
     private final ParameterExpander parameterExpander;
+    private final IGerritHudsonTriggerConfig config;
 
     /**
      * Constructor.
@@ -63,7 +72,8 @@ public class BuildStartedRestCommandJob extends AbstractRestCommandJob {
         this.build = build;
         this.stats = stats;
         this.listener = listener;
-        parameterExpander = new ParameterExpander(config);
+        this.parameterExpander = new ParameterExpander(config);
+        this.config = config;
     }
 
     /**
@@ -74,12 +84,34 @@ public class BuildStartedRestCommandJob extends AbstractRestCommandJob {
     @Override
     protected ReviewInput createReview() {
         String message = parameterExpander.getBuildStartedMessage(build, listener, event, stats);
+
+	Collection<ReviewLabel> scoredLabels = new ArrayList<ReviewLabel>();
+
+        if (event.isScorable()) {
+            if (config.isRestCodeReview()) {
+                Integer crValue = parameterExpander.getBuildStartedCodeReviewValue(build);
+                if (crValue != null && crValue != Integer.MAX_VALUE) {
+                    scoredLabels.add(new ReviewLabel(
+                            LABEL_CODEREVIEW,
+                            crValue));
+                }
+            }
+            if (config.isRestVerified()) {
+                Integer verValue = parameterExpander.getBuildStartedVerifiedValue(build);
+                if (verValue != null && verValue != Integer.MAX_VALUE) {
+                    scoredLabels.add(new ReviewLabel(
+                            LABEL_VERIFIED,
+                            verValue));
+                }
+            }
+        }
+
         Notify notificationLevel = Notify.ALL;
         GerritTrigger trigger = GerritTrigger.getTrigger(build.getParent());
         if (trigger != null) {
             notificationLevel = parameterExpander.getNotificationLevel(trigger);
         }
-        return new ReviewInput(message).setNotify(notificationLevel).setTag(Constants.TAG_VALUE);
+        return new ReviewInput(message, scoredLabels).setNotify(notificationLevel).setTag(Constants.TAG_VALUE);
     }
 
 }


### PR DESCRIPTION
Resolve the issue of JENKINS-47420: Gerrit Verified and Code-Riview labels was not sent in build started command when RestAPI is enabled. Now we have the correct labels in build started command after adding scoreLabels in Reviewinput.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

