### PR TITLE
TriggerMonitor: Fix grey icon anime bug and modernize icon animation

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/TriggerMonitor.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/TriggerMonitor.java
@@ -205,17 +205,17 @@ public class TriggerMonitor implements GerritEventLifecycleListener {
         @SuppressWarnings("unused") //called from jelly
         public String getBallColor() {
             if (!triggerScanStarted) {
-                return BallColor.GREY.getImage();
+                return BallColor.GREY.getIconClassName();
             } else if (!triggerScanDone) {
-                return BallColor.GREY_ANIME.getImage();
+                return BallColor.GREY_ANIME.getIconClassName();
             } else if (isUnTriggered()) {
-                return BallColor.DISABLED.getImage();
+                return BallColor.DISABLED.getIconClassName();
             } else {
                 Result result = getLeastFavorableResult();
                 if (result != null) {
-                    return result.color.getImage();
+                    return result.color.getIconClassName();
                 } else {
-                    return BallColor.GREY_ANIME.getImage();
+                    return BallColor.GREY_ANIME.getIconClassName();
                 }
             }
         }

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritCause/description.jelly
@@ -44,7 +44,7 @@
                     <j:choose>
                         <j:when test="${other.hasBuild()}">
                             <td width="18">
-                                <img src="${imagesURL}/16x16/${other.build.iconColor.image}"/>
+                                <l:icon class="${build.build.iconColor.iconClassName}"/>
                             </td>
                             <td>
                                 <a href="${rootURL}/${other.project.url}">${other.project.displayName}</a>

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/ajaxTriggerMonitor.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/actions/manual/ManualTriggerAction/ajaxTriggerMonitor.jelly
@@ -30,7 +30,7 @@
             <j:forEach items="${monitor.eventsIterator}" var="state">
                 <tr>
                     <td width="14">
-                        <img src="${imagesURL}/16x16/${state.ballColor}"/>
+                        <l:icon class="${state.ballColor}" />
                     </td>
                     <td colspan="2" style="font-weight: bold;">
                         <a href="${it.getGerritUrl(state.event)}" target="_new">
@@ -56,7 +56,7 @@
                                 <j:choose>
                                     <j:when test="${build.hasBuild()}">
                                         <td width="18">
-                                            <img src="${imagesURL}/16x16/${build.build.iconColor.image}"/>
+                                            <l:icon class="${build.build.iconColor.iconClassName}"/>
                                         </td>
                                         <td>
                                             <a href="${rootURL}/${build.project.url}">${build.project.displayName}</a>
@@ -67,7 +67,7 @@
                                     </j:when>
                                     <j:otherwise>
                                         <td width="14">
-                                            <img src="${rootURL}/images/build-status/build-status-sprite.svg#never-built" class="icon-grey-anime icon-sm"/>
+                                            <l:icon class="icon-grey-anime icon-sm"/>
                                         </td>
                                         <td>
                                             <a href="${rootURL}/${build.project.url}">${build.project.displayName}</a>


### PR DESCRIPTION
Use the new icon from jenkins build class and drop legacy icon

Falling this conversation https://github.com/jenkinsci/jenkins/pull/8806

The grey animation and grey icon are dropped from jenkins core. We need to move to use the new way

### Testing done

Deploy plugin in my jenkins instance

![Screenshot from 2023-12-29 09-49-32](https://github.com/jenkinsci/gerrit-trigger-plugin/assets/2083511/d7bb46ae-0f4a-474e-b571-89131b340d16)
