### PR TITLE
[JENKINS-66535] Fix situation when failed builds are missing and only successful builds remain

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpander.java
@@ -381,12 +381,14 @@ public class ParameterExpander {
     /**
      * Returns the minimum verified value for the build results in the memory.
      * If no builds have contributed to verified value, this method returns null
-     * @param memoryImprint the memory.
-     * @param onlyBuilt only count builds that completed (no NOT_BUILT builds)
+     *
+     * @param memoryImprint    the memory.
+     * @param onlyBuilt        only count builds that completed (no NOT_BUILT builds)
+     * @param maxAllowedVerifiedValue Upper boundary on verified value.
      * @return the lowest verified value.
      */
     @CheckForNull
-    public Integer getMinimumVerifiedValue(MemoryImprint memoryImprint, boolean onlyBuilt) {
+    public Integer getMinimumVerifiedValue(MemoryImprint memoryImprint, boolean onlyBuilt, Integer maxAllowedVerifiedValue) {
         Integer verified = Integer.MAX_VALUE;
         for (Entry entry : memoryImprint.getEntries()) {
             if (entry == null) {
@@ -415,7 +417,7 @@ public class ParameterExpander {
             return null;
         }
 
-        return verified;
+        return Math.min(verified, maxAllowedVerifiedValue);
     }
 
     /**
@@ -531,12 +533,19 @@ public class ParameterExpander {
         // builds were successful, unstable or failed, we find the minimum
         // verified/code review value for the NOT_BUILT ones too.
         boolean onlyCountBuilt = true;
+        // If some builds failed, but their verified score is no longer
+        // available, then Successful builds would bump up the score.
+        // Set upper boundary on verified values based on builds status.
+        // JENKINS-66535
+        Integer maxAllowedVerifiedValue = Integer.MAX_VALUE;
         if (memoryImprint.wereAllBuildsSuccessful()) {
             command = config.getGerritCmdBuildSuccessful();
         } else if (memoryImprint.wereAnyBuildsFailed()) {
             command = config.getGerritCmdBuildFailed();
+            maxAllowedVerifiedValue = config.getGerritBuildFailedVerifiedValue();
         } else if (memoryImprint.wereAnyBuildsUnstable()) {
             command = config.getGerritCmdBuildUnstable();
+            maxAllowedVerifiedValue = config.getGerritBuildUnstableVerifiedValue();
         } else if (memoryImprint.wereAllBuildsNotBuilt()) {
             onlyCountBuilt = false;
             command = config.getGerritCmdBuildNotBuilt();
@@ -545,13 +554,14 @@ public class ParameterExpander {
         } else {
             //Just as bad as failed for now.
             command = config.getGerritCmdBuildFailed();
+            maxAllowedVerifiedValue = config.getGerritBuildFailedVerifiedValue();
         }
 
         Integer verified = null;
         Integer codeReview = null;
         Notify notifyLevel = Notify.ALL;
         if (memoryImprint.getEvent().isScorable()) {
-            verified = getMinimumVerifiedValue(memoryImprint, onlyCountBuilt);
+            verified = getMinimumVerifiedValue(memoryImprint, onlyCountBuilt, maxAllowedVerifiedValue);
             codeReview = getMinimumCodeReviewValue(memoryImprint, onlyCountBuilt);
             notifyLevel = getHighestNotificationLevel(memoryImprint, onlyCountBuilt);
         }

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJob.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/job/rest/BuildCompletedRestCommandJob.java
@@ -90,7 +90,7 @@ public class BuildCompletedRestCommandJob extends AbstractRestCommandJob {
                     }
                 }
                 if (config.isRestVerified()) {
-                    Integer verValue = parameterExpander.getMinimumVerifiedValue(memoryImprint, true);
+                    Integer verValue = parameterExpander.getMinimumVerifiedValue(memoryImprint, true, Integer.MAX_VALUE);
                     if (verValue != null && verValue != Integer.MAX_VALUE) {
                         scoredLabels.add(new ReviewLabel(
                                 LABEL_VERIFIED,

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderSkipVoteParameterTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderSkipVoteParameterTest.java
@@ -103,14 +103,14 @@ public class ParameterExpanderSkipVoteParameterTest {
     }
 
     /**
-     * Tests that {@link ParameterExpander#getMinimumVerifiedValue(BuildMemory.MemoryImprint, boolean)}
+     * Tests that {@link ParameterExpander#getMinimumVerifiedValue(BuildMemory.MemoryImprint, boolean, Integer)}
      * returns {@link TestParameter#expectedVerified}.
      */
     @Test
     public void testVerified() {
         IGerritHudsonTriggerConfig config = Setup.createConfig();
         ParameterExpander instance = new ParameterExpander(config);
-        Integer result = instance.getMinimumVerifiedValue(parameter.memoryImprint, true);
+        Integer result = instance.getMinimumVerifiedValue(parameter.memoryImprint, true, Integer.MAX_VALUE);
         if (parameter.expectedVerified == null) {
             assertNull(result);
         } else {

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/ParameterExpanderTest.java
@@ -178,12 +178,12 @@ public class ParameterExpanderTest {
 
         // When not all results are NOT_BUILT, we should ignore NOT_BUILT.
         int expResult = -1;
-        int result = instance.getMinimumVerifiedValue(memoryImprint, true);
+        int result = instance.getMinimumVerifiedValue(memoryImprint, true, Integer.MAX_VALUE);
         assertEquals(expResult, result);
 
         // Otherwise, we should use NOT_BUILT.
         expResult = -4;
-        result = instance.getMinimumVerifiedValue(memoryImprint, false);
+        result = instance.getMinimumVerifiedValue(memoryImprint, false, Integer.MAX_VALUE);
         assertEquals(expResult, result);
     }
 

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
@@ -758,6 +758,12 @@ public final class Setup {
         return createImprintEntry(project, build);
     }
 
+    /**
+     * Create an MemoryImprint.Entry with a given trigger and a null build (missing).
+     *
+     * @param trigger the trigger
+     * @return an entry with the parameters.
+     */
     public static MemoryImprint.Entry createAndSetupMemoryImprintEntryWithEmptyBuild(GerritTrigger trigger) {
         AbstractProject project = mock(AbstractProject.class);
         setTrigger(trigger, project);

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/mock/Setup.java
@@ -758,6 +758,12 @@ public final class Setup {
         return createImprintEntry(project, build);
     }
 
+    public static MemoryImprint.Entry createAndSetupMemoryImprintEntryWithEmptyBuild(GerritTrigger trigger) {
+        AbstractProject project = mock(AbstractProject.class);
+        setTrigger(trigger, project);
+        return createImprintEntry(project, null);
+    }
+
     /**
      * Set/mock the supplied trigger onto the supplied {@link AbstractProject} instance.
      * @param trigger The trigger.


### PR DESCRIPTION
Solution proposal for situation when failed builds are missing and only successful builds remain. In such situations currently verified score will be calculated from remaining successful builds.
With the fix the verified score is saturated if any builds are failing even if those builds are no longer available to use them in score calculation.

https://issues.jenkins.io/browse/JENKINS-66535

### Testing done
Added two tests to cover the scenario described in the ticket.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

