### PR TITLE
BadgeAction: Add tooltip that show the first line of the commit message

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction.java
@@ -133,6 +133,22 @@ public class BadgeAction implements BuildBadgeAction {
     }
 
     /**
+     * Gets the tooltip text for the BadgeAction.
+     * @return the tooltip text.
+     */
+    public String getTooltip() {
+        if (tEvent instanceof ChangeBasedEvent) {
+            String commitMessage = ((ChangeBasedEvent)tEvent).getChange().getCommitMessage();
+            if (commitMessage == null || commitMessage.isEmpty()) {
+                return "";
+            }
+            return commitMessage.split("\n")[0];
+        } else {
+            return "";
+        }
+    }
+
+    /**
      * For backwards compatibility {@link #event} is kept to be able to deserialize old builds, here event gets resolved
      * to the more abstract version.
      * @return the resolved instance.

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction/badge.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction/badge.jelly
@@ -1,6 +1,8 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-    <a href="${it.url}" target="_new">
-        <img src="${rootURL}/plugin/gerrit-trigger/images/icon16.png" border="0"/> ${it.text}
-    </a>
+    <div title="${it.tooltip}">
+        <a href="${it.url}" target="_new">
+            <img src="${rootURL}/plugin/gerrit-trigger/images/icon16.png" border="0"/> ${it.text}
+        </a>
+    </div>
 </j:jelly>


### PR DESCRIPTION
The tooltip allow to look for a specific commit instead of open all of them.

Add a new feature to show build tooltip  of trigger build

### Testing done

Deployed in local enviroment

<img width="584" height="223" alt="image" src="https://github.com/user-attachments/assets/e1049d4e-50d3-4464-b93b-e950e48369ce" />
