### PR TITLE
Avoid name clash with newer Jenkins

### DIFF
--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/BadgeAction.java
@@ -80,17 +80,17 @@ public class BadgeAction implements BuildBadgeAction {
      *
      * @return the event.
      */
-    public GerritTriggeredEvent getEvent() {
+    public GerritTriggeredEvent getGerritEvent() {
         return tEvent;
     }
 
     /**
      * The event to show.
      *
-     * @param event the event.
+     * @param gerritEvent the event.
      */
-    public void setEvent(GerritTriggeredEvent event) {
-        this.tEvent = event;
+    public void setGerritEvent(GerritTriggeredEvent gerritEvent) {
+        this.tEvent = gerritEvent;
     }
 
     /**

--- a/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat252HudsonTest.java
+++ b/src/test/java/com/sonyericsson/hudson/plugins/gerrit/trigger/spec/BackCompat252HudsonTest.java
@@ -193,7 +193,7 @@ public class BackCompat252HudsonTest {
         assertNotNull(cause);
         BadgeAction action = freeStyleBuild.getAction(BadgeAction.class);
         assertNotNull(action);
-        GerritTriggeredEvent event = action.getEvent();
+        GerritTriggeredEvent event = action.getGerritEvent();
         assertNotNull(event);
         GerritEventType eventType = event.getEventType();
         assertSame(eventType.getEventRepresentative(), PatchsetCreated.class);


### PR DESCRIPTION
With https://github.com/jenkinsci/jenkins/pull/11204/ a new method was added to Action with name `getEvent`. This clashes with the `getEvent` method in BadgeAction.
As the getEvent in BadgeAction is not used outside of tests and there are no users of BadgeAction in other plugins it should be safe to rename the method.
Also rename the setter to by in sync, which is also not used anywhere. Persistence via XStream doesn't rely on the methods but works directly with the fields.

<!-- Please describe your pull request here. -->

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
