### PR TITLE
docs/add sysprop jobsLoadedGate to README

### DIFF
--- a/docs/README.adoc
+++ b/docs/README.adoc
@@ -300,6 +300,31 @@ in the Jenkins log file when the Gerrit Server Connection is started:
 INFO: (8) missed events to process for server: defaultServer ...
 ----
 
+==== Configuring the Startup Wait Timeout
+
+On startup, missed-events catch-up waits for Jenkins to finish loading all job
+configurations before replaying any missed events. This avoids a race where a
+replayed event arrives before a job's Gerrit Trigger has registered as a
+listener, which would cause that event to be silently dropped.
+
+This wait is capped by the `gerrit.trigger.playback.jobsLoadedGate.timeout.minutes`
+system property, which defaults to *30 minutes*. If the timeout elapses before job
+loading finishes, missed-events catch-up proceeds anyway and a warning is logged.
+
+NOTE: Instances with a very large number of jobs can take longer than 30 minutes to
+finish loading job configurations on startup. If your instance's startup routinely
+exceeds 30 minutes, set this property to a value comfortably above your instance's
+actual startup time rather than tuning it tight, for example:
+
+[source,syntaxhighlighter-pre]
+----
+-Dgerrit.trigger.playback.jobsLoadedGate.timeout.minutes=60
+----
+
+This setting only affects the very first missed-events catch-up after the JVM
+starts; later reconnects (e.g. after a network blip) always occur well after job
+loading has completed and are unaffected by it.
+
 == Skip Vote
 
 "Skipping" the vote means that if more than one build is triggered by a

--- a/docs/README_DISTRIBUTED_EVENT_MANAGEMENT.md
+++ b/docs/README_DISTRIBUTED_EVENT_MANAGEMENT.md
@@ -167,5 +167,15 @@ This has not been tested in distributed mode, so the actual behavior cannot be v
 been, treat the RabbitMQ Consumer plugin as unproven for multi-replica set ups of this feature and
 prefer a single Jenkins instance/replica.
 
