### PR TITLE
Provide commit message in manual queries

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
@@ -332,7 +332,7 @@ public class ManualTriggerAction implements RootAction {
             session.setAttribute("queryString", queryString);
 
             try {
-                List<JSONObject> json = handler.queryJava(queryString, allPatchSets, true, false);
+                List<JSONObject> json = handler.queryJava(queryString, allPatchSets, true, false, true, true);
                 if (!allPatchSets) {
                     for (JSONObject j : json) {
                         if (j.containsKey("id")) {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction.java
@@ -332,7 +332,7 @@ public class ManualTriggerAction implements RootAction {
             session.setAttribute("queryString", queryString);
 
             try {
-                List<JSONObject> json = handler.queryJava(queryString, allPatchSets, true, false, true, true);
+                List<JSONObject> json = handler.queryJava(queryString, allPatchSets, true, false, true);
                 if (!allPatchSets) {
                     for (JSONObject j : json) {
                         if (j.containsKey("id")) {

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionApprovalTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerActionApprovalTest.java
@@ -80,9 +80,10 @@ public class ManualTriggerActionApprovalTest {
         sshd = SshdServerMock.startServer(server);
         server.returnCommandFor("gerrit ls-projects", SshdServerMock.EofCommandMock.class);
         server.returnCommandFor("gerrit version", SshdServerMock.EofCommandMock.class);
-        server.returnCommandFor("gerrit query --format=JSON --current-patch-set \"status:open\"",
+        server.returnCommandFor("gerrit query --format=JSON --current-patch-set --commit-message \"status:open\"",
                 SshdServerMock.SendQueryLastPatchSet.class);
-        server.returnCommandFor("gerrit query --format=JSON --patch-sets --current-patch-set \"status:open\"",
+        server.returnCommandFor("gerrit query --format=JSON --patch-sets --current-patch-set "
+                                + "--commit-message \"status:open\"",
                 SshdServerMock.SendQueryAllPatchSets.class);
 
         GerritServer gerritServer = new GerritServer(gerritServerName);


### PR DESCRIPTION
[Gerrit 3.4.6](https://www.gerritcodereview.com/3.4.html#346) (cf. [gerrit issue 15941](https://bugs.chromium.org/p/gerrit/issues/detail?id=15941)) defaults to not show commit messages unless `--commit-message` is provided.
This yields a mismatch between "automatically" and "manually" triggered changesets in the plugin (`GERRIT_CHANGE_COMMIT_MESSAGE` missing in the latter case). 
This commit switches to a different overload of `GerritQueryHandler`'s `queryJava()` providing this functionality.