### PR TITLE
Migrate the last Commons Lang 2 usage to native Java

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,7 @@
         <changelist>999999-SNAPSHOT</changelist>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <no-test-jar>false</no-test-jar>
+        <ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>
         <findbugs.failOnError>false</findbugs.failOnError>
         <build-failure-analyzer-plugin.version>3.887.vc872cf1b_7dff</build-failure-analyzer-plugin.version>
         <checkstyle.version>3.6.0</checkstyle.version>

--- a/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginChangeMergedEvent.java
+++ b/src/main/java/com/sonyericsson/hudson/plugins/gerrit/trigger/hudsontrigger/events/PluginChangeMergedEvent.java
@@ -29,7 +29,6 @@ import com.sonyericsson.hudson.plugins.gerrit.trigger.Messages;
 import hudson.Extension;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
-import org.apache.commons.lang.StringUtils;
 import org.jenkinsci.Symbol;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -96,7 +95,7 @@ public class PluginChangeMergedEvent extends PluginGerritEvent implements Serial
         if (!super.shouldTriggerOn(event)) {
             return false;
         }
-        if (StringUtils.isNotEmpty(commitMessageContainsRegEx)) {
+        if (commitMessageContainsRegEx != null && !commitMessageContainsRegEx.isEmpty()) {
             if (commitMessagePattern == null) {
                 commitMessagePattern = Pattern.compile(
                         this.commitMessageContainsRegEx, Pattern.DOTALL | Pattern.MULTILINE);


### PR DESCRIPTION
- see https://github.com/jenkinsci/jenkins/issues/16404

#519 removed the Commons Lang 2 usages from this plugin, but it missed one file: `PluginChangeMergedEvent`, the sibling of `PluginPatchsetCreatedEvent` which that PR did migrate. It still has `import org.apache.commons.lang.StringUtils` on `master`, so the plugin will break at runtime once Jenkins core stops exposing Commons Lang 2 (jenkinsci/jenkins#26105).

This applies exactly the same transformation #519 used on the sibling file — `StringUtils.isNotEmpty(x)` becomes `x != null && !x.isEmpty()` — so no new dependency is introduced.

It also sets `<ban-commons-lang-2.skip>false</ban-commons-lang-2.skip>`. That property was never enabled here, which is precisely why the missed file went unnoticed: the enforcer rule was not running. With it on, a regression fails the build.

### Testing done

- `mvn clean install` passes with the enforcer enabled.
- Verified the enforcer is genuinely active, rather than silently skipping: restoring the Commons Lang 2 import with the property in place fails the build with `Reason: Use Commons Lang 2 (org.apache.commons.lang.*)`.
- `PluginChangeMergedEventTest` — 7 tests, 0 failures.

### A related problem this does not fix

`pct-build-failure-analyzer` in jenkinsci/bom#6234 fails with `NoClassDefFoundError: org/apache/commons/lang/StringUtils` thrown from `com.sonymobile.tools.gerrit.gerritevents.GerritHandler`, reached through this plugin. That is the `gerrit-events` library rather than plugin code, so it needs sonyxperiadev/gerrit-events#131 to merge and release, then a `gerrit-events` bump here.

---
This change was prepared with AI assistance (Claude Code); it has been reviewed and built locally by me.
