### PR TITLE
[JENKINS-70045] Fix active to wip state change triggers build

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -51,6 +51,7 @@ import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Change;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.PatchSet;
 import com.sonymobile.tools.gerrit.gerritevents.dto.attr.Provider;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.ChangeBasedEvent;
+import com.sonymobile.tools.gerrit.gerritevents.dto.events.WipStateChanged;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.CommentAdded;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.RefUpdated;
@@ -660,11 +661,20 @@ public class GerritTrigger extends Trigger<Job> {
         if (triggerOnEvents == null || triggerOnEvents.isEmpty()) {
             return false;
         }
+
         for (PluginGerritEvent e : triggerOnEvents) {
-            if (e.shouldTriggerOn(event)) {
-                return true;
+            if (!e.shouldTriggerOn(event)) {
+                continue;
             }
+
+            if (event instanceof WipStateChanged) {
+                // Switching from an active patchset to Wip should not trigger a build
+                return !((WipStateChanged)event).getChange().isWip();
+            }
+
+            return true;
         }
+
         return false;
     }
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTriggerTest.java
@@ -1875,7 +1875,7 @@ public class GerritTriggerTest {
             verify(listener).onTriggered(same(project), same(event));
             verify(queue).schedule2(same(project), anyInt(), hasCauseActionContainingCause(null));
 
-            // We change from active to WiP which should trigger a build.
+            // We change from active to WiP which should not trigger a build.
             event.getChange().setWip(true);
             assertFalse(trigger.isInteresting(event));
         }


### PR DESCRIPTION
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Rel to [JENKINS-70045](https://issues.jenkins.io/browse/JENKINS-70045) the behavior of the WipStateChanged right now triggers a build any time if we switch from "Active" state to "WiP". Logic wise someone does not want to trigger a build if he switches his workspace to WiP.
