### PR TITLE
Align docs with PLAIN matching

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -107,7 +107,7 @@ field. +
 You can specify the name pattern in three different ways, as provided by
 the "Type" drop-down menu.
 
-* *Plain:* The exact name in Gerrit, case sensitive equality.
+* *Plain:* The exact name in Gerrit, case insensitive equality.
 
 * *Path:* http://ant.apache.org/manual/dirtasks.html#patterns[ANT style
 pattern]. Ex: "***/base/**"

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/GerritProjectInterestingTest.java
@@ -107,6 +107,8 @@ public class GerritProjectInterestingTest {
         config = new GerritProject(CompareType.PLAIN, "project", branches, topics, null, null, false);
         parameters.add(new InterestingScenario[]{new InterestingScenario(config,
                 "project", "feature/mymaster", null, true), });
+        parameters.add(new InterestingScenario[]{new InterestingScenario(config,
+                "project", "Olstorp", null, true), });
 
         branches = new LinkedList<Branch>();
         branch = new Branch(CompareType.ANT, "**/master");


### PR DESCRIPTION
Documentation states that PLAIN matches with case sensitivity, but the implementation is with case insensitivity. This aligns documentation with implementation

Mutually exclusive with #474, proposing that maintainers select one and reject one - I have no opinion how it should work, just that is should be consistent

- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ x] Ensure that the pull request title represents the desired changelog entry
- [ x] Please describe what you did
- [ x] Link to relevant issues in GitHub or Jira
- [ x] Link to relevant pull requests, esp. upstream and downstream changes
- [ x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
