### PR TITLE
[JENKINS-71616] Use full project name instead of related name for comparing job names

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/RunningJobs.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/RunningJobs.java
@@ -28,6 +28,7 @@ import jenkins.model.CauseOfInterruption;
 import jenkins.model.Jenkins;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import java.util.regex.Pattern;
 
 /**
 * Class for maintaining and synchronizing the runningJobs info.
@@ -233,10 +234,14 @@ public class RunningJobs {
            List<Queue.Item> itemsInQueue = Queue.getInstance().getItems((Queue.Task)getJob());
            for (Queue.Item item : itemsInQueue) {
                if (checkCausedByGerrit(event, item.getCauses())) {
-                   // Use transformed fullDisplayNameFor to avoid
-                   // ambigous comparing between same name projects but located at different folders
-                   // FolderName » jobName to FolderName/jobName
-                   if (jobName.equals(item.task.getFullDisplayName().replace(" » ", "/"))) {
+                   // Use regexpt .*jobName to avoid
+                   // incorrect comparison in case of complicated full name
+                   // .*\/jobName$|^jobName$
+
+                   String regex = ".*\\/" + jobName + "$|^" + jobName + "$";
+                   Pattern pattern = Pattern.compile(regex);
+
+                   if (pattern.matcher(item.task.getName()).matches()) {
                        Queue.getInstance().cancel(item);
 
                    }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/RunningJobs.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/RunningJobs.java
@@ -233,8 +233,12 @@ public class RunningJobs {
            List<Queue.Item> itemsInQueue = Queue.getInstance().getItems((Queue.Task)getJob());
            for (Queue.Item item : itemsInQueue) {
                if (checkCausedByGerrit(event, item.getCauses())) {
-                   if (jobName.equals(item.task.getName())) {
+                   // Use transformed fullDisplayNameFor to avoid
+                   // ambigous comparing between same name projects but located at different folders
+                   // FolderName » jobName to FolderName/jobName
+                   if (jobName.equals(item.task.getFullDisplayName().replace(" » ", "/"))) {
                        Queue.getInstance().cancel(item);
+
                    }
                }
            }


### PR DESCRIPTION
https://issues.jenkins.io/browse/JENKINS-71616

If project has complicated name like folder/project-name then buildCurrentPatchesOnly feature does not work because of cancelMatchingJobs gets parametr jobName as full name but for comparing it uses just relative name without folder or parent project item.task.getName()).

Cannot get fullName form the task. Workaround is transform fullDisplayName with replacing separator from " » "to "/"
item.task.getFullDisplayName().replace(" » ", "/")

Don't have any idea how to prepare tests, looks like test implementation requires much more time then fix.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
