### PR TITLE
[JENKINS-70558] Fix TopicAssociation not set after Jenkins restart

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -2176,11 +2176,8 @@ public class GerritTrigger extends Trigger<Job> {
         if (projectListIsReady == null) {
             projectListIsReady = new CountDownLatch(0);
         }
-
-        if (enableTopicAssociation) {
+        if (topicAssociation == null) {
             topicAssociation = new TopicAssociation();
-        } else {
-            topicAssociation = null;
         }
 
         return super.readResolve();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1898,7 +1898,6 @@ public class GerritTrigger extends Trigger<Job> {
      * @param enable true or false.
      */
     @Deprecated
-    @DataBoundSetter
     public void setEnableTopicAssociation(boolean enable) {
         if (enable) {
             topicAssociation = new TopicAssociation();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -1893,10 +1893,12 @@ public class GerritTrigger extends Trigger<Job> {
 
     /**
      * Enable or disable Topic Association option.
+     * Replaced by {@link #setTopicAssociation(TopicAssociation)} ()
      *
      * @param enable true or false.
      */
     @Deprecated
+    @DataBoundSetter
     public void setEnableTopicAssociation(boolean enable) {
         if (enable) {
             topicAssociation = new TopicAssociation();
@@ -2176,7 +2178,7 @@ public class GerritTrigger extends Trigger<Job> {
         if (projectListIsReady == null) {
             projectListIsReady = new CountDownLatch(0);
         }
-        if (topicAssociation == null) {
+        if (topicAssociation == null && enableTopicAssociation) {
             topicAssociation = new TopicAssociation();
         }
 


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

The PR #481 introduced a small bug that the `TopicAssociation` field is not set after a Jenkins restart.

Description from Jenkins issue: https://issues.jenkins.io/browse/JENKINS-70558 

In the job configuration if TopicAssociation is enabled and Jenkins is restarted the option is not set anymore.
The reason is that the `readResolve()` function checks the config value 
`private transient boolean enableTopicAssociation = Config.DEFAULT_ENABLE_TOPIC_ASSOCIATION;`
 (GerritTrigger.java) which is always **false**. Since this condition is always the case the topicAssociation value in the GerritTrigger class is set to "null".