### PR TITLE
[JENKINS-71789] Fix Gerrit changes with the kind NO_CHANGE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,7 +72,7 @@
         <dependency>
             <groupId>com.sonymobile.tools.gerrit</groupId>
             <artifactId>gerrit-events</artifactId>
-            <version>2.19.0</version>
+            <version>2.21.0</version>
             <exclusions>
                 <!-- Provided by core -->
                 <exclusion>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginPatchsetCreatedEvent.java
@@ -253,11 +253,13 @@ public class PluginPatchsetCreatedEvent extends PluginGerritEvent implements Ser
             return true;
         }
         if (excludeTrivialRebase
-                && GerritChangeKind.TRIVIAL_REBASE == ((PatchsetCreated)event).getPatchSet().getKind()) {
+                && (GerritChangeKind.TRIVIAL_REBASE == ((PatchsetCreated)event).getPatchSet().getKind()
+                || GerritChangeKind.NO_CHANGE == ((PatchsetCreated)event).getPatchSet().getKind())) {
             return false;
         }
         if (excludeNoCodeChange
-                && GerritChangeKind.NO_CODE_CHANGE == ((PatchsetCreated)event).getPatchSet().getKind()) {
+                && (GerritChangeKind.NO_CODE_CHANGE == ((PatchsetCreated)event).getPatchSet().getKind()
+                || GerritChangeKind.NO_CHANGE == ((PatchsetCreated)event).getPatchSet().getKind())) {
             return false;
         }
         if (excludePrivateState && ((PatchsetCreated)event).getChange().isPrivate()) {

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/event/PluginPatchsetCreatedEventTest.java
@@ -54,6 +54,7 @@ public class PluginPatchsetCreatedEventTest {
 
     /**
      * Tests that it should not fire on trivial rebase when they are excluded.
+     * Also tests that we don't fire for no change while ignoring trivial rebases.
      * @author Doug Kelly &lt;dougk.ff7@gmail.com&gt;
      */
     @Test
@@ -68,10 +69,13 @@ public class PluginPatchsetCreatedEventTest {
         assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
         patchsetCreated.getPatchSet().setKind(GerritChangeKind.TRIVIAL_REBASE);
         assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+        patchsetCreated.getPatchSet().setKind(GerritChangeKind.NO_CHANGE);
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
     }
 
     /**
      * Tests that it should not fire on no code changes when they are excluded.
+     * Also tests that we don't fire for no change while ignoring no code change.
      * @author Doug Kelly &lt;dougk.ff7@gmail.com&gt;
      */
     @Test
@@ -85,6 +89,8 @@ public class PluginPatchsetCreatedEventTest {
         //should fire only on regular patchset (no drafts)
         assertTrue(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
         patchsetCreated.getPatchSet().setKind(GerritChangeKind.NO_CODE_CHANGE);
+        assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
+        patchsetCreated.getPatchSet().setKind(GerritChangeKind.NO_CHANGE);
         assertFalse(pluginPatchsetCreatedEvent.shouldTriggerOn(patchsetCreated));
     }
 


### PR DESCRIPTION
Gerrit changes with the kind NO_CHANGE are not excluded from building with exclude trivial rebase or exclude no code change. This fixes that, since NO_CHANGE is even more trivial than those.

<!-- Please describe your pull request here. -->

### Testing done
Added tests for the fix in the existing test cases for testing trivial rebase + no code change.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [X] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [X] Ensure that the pull request title represents the desired changelog entry
- [X] Please describe what you did
- [X] Link to relevant issues in GitHub or Jira
- [X] Link to relevant pull requests, esp. upstream and downstream changes
- [X] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
