### PR TITLE
Disable project list auto completion by default

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/config/Config.java
@@ -119,7 +119,7 @@ public class Config implements IGerritHudsonTriggerConfig {
     /**
      * Default value indicating if the Gerrit server should be used to fetch project names.
      */
-    public static final boolean DEFAULT_ENABLE_PROJECT_AUTO_COMPLETION = true;
+    public static final boolean DEFAULT_ENABLE_PROJECT_AUTO_COMPLETION = false;
     /**
      * Default value for the dynamic config refresh interval.
      */

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdaterFunctionalTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritProjectListUpdaterFunctionalTest.java
@@ -161,7 +161,7 @@ public class GerritProjectListUpdaterFunctionalTest {
         gerritServer.start();
         gerritServer.startConnection();
 
-        StopWatch watch = new StopWatch();
+        watch.reset();
         watch.start();
         while (!gerritServer.isConnected()) {
             TimeUnit.SECONDS.sleep(SLEEPTIME);


### PR DESCRIPTION
Having project list auto completion enabled by default higher number of Jenkins instances using Gerrit Trigger plugin will put high load on the Gerrit server without the knowledge of the Jenkins administrators.

Disabling by default the project list auto completion does not affect the main functionality of the plugin as this is convenience functionality.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
