### PR TITLE
feat: Add new feature to disable topicAbort at project level

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger.java
@@ -141,6 +141,7 @@ public class GerritTrigger extends Trigger<Job> {
     @Deprecated
     private transient boolean enableTopicAssociation = Config.DEFAULT_ENABLE_TOPIC_ASSOCIATION;
     private TopicAssociation topicAssociation;
+    private boolean topicAbort;
     private String notificationLevel;
     private boolean silentStartMode;
     private boolean escapeQuotes;
@@ -1949,6 +1950,25 @@ public class GerritTrigger extends Trigger<Job> {
     }
 
     /**
+     * Enable or disable Topic abort option.
+     *
+     * @param enable true or false.
+     */
+    @DataBoundSetter
+    public void setTopicAbortDisable(boolean enable) {
+        topicAbort = enable;
+    }
+
+    /**
+    * Check if topic association is enabled.
+    *
+    * @return true if so.
+    */
+    public boolean isTopicAbortDisable() {
+        return topicAbort;
+    }
+
+    /**
      * Enable or disable Topic Association option.
      * Replaced by {@link #setTopicAssociation(TopicAssociation)} ()
      *
@@ -2267,6 +2287,7 @@ public class GerritTrigger extends Trigger<Job> {
         }
 
         return policy.isAbortSameTopic()
+                && !isTopicAbortDisable()
                 && topicName != null
                 && !topicName.isEmpty()
                 && topicName.equals(runningChange.getChange().getTopic());

--- a/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
+++ b/src/main/resources/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/GerritTrigger/config.jelly
@@ -227,6 +227,13 @@
                         checked="${it.silentMode}"/>
         </f:entry>
 
+        <f:entry field="topicAbortDisable"
+                 title="${%Topic Abort Disable}"
+                 help="/plugin/gerrit-trigger/trigger/help-TopicAbort.html">
+            <f:checkbox name="topicAbortDisable"
+                        checked="${it.topicAbortDisable}"/>
+        </f:entry>
+
         <f:optionalProperty field="topicAssociation"
                             title="${%Topic Association}"
                             help="/plugin/gerrit-trigger/trigger/help-TopicAssociation.html"/>

--- a/src/main/webapp/trigger/help-TopicAbort.html
+++ b/src/main/webapp/trigger/help-TopicAbort.html
@@ -1,0 +1,1 @@
+Disable topic abort feature even if it is set at global policy level.


### PR DESCRIPTION
Allow to disable the topic abort at project level. Without change the current behavior we have project where topic abort is needed at policy level and some project where we want it disabled

### Testing done

Deploy in my envriroment and test if we can override the policy

### Submitter checklist
- [x ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x ] Ensure that the pull request title represents the desired changelog entry
- [x ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
