### PR TITLE
[JENKINS-70111] Provide options to prevent triggering jobs when Change status != NEW

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TopicAssociation.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TopicAssociation.java
@@ -1,0 +1,188 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright (c) 2022 Christoph Kreisl. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeStatus;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+/**
+ * Topic Association Option.
+ * If this option is enabled the job matching the topic configuration is triggered.
+ * Since changes assigned to a topic could be in an inappropriate state we check if changes
+ * in state NEW, MERGED or ABANDONED should be ignored.
+ *
+ * In general this shouldn't happen since changes can only be merged together.
+ * However, if someone adds a change to an already merged topic the jobs for the merged changes
+ * shouldn't be triggered again if not required.
+ */
+public class TopicAssociation extends AbstractDescribableImpl<TopicAssociation> {
+
+   private boolean enabled;
+   private boolean ignoreNewChangeStatus;
+   private boolean ignoreMergedChangeStatus;
+   private boolean ignoreAbandonedChangeStatus;
+
+    /**
+     * Default data bound constructor.
+     *
+     * @param ignoreNewChangeStatus If changes with status NEW should be ignored
+     * @param ignoreMergedChangeStatus If changes with status MERGED should be ignored
+     * @param ignoreAbandonedChangeStatus If changes with status ABANDONED should be ignored
+     */
+    @DataBoundConstructor
+    public TopicAssociation(final boolean ignoreNewChangeStatus,
+                            final boolean ignoreMergedChangeStatus,
+                            final boolean ignoreAbandonedChangeStatus) {
+        this.enabled = true;
+        this.ignoreNewChangeStatus = ignoreNewChangeStatus;
+        this.ignoreMergedChangeStatus = ignoreMergedChangeStatus;
+        this.ignoreAbandonedChangeStatus = ignoreAbandonedChangeStatus;
+    }
+
+    /**
+     * Default constructor.
+     */
+    public TopicAssociation() {
+        this.enabled = false;
+        this.ignoreNewChangeStatus = false;
+        this.ignoreMergedChangeStatus = false;
+        this.ignoreAbandonedChangeStatus = false;
+    }
+
+    /**
+     * Returns true if the topic association option is enabled.
+     *
+     * @return true if enabled otherwise false.
+     */
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    /**
+     * Enable or disable topic association.
+     *
+     * @param enabled true or false.
+     */
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+
+    /**
+     * Returns true if a change in state NEW should be ignored otherwise false.
+     *
+     * @return true if it should be ignored otherwise false
+     */
+    public boolean isIgnoreNewChangeStatus() {
+        return ignoreNewChangeStatus;
+    }
+
+    /**
+     * Enable or disable ignoring changes with status NEW.
+     *
+     * @param ignoreNewChangeStatus true or false.
+     */
+    public void setIgnoreNewChangeStatus(boolean ignoreNewChangeStatus) {
+        this.ignoreNewChangeStatus = ignoreNewChangeStatus;
+    }
+
+    /**
+     * Returns true if a change in state NEW should be ignored otherwise false.
+     * Used for jelly file.
+     *
+     * @return true if it should be ignored otherwise false
+     */
+    public boolean isIgnoreMergedChangeStatus() {
+        return ignoreMergedChangeStatus;
+    }
+
+    /**
+     * Enable or disable ignoring changes with status MERGED.
+     *
+     * @param ignoreMergedChangeStatus true or false.
+     */
+    public void setIgnoreMergedChangeStatus(boolean ignoreMergedChangeStatus) {
+        this.ignoreMergedChangeStatus = ignoreMergedChangeStatus;
+    }
+
+    /**
+     * Returns true if a change in state NEW should be ignored otherwise false.
+     * Used for jelly file.
+     *
+     * @return true if it should be ignored otherwise false
+     */
+    public boolean isIgnoreAbandonedChangeStatus() {
+        return ignoreAbandonedChangeStatus;
+    }
+
+    /**
+     * Enable or disable ignoring changes with status ABANDONED.
+     *
+     * @param ignoreAbandonedChangeStatus true or false.
+     */
+    public void setIgnoreAbandonedChangeStatus(boolean ignoreAbandonedChangeStatus) {
+        this.ignoreAbandonedChangeStatus = ignoreAbandonedChangeStatus;
+    }
+
+    /**
+     * Checks if the change state is interesting.
+     *
+     * @param c the change.
+     * @return true if the change is interesting otherwise false.
+     */
+    public boolean isInterestingChangeStatus(final Change c) {
+        boolean isNewChange = c.getStatus().equals(GerritChangeStatus.NEW);
+        boolean isMergedChange = c.getStatus().equals(GerritChangeStatus.MERGED);
+        boolean isAbandonedChange = c.getStatus().equals(GerritChangeStatus.ABANDONED);
+
+        if (isNewChange && ignoreNewChangeStatus) {
+            return false;
+        }
+
+        if (isMergedChange && ignoreMergedChangeStatus) {
+            return false;
+        }
+
+        if (isAbandonedChange && ignoreAbandonedChangeStatus) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * The Descriptor for the Topic Association.
+     */
+    @Extension
+    public static class DescriptorImpl extends Descriptor<TopicAssociation> {
+        @Override
+        public String getDisplayName() {
+            return "Topic Association";
+        }
+    }
+}

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -236,12 +236,32 @@
            <f:checkbox name="silentMode"
                        checked="${it.silentMode}"/>
         </f:entry>
-        <f:entry title="${%Enable Topic Association}"
-                 field="enableTopicAssociation"
-                 help="/plugin/gerrit-trigger/trigger/help-EnableTopicAssociation.html">
-           <f:checkbox name="enableTopicAssociation"
-                       checked="${it.enableTopicAssociation}"/>
-        </f:entry>
+
+        <f:optionalBlock name="topicAssociation"
+                         field="topicAssociation"
+                         title="${%Topic Association}"
+                         help="/plugin/gerrit-trigger/trigger/help-EnableTopicAssociation.html"
+                         checked="${it.topicAssociation.enabled}">
+            <f:entry title="${%Ignore changes in state NEW}"
+                     help="/plugin/gerrit-trigger/trigger/help-EnableTopicAssociationIgnoreNew.html">
+                <f:checkbox field="ignoreNewChangeStatus"
+                            checked="${it.topicAssociation.ignoreNewChangeStatus}"
+                            default="false"/>
+            </f:entry>
+            <f:entry title="${%Ignore changes in state MERGED}"
+                     help="/plugin/gerrit-trigger/trigger/help-EnableTopicAssociationIgnoreMerged.html">
+                <f:checkbox field="ignoreMergedChangeStatus"
+                            checked="${it.topicAssociation.ignoreMergedChangeStatus}"
+                            default="false"/>
+            </f:entry>
+            <f:entry title="${%Ignore changes in state ABANDONED}"
+                     help="/plugin/gerrit-trigger/trigger/help-EnableTopicAssociationIgnoreAbandoned.html">
+                <f:checkbox field="ignoreAbandonedChangeStatus"
+                            checked="${it.topicAssociation.ignoreAbandonedChangeStatus}"
+                            default="false"/>
+            </f:entry>
+        </f:optionalBlock>
+
         <f:entry title="${%Trigger on}"
                 help="/plugin/gerrit-trigger/trigger/help-GerritEventType.html">
             <f:hetero-list descriptors="${descriptor.getGerritEventDescriptors()}" items="${instance.triggerOnEvents}" name="triggerOnEvents" hasHeader="true"/>

--- a/src/main/webapp/trigger/help-EnableTopicAssociation.html
+++ b/src/main/webapp/trigger/help-EnableTopicAssociation.html
@@ -1,1 +1,1 @@
-If any change in a topic matches the trigger configuration, the job will be triggered
+If any change in a topic matches the trigger configuration, the job will be triggered.

--- a/src/main/webapp/trigger/help-EnableTopicAssociationIgnoreAbandoned.html
+++ b/src/main/webapp/trigger/help-EnableTopicAssociationIgnoreAbandoned.html
@@ -1,0 +1,1 @@
+Ignore changes assigned to the interesting topic if they have been ABANDONED.

--- a/src/main/webapp/trigger/help-EnableTopicAssociationIgnoreMerged.html
+++ b/src/main/webapp/trigger/help-EnableTopicAssociationIgnoreMerged.html
@@ -1,0 +1,3 @@
+Ignore changes assigned to the interesting topic if they have been already MERGED.
+
+Ignore changes assigned to the interesting topic if they have been ABANDONED.

--- a/src/main/webapp/trigger/help-EnableTopicAssociationIgnoreNew.html
+++ b/src/main/webapp/trigger/help-EnableTopicAssociationIgnoreNew.html
@@ -1,0 +1,1 @@
+Ignore changes assigned to the topic if they are in state NEW (open).

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TopicAssociationTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TopicAssociationTest.java
@@ -1,0 +1,79 @@
+/*
+ *  The MIT License
+ *
+ *  Copyright 2022 Christoph Kreisl. All rights reserved.
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ *  THE SOFTWARE.
+ */
+
+package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data;
+
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeStatus;
+import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
+import org.junit.Test;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Tests the TopicAssociation method.
+ * @author Christoph Kreisl
+ */
+public class TopicAssociationTest {
+
+    /**
+     * Create a custom change for testing.
+     *
+     * @param status The GerritChangeStatus
+     * @return new Change object based on status parameter.
+     */
+    private Change createChange(GerritChangeStatus status) {
+        Change change = new Change();
+        change.setStatus(status);
+        return change;
+    }
+
+    /**
+     * Test if change with status is interesting.
+     */
+    @Test
+    public void testIsInterestingChange() {
+        TopicAssociation topicAssociation = new TopicAssociation();
+        topicAssociation.setEnabled(true);
+
+        Change c = createChange(GerritChangeStatus.NEW);
+        assertTrue(topicAssociation.isInterestingChangeStatus(c));
+
+        topicAssociation.setIgnoreNewChangeStatus(true);
+        assertFalse(topicAssociation.isInterestingChangeStatus(c));
+
+        c = createChange(GerritChangeStatus.MERGED);
+        assertTrue(topicAssociation.isInterestingChangeStatus(c));
+
+        topicAssociation.setIgnoreMergedChangeStatus(true);
+        assertFalse(topicAssociation.isInterestingChangeStatus(c));
+
+        c = createChange(GerritChangeStatus.ABANDONED);
+        assertTrue(topicAssociation.isInterestingChangeStatus(c));
+
+        topicAssociation.setIgnoreAbandonedChangeStatus(true);
+        assertFalse(topicAssociation.isInterestingChangeStatus(c));
+    }
+
+}

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/TopicAssociationTriggerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/TopicAssociationTriggerTest.java
@@ -7,8 +7,10 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigge
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.Branch;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.CompareType;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.GerritProject;
+import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.TopicAssociation;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.events.PluginCommentAddedEvent;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.mock.Setup;
+import com.sonymobile.tools.gerrit.gerritevents.dto.GerritChangeStatus;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.CommentAdded;
 import com.sonymobile.tools.gerrit.gerritevents.mock.SshdServerMock;
 
@@ -61,9 +63,9 @@ public class TopicAssociationTriggerTest {
      * @throws IOException if so.
      */
     private FreeStyleProject createJob(String pattern) throws IOException {
+
         FreeStyleProject job = j.createFreeStyleProject();
         job.getBuildersList().add(new ParametersBuilder());
-
         GerritTrigger trigger = Setup.createDefaultTrigger(job);
         trigger.setEnableTopicAssociation(true);
         trigger.getTriggerOnEvents().add(new PluginCommentAddedEvent("Code-Review", "1"));
@@ -119,18 +121,20 @@ public class TopicAssociationTriggerTest {
     }
 
     /**
-     * Trigger a
+     * Trigger and wait.
      * {@link com.sonymobile.tools.gerrit.gerritevents.dto.events.createCommentAdded} event and wait until no activity.
      * @param project The gerrit project name.
+     * @param status The status of the change.
      * @throws Exception if so
      */
-    private void triggerAndWait(String project) throws Exception {
+    private void triggerAndWait(String project, GerritChangeStatus status) throws Exception {
         System.out.println("trigger " + project);
         String expected = "Triggering comment";
         CommentAdded event = Setup.createCommentAdded();
         event.setComment(expected);
         event.getChange().setProject(project);
         event.getChange().setTopic("topic");
+        event.getChange().setStatus(status);
         gerritServer.triggerEvent(event);
         j.waitUntilNoActivity();
     }
@@ -144,21 +148,46 @@ public class TopicAssociationTriggerTest {
      */
     @Test
     public void testTopicAssociationTrigger() throws Exception {
-        //CS IGNORE MagicNumber FOR NEXT 14 LINES. REASON: Testdata.
+        //CS IGNORE MagicNumber FOR NEXT 41 LINES. REASON: Testdata.
         server.waitForCommand("gerrit stream-events", 2000);
-        triggerAndWait(projects[0]);
+
+        triggerAndWait(projects[0], GerritChangeStatus.NEW);
         assertEquals(1, jobs.get(0).getLastBuild().getNumber());
+        assertEquals(1, jobs.get(1).getLastBuild().getNumber());
+
+        TopicAssociation ta = new TopicAssociation();
+        ta.setEnabled(true);
+        ta.setIgnoreNewChangeStatus(true);
+
+        jobs.get(1).getTrigger(GerritTrigger.class).setTopicAssociation(ta);
+
+        triggerAndWait(projects[0], GerritChangeStatus.NEW);
+        assertEquals(2, jobs.get(0).getLastBuild().getNumber());
+        assertEquals(1, jobs.get(1).getLastBuild().getNumber());
+
+        ta.setIgnoreMergedChangeStatus(true);
+        jobs.get(1).getTrigger(GerritTrigger.class).setTopicAssociation(ta);
+
+        triggerAndWait(projects[0], GerritChangeStatus.MERGED);
+        assertEquals(3, jobs.get(0).getLastBuild().getNumber());
+        assertEquals(1, jobs.get(1).getLastBuild().getNumber());
+
+        ta.setIgnoreAbandonedChangeStatus(true);
+        jobs.get(1).getTrigger(GerritTrigger.class).setTopicAssociation(ta);
+
+        triggerAndWait(projects[0], GerritChangeStatus.ABANDONED);
+        assertEquals(4, jobs.get(0).getLastBuild().getNumber());
         assertEquals(1, jobs.get(1).getLastBuild().getNumber());
 
         jobs.get(0).getTrigger(GerritTrigger.class).setEnableTopicAssociation(false);
         jobs.get(1).getTrigger(GerritTrigger.class).setEnableTopicAssociation(false);
 
-        triggerAndWait(projects[0]);
-        assertEquals(2, jobs.get(0).getLastBuild().getNumber());
+        triggerAndWait(projects[0], GerritChangeStatus.NEW);
+        assertEquals(5, jobs.get(0).getLastBuild().getNumber());
         assertEquals(1, jobs.get(1).getLastBuild().getNumber());
 
-        triggerAndWait(projects[1]);
-        assertEquals(2, jobs.get(0).getLastBuild().getNumber());
+        triggerAndWait(projects[1], GerritChangeStatus.NEW);
+        assertEquals(5, jobs.get(0).getLastBuild().getNumber());
         assertEquals(2, jobs.get(1).getLastBuild().getNumber());
     }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

When enabling the option "Enable Topic Association" within the job configurations every job will be triggered as soon as the topic is of interest. This can lead to jobs triggered even if the Change matching the topic has the status MERGED or ABANDONED.

In general you can't submit a whole topic in Gerrit if there is one change which has been abandoned. Since topics are not unique in Gerrit and it always can happen that some developers assign a change to another topic as reference there should be an option to prevent triggering builds if the change of interest assigned to the topic is already in a specific state.