### PR TITLE
[JENKINS-72409] `StackOverflowError` with Rebuild v330.v645b_7df10e2a

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritRebuildValidator.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritRebuildValidator.java
@@ -42,7 +42,8 @@ public class GerritRebuildValidator extends RebuildValidator {
 
     @Override
     public boolean isApplicable(Run build) {
-        return (build.getCause(GerritCause.class) != null);
+        // Build#getActions is deprecated but the only way to prevent a stack overflow here
+        return build.getActions().stream().anyMatch(it -> it instanceof GerritCause);
     }
 
 }

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritRebuildValidatorTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/GerritRebuildValidatorTest.java
@@ -1,0 +1,32 @@
+package com.sonyericsson.hudson.plugins.gerrit.trigger;
+
+import static org.junit.Assert.assertNotNull;
+
+import hudson.ExtensionList;
+import hudson.model.Action;
+import hudson.model.FreeStyleProject;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+/**
+ * Tests for {@link GerritRebuildValidator}.
+ */
+public class GerritRebuildValidatorTest {
+
+    /**
+     * An instance of {@link JenkinsRule}.
+     */
+    // CS IGNORE VisibilityModifier FOR NEXT 2 LINES. REASON: JenkinsRule.
+    @Rule
+    public final JenkinsRule j = new JenkinsRule();
+
+    @Issue("JENKINS-72409")
+    @Test
+    public void testRebuildValidatorStackOverflow() throws Exception {
+        assertNotNull(ExtensionList.lookupSingleton(GerritRebuildValidator.class));
+        FreeStyleProject p = j.createFreeStyleProject();
+        j.assertBuildStatusSuccess(p.scheduleBuild2(0, null, new Action[0]));
+    }
+}


### PR DESCRIPTION
See [JENKINS-72409](https://issues.jenkins.io/browse/JENKINS-72409), [JENKINS-72420](https://issues.jenkins.io/browse/JENKINS-72420), [JENKINS-72677](https://issues.jenkins.io/browse/JENKINS-72677), and [JENKINS-72764](https://issues.jenkins.io/browse/JENKINS-72764). Adapt to https://github.com/jenkinsci/rebuild-plugin/pull/155 by applying the same change as was made there in https://github.com/jenkinsci/rebuild-plugin/blob/645b7df10e2a935b0b3347aac2e784ee10fdc4ef/src/main/java/com/sonyericsson/rebuild/RebuildActionFactory.java#L61-L63.

### Testing done

New test fails with the `StackOverflowError` mentioned in the ticket and passes with the fix in `src/main`.

[CI build is green](https://ci.jenkins.io/job/Plugins/job/gerrit-trigger-plugin/job/PR-507/1/)