### PR TITLE
Increase the default events log support check period

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackEnabledChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/playback/GerritMissedEventsPlaybackEnabledChecker.java
@@ -46,7 +46,7 @@ import java.util.logging.Level;
 public class GerritMissedEventsPlaybackEnabledChecker extends AsyncPeriodicWork {
 
     // default check period in seconds
-    private static final long DEFAULTCHECKPERIOD = 2;
+    private static final long DEFAULTCHECKPERIOD = 86400;
     private final Long recurrencePeriod;
     private static final Logger logger =
             LoggerFactory.getLogger(GerritMissedEventsPlaybackEnabledChecker.class);


### PR DESCRIPTION
The previous default events log checking period was two seconds. This
spams Gerrit server logs with unnecessary requests checking for this
functionality. Gerrit plugins don't tend to be added and removed quickly
enough where a 2 second interval to check if it is supported is
appropriate. Instead increase the interval to once per day by default.

This is quickly enough that if a Gerrit server is updated you'll notice
in a reasonable amount of time, but infrequent enough to not flood
server logs with annoying 404 request logs for /plugins/events-log/.
Additionally it appears this Jenkins plugin queries for this support on
startup which means Jenkins users can restart the Jenkins installation
to have it query more quickly.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
