### PR TITLE
Require Jenkins 2.414.3 LTS or newer

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,4 +1,4 @@
 buildPlugin(useContainerAgent: true, configurations: [
+  [platform: 'linux', jdk: 21],
   [platform: 'linux', jdk: 17],
-  [platform: 'linux', jdk: 11],
 ])

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.66</version>
+        <version>4.76</version>
         <relativePath />
     </parent>
 
@@ -54,7 +54,7 @@
     </developers>
 
     <properties>
-        <jenkins.version>2.410</jenkins.version>
+        <jenkins.version>2.414.3</jenkins.version>
         <revision>2.39.4</revision>
         <changelist>-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
@@ -62,6 +62,7 @@
         <no-test-jar>false</no-test-jar>
         <findbugs.failOnError>false</findbugs.failOnError>
         <!--<concurrency>0.5C</concurrency>-->
+        <build-failure-analyzer-plugin.version>2.5.0</build-failure-analyzer-plugin.version>
         <checkstyle.version>2.16</checkstyle.version>
         <surefire.rerunFailingTestsCount>3</surefire.rerunFailingTestsCount>
         <forkCount>0.5C</forkCount>
@@ -74,16 +75,26 @@
             <artifactId>gerrit-events</artifactId>
             <version>2.21.0</version>
             <exclusions>
+                <!-- Provided by gson-api plugin -->
+                <exclusion>
+                    <groupId>com.google.code.gson</groupId>
+                    <artifactId>gson</artifactId>
+                </exclusion>
+                <!-- Provided by jsch plugin -->
+                <exclusion>
+                    <groupId>com.jcraft</groupId>
+                    <artifactId>jsch</artifactId>
+                </exclusion>
                 <!-- Provided by core -->
                 <exclusion>
                     <groupId>commons-io</groupId>
                     <artifactId>commons-io</artifactId>
                 </exclusion>
                 <exclusion>
-                    <!-- json-lib-2.4-jenkins-2 is provided by core/stapler -->
                     <groupId>net.sf.json-lib</groupId>
                     <artifactId>json-lib</artifactId>
                 </exclusion>
+                <!-- Provided by apache-httpcomponents-client-4-api plugin -->
                 <exclusion>
                     <groupId>org.apache.httpcomponents</groupId>
                     <artifactId>httpclient</artifactId>
@@ -95,6 +106,10 @@
                 </exclusion>
             </exclusions>
             <!-- New source is here: https://github.com/sonyxperiadev/gerrit-events -->
+        </dependency>
+        <dependency>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>gson-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -114,6 +129,10 @@
             <groupId>com.sonyericsson.hudson.plugins.rebuild</groupId>
             <artifactId>rebuild</artifactId>
             <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins</groupId>
+            <artifactId>jsch</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
@@ -237,37 +256,27 @@
         <dependency>
             <groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
             <artifactId>build-failure-analyzer</artifactId>
-            <version>2.4.0</version>
+            <version>${build-failure-analyzer-plugin.version}</version>
             <classifier>tests</classifier>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.sonyericsson.jenkins.plugins.bfa</groupId>
             <artifactId>build-failure-analyzer</artifactId>
-            <version>2.4.0</version>
+            <version>${build-failure-analyzer-plugin.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
     <dependencyManagement>
-      <dependencies>
-          <dependency>
-              <groupId>io.jenkins.tools.bom</groupId>
-              <artifactId>bom-2.401.x</artifactId>
-              <version>2244.vd60654536b_96</version>
-              <type>pom</type>
-              <scope>import</scope>
-          </dependency>
-          <dependency>
-              <groupId>com.google.code.gson</groupId>
-              <artifactId>gson</artifactId>
-              <version>2.8.9</version>
-          </dependency>
-          <dependency>
-              <groupId>org.apache.commons</groupId>
-              <artifactId>commons-lang3</artifactId>
-              <version>3.12.0</version>
-          </dependency>
-      </dependencies>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.414.x</artifactId>
+                <version>2675.v1515e14da_7a_6</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
     </dependencyManagement>
     <repositories>
         <repository>

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcherTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/replication/ReplicationQueueTaskDispatcherTest.java
@@ -39,9 +39,10 @@ import hudson.ExtensionList;
 import hudson.model.Action;
 import hudson.model.AbstractProject;
 import hudson.model.CauseAction;
+import hudson.model.MockBuildableItem;
+import hudson.model.MockWaitingItem;
 import hudson.model.Queue;
 import hudson.model.Queue.Item;
-import hudson.model.Queue.WaitingItem;
 import hudson.model.queue.CauseOfBlockage;
 
 import java.util.ArrayList;
@@ -214,7 +215,7 @@ public class ReplicationQueueTaskDispatcherTest {
                 "refs/changes/1/1/1");
         Item item = createItem(patchsetCreated, new String[] {"slaveA", "slaveB", "slaveC"});
 
-        CauseOfBlockage cause = dispatcher.canRun(new Queue.BuildableItem((WaitingItem)item));
+        CauseOfBlockage cause = dispatcher.canRun(new MockBuildableItem(item));
         assertNull("Build should not be blocked", cause);
     }
 
