### PR TITLE
[JENKINS-74929] Unable to clear the Aborted checkbox for Skip Vote

### DIFF
--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -77,7 +77,7 @@
                         <f:checkbox title="${%Not Built}" field="onNotBuilt"
                                     checked="${skipIt.onNotBuilt?'true':null}"/>
                         <f:checkbox title="${%Aborted}" field="onAborted"
-                                    checked="${skipIt.onNotBuilt?'true':null}"/>
+                                    checked="${skipIt.onAborted?'true':null}"/>
                     </div>
                 </f:entry>
                 <div class="gt-config__subsection">${%Verify}</div>


### PR DESCRIPTION
Change the Skip vote on aborted checkbox to be checked if onAborted is true, instead of if onNotBuilt is true.

<!-- Please describe your pull request here. -->
The checkbox for skip on aborted wrongly controlled the filed onNotBuilt instead of onAborted. My pull request fixes this so that it points to onAborted.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

I ran 
`mvn clean package`, `mvn findbugs:findbugs` and `mvn checkstyle:checkstyle`

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
