### PR TITLE
[JENKINS-70494] Fix retrigger button visibility

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction.java
@@ -100,7 +100,7 @@ public class RetriggerAction implements Action {
      * checks if the current user has permission to build/retrigger the project.
      * @return true if so.
      */
-    public boolean hasPermission() {
+    private boolean hasPermission() {
         if (context == null || context.getThisBuild() == null || context.getThisBuild().getProject() == null) {
             return false;
         } else {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction.java
@@ -137,6 +137,16 @@ public class RetriggerAction implements Action {
             return;
         }
 
+        if (!hasPermission()) {
+            //TODO Access denied message to user?
+            return;
+        }
+
+        if (isBuilding()) {
+            //TODO show error to user?
+            return;
+        }
+
         trigger.retriggerThisBuild(context);
         response.sendRedirect2(entity.getProject().getAbsoluteUrl());
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction.java
@@ -66,29 +66,17 @@ public class RetriggerAction implements Action {
 
     @Override
     public String getIconFileName() {
-        if (!hasPermission() || isBuilding()) {
-            return null;
-        } else {
-            return getPluginImageUrl("icon_retrigger24.png");
-        }
+        return getPluginImageUrl("icon_retrigger24.png");
     }
 
     @Override
     public String getDisplayName() {
-        if (!hasPermission() || isBuilding()) {
-            return null;
-        } else {
-            return Messages.Retrigger();
-        }
+        return Messages.Retrigger();
     }
 
     @Override
     public String getUrlName() {
-        if (!hasPermission() || isBuilding()) {
-            return null;
-        } else {
-            return "gerrit-trigger-retrigger-this";
-        }
+        return "gerrit-trigger-retrigger-this";
     }
 
     /**
@@ -112,13 +100,21 @@ public class RetriggerAction implements Action {
      * checks if the current user has permission to build/retrigger the project.
      * @return true if so.
      */
-    @Restricted(NoExternalUse.class)
     public boolean hasPermission() {
         if (context == null || context.getThisBuild() == null || context.getThisBuild().getProject() == null) {
             return false;
         } else {
             return context.getThisBuild().getProject().hasPermission(PluginImpl.RETRIGGER);
         }
+    }
+
+    /**
+     * Displays the retrigger option if permission is granted and the build is not already running.
+     * @return true if so.
+     */
+    @Restricted(NoExternalUse.class)
+    public boolean isVisible() {
+        return hasPermission() && !isBuilding();
     }
 
     /**
@@ -131,16 +127,6 @@ public class RetriggerAction implements Action {
     public void doIndex(StaplerRequest request, StaplerResponse response) throws IOException {
 
         if (context == null || context.getThisBuild() == null) {
-            return;
-        }
-
-        if (!hasPermission()) {
-            //TODO Access denied message to user?
-            return;
-        }
-
-        if (isBuilding()) {
-            //TODO show error to user?
             return;
         }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction.java
@@ -126,6 +126,16 @@ public class RetriggerAction implements Action {
     @POST
     public void doIndex(StaplerRequest request, StaplerResponse response) throws IOException {
 
+        if (!hasPermission()) {
+            //TODO Access denied message to user?
+            return;
+        }
+
+        if (isBuilding()) {
+            //TODO show error to user?
+            return;
+        }
+
         if (context == null || context.getThisBuild() == null) {
             return;
         }
@@ -134,16 +144,6 @@ public class RetriggerAction implements Action {
         GerritTrigger trigger = GerritTrigger.getTrigger(entity.getProject());
         if (trigger == null) {
             //TODO show config error to user?
-            return;
-        }
-
-        if (!hasPermission()) {
-            //TODO Access denied message to user?
-            return;
-        }
-
-        if (isBuilding()) {
-            //TODO show error to user?
             return;
         }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
@@ -116,7 +116,7 @@ public class RetriggerAllAction implements Action {
      * checks if the current user has permission to build/retrigger this and the other projects.
      * @return true if so.
      */
-    public boolean hasPermission() {
+    private boolean hasPermission() {
         if (context == null || context.getThisBuild() == null || context.getThisBuild().getProject() == null) {
             return false;
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
@@ -86,7 +86,7 @@ public class RetriggerAllAction implements Action {
      * It does a null check on the context before calling.
      * @return true if there are any other builds in the context.
      */
-    public boolean hasOthers() {
+    private boolean hasOthers() {
         if (context != null) {
             return context.hasOthers();
         } else {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
@@ -161,6 +161,21 @@ public class RetriggerAllAction implements Action {
             return;
         }
 
+        if (!hasPermission()) {
+            //TODO Access denied message to user?
+            return;
+        }
+
+        if (isBuilding()) {
+            //TODO show error to user?
+            return;
+        }
+
+        if (!context.hasOthers()) {
+            //There is no reason to run this action on a lonely project.
+            return;
+        }
+
         trigger.retriggerAllBuilds(context);
         response.sendRedirect2(entity.getProject().getAbsoluteUrl());
     }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
@@ -68,29 +68,17 @@ public class RetriggerAllAction implements Action {
 
     @Override
     public String getIconFileName() {
-        if (!hasPermission() || isBuilding() || !hasOthers()) {
-            return null;
-        } else {
-            return getPluginImageUrl("icon_retrigger24.png");
-        }
+        return getPluginImageUrl("icon_retrigger24.png");
     }
 
     @Override
     public String getDisplayName() {
-        if (!hasPermission() || isBuilding() || !hasOthers()) {
-            return null;
-        } else {
-            return Messages.RetriggerAll();
-        }
+        return Messages.RetriggerAll();
     }
 
     @Override
     public String getUrlName() {
-        if (!hasPermission() || isBuilding() || !hasOthers()) {
-            return null;
-        } else {
-            return "gerrit-trigger-retrigger-all";
-        }
+        return "gerrit-trigger-retrigger-all";
     }
 
     /**
@@ -98,7 +86,6 @@ public class RetriggerAllAction implements Action {
      * It does a null check on the context before calling.
      * @return true if there are any other builds in the context.
      */
-    @Restricted(NoExternalUse.class)
     public boolean hasOthers() {
         if (context != null) {
             return context.hasOthers();
@@ -129,7 +116,6 @@ public class RetriggerAllAction implements Action {
      * checks if the current user has permission to build/retrigger this and the other projects.
      * @return true if so.
      */
-    @Restricted(NoExternalUse.class)
     public boolean hasPermission() {
         if (context == null || context.getThisBuild() == null || context.getThisBuild().getProject() == null) {
             return false;
@@ -147,6 +133,15 @@ public class RetriggerAllAction implements Action {
     }
 
     /**
+     * Displays the retrigger all option if permission is granted and the build is not already running.
+     * @return true if so.
+     */
+    @Restricted(NoExternalUse.class)
+    public boolean isVisible() {
+        return hasPermission() && hasOthers() && !isBuilding();
+    }
+
+    /**
      * Handles the request to re-trigger and redirects back to the page that called.
      * @param request StaplerRequest the request.
      * @param response StaplerResponse the response handler.
@@ -156,21 +151,6 @@ public class RetriggerAllAction implements Action {
     public void doIndex(StaplerRequest request, StaplerResponse response) throws IOException {
 
         if (context == null || context.getThisBuild() == null) {
-            return;
-        }
-
-        if (!hasPermission()) {
-            //TODO Access denied message to user?
-            return;
-        }
-
-        if (isBuilding()) {
-            //TODO show error to user?
-            return;
-        }
-
-        if (!context.hasOthers()) {
-            //There is no reason to run this action on a lonely project.
             return;
         }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction.java
@@ -150,17 +150,6 @@ public class RetriggerAllAction implements Action {
     @POST
     public void doIndex(StaplerRequest request, StaplerResponse response) throws IOException {
 
-        if (context == null || context.getThisBuild() == null) {
-            return;
-        }
-
-        TriggeredItemEntity entity = context.getThisBuild();
-        GerritTrigger trigger = GerritTrigger.getTrigger(entity.getProject());
-        if (trigger == null) {
-            //TODO show config error to user?
-            return;
-        }
-
         if (!hasPermission()) {
             //TODO Access denied message to user?
             return;
@@ -171,8 +160,19 @@ public class RetriggerAllAction implements Action {
             return;
         }
 
+        if (context == null || context.getThisBuild() == null) {
+            return;
+        }
+
         if (!context.hasOthers()) {
             //There is no reason to run this action on a lonely project.
+            return;
+        }
+
+        TriggeredItemEntity entity = context.getThisBuild();
+        GerritTrigger trigger = GerritTrigger.getTrigger(entity.getProject());
+        if (trigger == null) {
+            //TODO show config error to user?
             return;
         }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/GerritPluginChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/GerritPluginChecker.java
@@ -153,7 +153,7 @@ public final class GerritPluginChecker {
         } catch (Exception e) {
             logger.warn(Messages.PluginHttpConnectionGeneralError(pluginName,
                     e.getMessage()), e);
-            return null;
+            return false;
         } finally {
             if (execute != null) {
                 try {

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/GerritPluginChecker.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/utils/GerritPluginChecker.java
@@ -153,7 +153,7 @@ public final class GerritPluginChecker {
         } catch (Exception e) {
             logger.warn(Messages.PluginHttpConnectionGeneralError(pluginName,
                     e.getMessage()), e);
-            return false;
+            return null;
         } finally {
             if (execute != null) {
                 try {

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction/action.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAction/action.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout">
-    <j:if test="${action.hasPermission()}">
+    <j:if test="${action.isVisible()}">
         <l:task icon="${action.iconFileName}" title="${action.displayName}"
                 href="${rootURL}/${it.url}${action.urlName}/index"
                 post="true"

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction/action.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/RetriggerAllAction/action.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:l="/lib/layout" xmlns:st="jelly:stapler">
-    <j:if test="${action.hasPermission() &amp;&amp; action.hasOthers()}">
+    <j:if test="${action.isVisible()}">
         <l:task icon="${action.iconFileName}" title="${action.displayName}"
                 href="${rootURL}/${it.url}${action.urlName}/index"
                 post="true"


### PR DESCRIPTION
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Rel to: https://issues.jenkins.io/browse/JENKINS-70494 

With the latest security patch in version 2.38.1 the behavior of the visibility of the retrigger buttons has changed due to the newly added action.jelly files.

Security patch change: https://github.com/jenkinsci/gerrit-trigger-plugin/commit/691d76fdf54d659f8585ea3cbc3cce60d9edfec8

With the introduced pre-check in this jelly file whether the button should be visible or not we could get rid of some obsolete code.

The only "issue" i faced now during debugging is that the  `response.sendRedirect2(entity.getProject().getAbsoluteUrl());` did not redirect me to the build job page. There was just a small popup by clicking the "Retrigger" button stating "Done.".
I've justed tested it on Win 11 - Google Chrome.

Any feedback from your end @rsandell ?