+## Configuration Options
+
+Instances with a large number of jobs — including multi-replica deployments running under
+this feature — can take longer than 30 minutes to finish loading job configurations on
+startup. See
+[Configuring the Startup Wait Timeout](README.adoc#_configuring_the_startup_wait_timeout)
+in the main README for how to raise the `gerrit.trigger.playback.jobsLoadedGate.timeout.minutes`
+system property above your instance's actual startup time, so missed-events catch-up doesn't
+proceed before every replica's jobs have finished loading.
+
 (*) Jenkins does not support multiple replicas or nodes for a single logical instance, this feature is not tested with Jenkins. This feature is provided for CloudBees CI (Enterprise Jenkins).
 This feature is provided as a community effort and is not endorsed or officially supported by CloudBees.

--- a/docs/README_DISTRIBUTED_EVENT_MANAGEMENT.md
+++ b/docs/README_DISTRIBUTED_EVENT_MANAGEMENT.md
@@ -64,54 +64,64 @@ Choose a value that reflects your actual expected downtime rather than leaving i
 
 #### Kubernetes — Client Mode with Hazelcast Sidecar
 
-The plugin can connect to Hazelcast cluster as a lightweight client. For example, if we are running 
+The plugin can connect to Hazelcast cluster as a lightweight client. For example, if we are running
 K8s environment with the Jenkins instance inside a pod, we can have a side-container with Hazelcast
-to set up the Hazelcast cluster. In this kind of cases, we would the a configuration setup similar
+to set up the Hazelcast cluster. In this kind of cases, we would use a configuration setup similar
 to the following one:
 
-Add the following JVM arguments to the Jenkins instance:
+The plugin's default configuration values (`localhost:5702` and cluster name `gerrit-trigger-cluster`)
+already match this sidecar setup, so the only JVM argument needed on the Jenkins instance is:
 
     -Dgerrit.trigger.coordination.mode=hazelcast
-    -Dgerrit.trigger.coordination.hazelcast.client.addresses=localhost:5702
-    -Dgerrit.trigger.coordination.hazelcast.client.cluster.name=gerrit-trigger-cluster
 
 Add the sidecar container to the instance pod spec:
 
 ```yaml
 - name: hazelcast
   image: hazelcast/hazelcast:5.3.8
-  ports:
-    - containerPort: 5702
-      name: hazelcast
   env:
-    - name: JAVA_OPTS
-      value: >-
-        -Dhazelcast.config=/dev/stdin
-        -Dhazelcast.local.publicAddress=$(POD_IP):5702
+    - name: POD_IP
+      valueFrom:
+        fieldRef:
+          fieldPath: status.podIP
+    # Network and cluster setup (HZ_CLUSTERNAME = plugin's default gerrit-trigger-cluster)
     - name: HZ_CLUSTERNAME
       value: gerrit-trigger-cluster
     - name: HZ_NETWORK_PORT_PORT
       value: "5702"
+    - name: HZ_NETWORK_PORT_AUTOINCREMENT
+      value: "false"
+    - name: HZ_NETWORK_PUBLICADDRESS
+      value: "$(POD_IP):5702"
+    # Kubernetes Discovery configuration
+    - name: HZ_NETWORK_JOIN_MULTICAST_ENABLED
+      value: "false"
+    - name: HZ_NETWORK_JOIN_KUBERNETES_ENABLED
+      value: "true"
+    - name: HZ_NETWORK_JOIN_KUBERNETES_SERVICEPORT
+      value: "5702"
+    - name: HZ_NETWORK_JOIN_KUBERNETES_PODLABELNAME
+      value: "tenant"
+    - name: HZ_NETWORK_JOIN_KUBERNETES_PODLABELVALUE
+      value: "${name}"
+  ports:
+    - containerPort: 5702
+      name: gerritstorage
 ```
 
-Grant the pod's service account read access to Kubernetes endpoints so Hazelcast can
-discover its peers:
-
-```yaml
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: hazelcast-gerrit-trigger
-rules:
-  - apiGroups: [""]
-    resources: ["endpoints", "pods", "nodes", "services"]
-    verbs: ["get", "list"]
-  - apiGroups: ["discovery.k8s.io"]
-    resources: ["endpointslices"]
-    verbs: ["get", "list"]
-```
+> [!NOTE]
+> `HZ_NETWORK_JOIN_KUBERNETES_PODLABELNAME`/`PODLABELVALUE` scope peer discovery to only the pods
+> that belong to this logical instance's cluster. Set them so no other pod in the namespace matches.
+> For a logical instance named `my-instance`, label every valid pod `tenant=my-instance`.
+>
+> `HZ_CLUSTERNAME` and `gerrit.trigger.coordination.hazelcast.client.cluster.name` must match exactly.
+> Plugin defaults to `gerrit-trigger-cluster`. Override one, override the other the same way.
 
 #### Kubernetes — Client Mode with Separate Hazelcast Cluster
+
+> [!IMPORTANT]
+> Each instance needs its own unique cluster name, or their event claims and build memory will collide.
+> e.g. for a logical instance named `my-instance`, use `gerrit-trigger-cluster-my-instance` for both settings.
 
 For larger deployments or strict separation of concerns, you can decouple the coordination layer by running a standalone Hazelcast cluster. Jenkins still connects as a lightweight client, but routes traffic to the separate cluster via a Kubernetes service instead of a sidecar.
 
@@ -122,6 +132,7 @@ Add the following JVM arguments to the Jenkins instance, updating the client add
     -Dgerrit.trigger.coordination.hazelcast.client.cluster.name=gerrit-trigger-cluster-<LOGICAL_INSTANCE_NAME>
 
 In this topology:
+
 - You do not need to add the sidecar container to the Jenkins pod spec.
 - The Jenkins service account does not need RBAC permissions for peer discovery, as cluster management is handled entirely by the standalone Hazelcast nodes.
 - You must deploy and manage the Hazelcast cluster independently (e.g. via the official Hazelcast Helm chart), ensuring you configure it to match your expected `HZ_CLUSTERNAME` and port (`5702`).


### PR DESCRIPTION
This pull request updates the documentation to clarify and improve configuration instructions for distributed event management with Hazelcast and to explain the startup wait timeout for missed-events catch-up. The changes make it easier to configure multi-replica Jenkins deployments and ensure reliable missed-event processing, especially for large instances.

**Hazelcast/Kubernetes Configuration Improvements:**
* Simplified the recommended JVM arguments for Hazelcast sidecar setups, clarifying that the plugin's defaults usually suffice and only the coordination mode property is needed.
* Updated the Hazelcast sidecar container configuration to use environment variables for Kubernetes discovery, and added notes on scoping peer discovery and matching cluster names.
* Added warnings and guidance for using unique cluster names per logical instance to avoid event/build memory collisions.
* Clarified that in standalone Hazelcast cluster setups, the Jenkins pod does not need a sidecar or RBAC permissions, but the Hazelcast cluster must be managed independently.

**Missed-Events Catch-Up and Startup Timeout:**
* Added documentation for the `gerrit.trigger.playback.jobsLoadedGate.timeout.minutes` system property, explaining its role in ensuring all jobs are loaded before missed-events are replayed, and guidance for instances with long startup times. [[1]](diffhunk://#diff-af3ef72d2f8bd1c682fddb4b4b91757e1965f8f47078a4198e6de160797312c1R303-R327) [[2]](diffhunk://#diff-9ae942d09a0b7b76a8cc2ac5dfd709b200a0667fb5e838c095fc204e4d279e1bR181-R190)