### PR TITLE
[JENKINS-71007] Replace Deprecated Icons

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.jelly
@@ -54,7 +54,7 @@
                         </j:when>
                         <j:otherwise>
                             <td width="18">
-                                <img src="${imagesURL}/16x16/grey_anime.gif"/>
+                                <img src="${rootURL}/images/build-status/build-status-sprite.svg#never-built" class="icon-grey-anime icon-sm"/>
                             </td>
                             <td>
                                 <a href="${rootURL}/${other.project.url}">${other.project.displayName}</a>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/ajaxTriggerMonitor.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/ajaxTriggerMonitor.jelly
@@ -67,7 +67,7 @@
                                     </j:when>
                                     <j:otherwise>
                                         <td width="14">
-                                            <img src="${imagesURL}/16x16/grey_anime.gif"/>
+                                            <img src="${rootURL}/images/build-status/build-status-sprite.svg#never-built" class="icon-grey-anime icon-sm"/>
                                         </td>
                                         <td>
                                             <a href="${rootURL}/${build.project.url}">${build.project.displayName}</a>


### PR DESCRIPTION
Resolves [JENKINS-71007](https://issues.jenkins.io/browse/JENKINS-71007)

grey_anime.gif icon was removed from jenkins core with [JENKINS-67753](https://issues.jenkins.io/browse/JENKINS-67753) but still used at GerritCause/description.jelly and ManualTriggerAction/ajaxTriggerMonitor.jelly

Replacement of icon image according to the changes made in [JENKINS-67753](https://issues.jenkins.io/browse/JENKINS-67753) were made

- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes