### PR TITLE
Align PLAIN matching with docs

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/CompareUtil.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/CompareUtil.java
@@ -86,7 +86,7 @@ public interface CompareUtil {
 
         @Override
         public boolean matches(String pattern, String str) {
-            return pattern.equalsIgnoreCase(str);
+            return pattern.equals(str);
         }
 
         @Override

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
@@ -107,6 +107,8 @@ public class GerritProjectInterestingTest {
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "feature/mymaster", null, true), });
+        parameters.add(new InterestingScenario[]{new InterestingScenario(config,
+                "project", "Olstorp", null, false), });
 
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.ANT, "**/master");


### PR DESCRIPTION
Documentation states that PLAIN matches with case sensitivity, but the implementation is with case insensitivity. This aligns implementation with documentation

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

