### PR TITLE
Remove useless annotations

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/gerritnotifier/model/BuildMemory.java
@@ -24,15 +24,12 @@
  */
 package com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.diagnostics.BuildMemoryReport;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.gerritnotifier.model.BuildMemory.MemoryImprint.Entry;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritCause;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.GerritTrigger;
 import com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data.TriggerContext;
 import com.sonymobile.tools.gerrit.gerritevents.dto.events.GerritTriggeredEvent;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.model.Result;
 import hudson.model.Run;
@@ -931,7 +928,6 @@ public class BuildMemory {
              * @return the project.
              */
             @CheckForNull
-            @WithBridgeMethods(AbstractProject.class)
             public Job getProject() {
                 Jenkins jenkins = Jenkins.getInstanceOrNull();
                 if (jenkins != null) {
@@ -947,7 +943,6 @@ public class BuildMemory {
              * @return the build.
              */
             @CheckForNull
-            @WithBridgeMethods(AbstractBuild.class)
             public Run getBuild() {
                 if (build != null && project != null) {
                     Job p = getProject();

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggeredItemEntity.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/data/TriggeredItemEntity.java
@@ -24,10 +24,7 @@
 
 package com.sonyericsson.hudson.plugins.gerrit.trigger.hudsontrigger.data;
 
-import com.infradna.tool.bridge_method_injector.WithBridgeMethods;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractProject;
 import hudson.model.Job;
 import hudson.model.Run;
 import java.util.Objects;
@@ -103,7 +100,6 @@ public class TriggeredItemEntity {
          * If this object is newly deserialized, the build will be looked up via {@link #getBuildNumber() }.
          * @return the build.
          */
-        @WithBridgeMethods(AbstractBuild.class)
         public Run getBuild() {
             if (build == null) {
                 if (buildNumber != null) {
@@ -130,7 +126,6 @@ public class TriggeredItemEntity {
          * If this object is newly deserialized, the project will be looked up from {@link #getProjectId() }
          * @return the project.
          */
-        @WithBridgeMethods(AbstractProject.class)
         public Job getProject() {
             if (project == null) {
                 project = Jenkins.get().getItemByFullName(projectId, Job.class);


### PR DESCRIPTION
The use of these annotations dates back to https://github.com/jenkinsci/gerrit-trigger-plugin/pull/240, but the bridge methods are not actually present today because of the lack of `bridge-method-injector` during the build process. Since the intervening 10 years have clearly demonstrated that the bridge method is not actually needed, remove the useless annotations rather than adding `bridge-method-injector` to the build.

### Testing done

Dumped the bytecode of the classes with `javap` before and after this change and verified they were the same (i.e., no bridge methods both before and after this PR, as expected).

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
