### PR TITLE
Should fix  [JENKINS-70162]   [JENKINS-72193]   [JENKINS-70539]   [JENKINS-69338] Fix topic cancelling patches (this close races in abortBuild)

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/EventListener.java
@@ -124,15 +124,17 @@ public final class EventListener implements GerritEventListener {
         }
         if (event instanceof GerritTriggeredEvent) {
             GerritTriggeredEvent triggeredEvent = (GerritTriggeredEvent)event;
-            if (t.isInteresting(triggeredEvent)) {
-                logger.trace("The event is interesting.");
-                abortBuild(t, triggeredEvent);
-                if (t.isOnlyAbortRunningBuild(triggeredEvent)) {
-                    logger.trace("Just aborting build based on event not scheduling new one.");
-                    return;
+            synchronized (this) {
+                if (t.isInteresting(triggeredEvent)) {
+                    logger.trace("The event is interesting.");
+                    abortBuild(t, triggeredEvent);
+                    if (t.isOnlyAbortRunningBuild(triggeredEvent)) {
+                        logger.trace("Just aborting build based on event not scheduling new one.");
+                        return;
+                    }
+                    notifyOnTriggered(t, triggeredEvent);
+                    schedule(t, new GerritCause(triggeredEvent, t.isSilentMode()), triggeredEvent);
                 }
-                notifyOnTriggered(t, triggeredEvent);
-                schedule(t, new GerritCause(triggeredEvent, t.isSilentMode()), triggeredEvent);
             }
         }
     }
@@ -162,15 +164,17 @@ public final class EventListener implements GerritEventListener {
             // to just return now without processing the event.
             return;
         }
-        if (t.isInteresting(event)) {
-            logger.trace("The event is interesting.");
-            abortBuild(t, event);
-            if (t.isOnlyAbortRunningBuild(event)) {
-                logger.trace("Just aborting build based on event not scheduling new one.");
-                return;
+        synchronized (this) {
+            if (t.isInteresting(event)) {
+                logger.trace("The event is interesting.");
+                abortBuild(t, event);
+                if (t.isOnlyAbortRunningBuild(event)) {
+                    logger.trace("Just aborting build based on event not scheduling new one.");
+                    return;
+                }
+                notifyOnTriggered(t, event);
+                schedule(t, new GerritManualCause(event, t.isSilentMode()), event);
             }
-            notifyOnTriggered(t, event);
-            schedule(t, new GerritManualCause(event, t.isSilentMode()), event);
         }
     }
 
@@ -206,15 +210,17 @@ public final class EventListener implements GerritEventListener {
             // to just return now without processing the event.
             return;
         }
-        if (t.isInteresting(event) && t.commentAddedMatch(event)) {
-            logger.trace("The event is interesting.");
-            abortBuild(t, event);
-            if (t.isOnlyAbortRunningBuild(event)) {
-                logger.trace("Just aborting build based on event not scheduling new one.");
-                return;
+        synchronized (this) {
+            if (t.isInteresting(event) && t.commentAddedMatch(event)) {
+                logger.trace("The event is interesting.");
+                abortBuild(t, event);
+                if (t.isOnlyAbortRunningBuild(event)) {
+                    logger.trace("Just aborting build based on event not scheduling new one.");
+                    return;
+                }
+                notifyOnTriggered(t, event);
+                schedule(t, new GerritCause(event, t.isSilentMode()), event);
             }
-            notifyOnTriggered(t, event);
-            schedule(t, new GerritCause(event, t.isSilentMode()), event);
         }
     }
 

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/RunningJobs.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/RunningJobs.java
@@ -13,6 +13,7 @@ import hudson.model.Cause;
 import hudson.model.Computer;
 import hudson.model.Executor;
 import hudson.model.Item;
+import hudson.model.Job;
 import hudson.model.Queue;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -242,7 +243,8 @@ public class RunningJobs {
            List<Queue.Item> itemsInQueue = Queue.getInstance().getItems((Queue.Task)getJob());
            for (Queue.Item item : itemsInQueue) {
                if (checkCausedByGerrit(event, item.getCauses())) {
-                   if (jobName.equals(item.task.getName())) {
+                   Job tJob = (Job)item.task;
+                   if (jobName.equals(tJob.getFullName())) {
                        Queue.getInstance().cancel(item);
                    }
                }


### PR DESCRIPTION
Pull request fix bug connected of abort jobs coming from the same topic. What we try to get is the same behavior
of 2.36.1.

If we have a topic A->B->C we would like that the whole topic get built so build it from C. The problem was
that the jenkins try to build A , B and C for each new patcheset. There were mainly to problem:
- one was the name matching
-  other was block syncronization. I did not find for now a better way

### Testing done

Create a project in gerrit, allow the project to be triggered and confirm that topic was really aborted