### PR TITLE
Remove usages of Prototype

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.361.4</jenkins.version>
+        <jenkins.version>2.410</jenkins.version>
         <revision>2.39.2</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -252,8 +252,8 @@
       <dependencies>
           <dependency>
               <groupId>io.jenkins.tools.bom</groupId>
-              <artifactId>bom-2.361.x</artifactId>
-              <version>2081.v85885a_d2e5c5</version>
+              <artifactId>bom-2.401.x</artifactId>
+              <version>2244.vd60654536b_96</version>
               <type>pom</type>
               <scope>import</scope>
           </dependency>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritServer/index.jelly
@@ -463,8 +463,8 @@
                                             <p:blockWrapperTd>
                                                 <f:textbox name="from"
                                                            value="${h.appendIfNotNull(t.from.hourAsString,'','00')}:${h.appendIfNotNull(t.from.minuteAsString,'','00')}"
-                                                           checkUrl="'${rootURL}/${serverURL}/validTimeCheck?fromValue='+escape(Form.findMatchingInput(this,'from').value)
-                                                           +'&amp;toValue='+escape(Form.findMatchingInput(this, 'to').value)"/>
+                                                           checkUrl="'${rootURL}/${serverURL}/validTimeCheck?fromValue='+escape(findMatchingFormInput(this,'from').value)
+                                                           +'&amp;toValue='+escape(findMatchingFormInput(this, 'to').value)"/>
                                             </p:blockWrapperTd>
                                         </p:blockWrapperTr>
                                         <p:blockWrapperTr>
@@ -474,8 +474,8 @@
                                             <p:blockWrapperTd>
                                                 <f:textbox name="to"
                                                            value="${h.appendIfNotNull(t.to.hourAsString,'','00')}:${h.appendIfNotNull(t.to.minuteAsString,'','01')}"
-                                                           checkUrl="'${rootURL}/${serverURL}/validTimeCheck?fromValue='+escape(Form.findMatchingInput(this,'from').value)
-                                                           +'&amp;toValue='+escape(Form.findMatchingInput(this, 'to').value)"/>
+                                                           checkUrl="'${rootURL}/${serverURL}/validTimeCheck?fromValue='+escape(findMatchingFormInput(this,'from').value)
+                                                           +'&amp;toValue='+escape(findMatchingFormInput(this, 'to').value)"/>
                                             </p:blockWrapperTd>
                                         </p:blockWrapperTr>
                                         <!--used to display the form validation error -->


### PR DESCRIPTION
Remove usages of Prototype in favor of the new API introduced in https://github.com/jenkinsci/jenkins/pull/8008 (2.406) and subsequently corrected in https://github.com/jenkinsci/jenkins/pull/8100 (2.410).