@@ -779,6 +780,6 @@ public class ReplicationQueueTaskDispatcherTest {
             }
             when(gerritTriggerMock.gerritSlavesToWaitFor(any(String.class))).thenReturn(gerritSlaves);
         }
-        return new WaitingItem(Calendar.getInstance(), abstractProjectMock, actions);
+        return new MockWaitingItem(abstractProjectMock, actions);
     }
 }

--- a/src/test/java/hudson/model/MockBuildableItem.java
+++ b/src/test/java/hudson/model/MockBuildableItem.java
@@ -1,0 +1,49 @@
+package hudson.model;
+
+import hudson.model.queue.CauseOfBlockage;
+
+/**
+ * Mock version of {@link Queue.BuildableItem} (which is final) that avoids {@link jenkins.model.TransientActionFactory}.
+ */
+public class MockBuildableItem extends Queue.Item {
+
+    /**
+     * Create a new mock buildable item.
+     *
+     * @param item The item.
+     */
+    public MockBuildableItem(Queue.Item item) {
+        super(item);
+    }
+
+    @SuppressWarnings("deprecation") // avoid TransientActionFactory
+    @Override
+    public <T extends Action> T getAction(Class<T> type) {
+        for (Action a : getActions()) {
+            if (type.isInstance(a)) {
+                return type.cast(a);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isBuildable() {
+        return true;
+    }
+
+    @Override
+    public CauseOfBlockage getCauseOfBlockage() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void enter(Queue q) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    boolean leave(Queue q) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/test/java/hudson/model/MockWaitingItem.java
+++ b/src/test/java/hudson/model/MockWaitingItem.java
@@ -1,0 +1,55 @@
+package hudson.model;
+
+import hudson.model.queue.CauseOfBlockage;
+import hudson.model.queue.FutureImpl;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * Mock version of {@link Queue.WaitingItem} (which is final) that avoids {@link jenkins.model.TransientActionFactory}.
+ */
+public class MockWaitingItem extends Queue.Item {
+
+    private static final AtomicLong COUNTER = new AtomicLong(0);
+
+    /**
+     * Create a new mock waiting item.
+     *
+     * @param project The project.
+     * @param actions The actions.
+     */
+    public MockWaitingItem(Queue.Task project, List<Action> actions) {
+        super(project, actions, COUNTER.incrementAndGet(), new FutureImpl(project));
+    }
+
+    @SuppressWarnings("deprecation") // avoid TransientActionFactory
+    @Override
+    public <T extends Action> T getAction(Class<T> type) {
+        for (Action a : getActions()) {
+            if (type.isInstance(a)) {
+                return type.cast(a);
+            }
+        }
+        return null;
+    }
+
+    @Override
+    public boolean isBuildable() {
+        return false;
+    }
+
+    @Override
+    public CauseOfBlockage getCauseOfBlockage() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    void enter(Queue q) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    boolean leave(Queue q) {
+        throw new UnsupportedOperationException();
+    }
+}


### PR DESCRIPTION
Now that the baseline is available in LTS form, prefer it for the reasons given in [the documentation](https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/).

While I was here, I also updated the plugin POM/BOM and added dependencies on the library plugin versions of GSON and Jsch rather than bundling them. Also adapt to https://github.com/jenkinsci/jenkins/pull/8048.