### PR TITLE
[JENKINS-67761] Fix cancelling jobs multiple times

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -103,15 +103,6 @@ public class GerritTrigger extends Trigger<Job> {
 
     private static final Logger logger = LoggerFactory.getLogger(GerritTrigger.class);
 
-    /**
-     * Default 'true'.
-     *
-     * As a workaround for https://issues.jenkins-ci.org/browse/JENKINS-17116 it is
-     * possible to only remove pending jobs from the queue, but not to
-     * abort running jobs by setting this to 'false'.
-     */
-    public static final String JOB_ABORT = GerritTrigger.class.getName() + "_job_abort";
-
     //! A workaround for https://issues.jenkins.io/browse/JENKINS-63000
     //! projectListIsReady waiting limit to not block event listener
     //! so the queue won't grow in case of dynamic config fetch failure

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/RunningJobs.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/RunningJobs.java
@@ -221,7 +221,7 @@ public class RunningJobs {
            List<Queue.Item> itemsInQueue = queue.getItems((Queue.Task)getJob());
            for (Queue.Item item : itemsInQueue) {
                if (checkCausedByGerrit(event, item.getCauses())) {
-                   if(jobName.equals(item.task.getName())) {
+                   if (jobName.equals(item.task.getName())) {
                        queue.cancel(item);
                    }
                }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

In case N (N > 1) jobs are triggered via one event the build will be aborted N times if the build policy "Only build latest patchset" is enabled. Related to [JENKINS-67761](https://issues.jenkins.io/browse/JENKINS-67761). Instead of parsing `null` to `cancelMatchingJobs(...)` as `jobName` we actually parse the correct job name which should be cancelled.

In addition related to [JENKINS-69338](https://issues.jenkins.io/browse/JENKINS-69338) "zombie" leftovers in the queue marked with "Stopped" will be cancelled properly. During debugging noticed that `items.getCauses()` returns an empty list in case the build is a Pipeline project. Maybe there is a better way how we can handle it but right now I just added one additional cancel call before the actual thread is terminated.