### PR TITLE
Remove unused `hudson.udp` property

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -293,12 +293,6 @@
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <systemProperties>
-                        <property>
-                            <name>hudson.udp</name>
-                            <value>33849</value>
-                        </property>
-                    </systemProperties>
                     <reuseForks>false</reuseForks>
                     <forkCount>${concurrency}</forkCount>
                 </configuration>


### PR DESCRIPTION
Forgotten in jenkinsci/jenkins#4460 & jenkinsci/jenkins#5720.